### PR TITLE
DHIS2-3993 Add support for d2-i18n translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 .vscode/
 .DS_Store
 npm-debug.log
+
+# generated localization files
+src/locales/

--- a/config/cssMod.config.js
+++ b/config/cssMod.config.js
@@ -17,6 +17,7 @@ const cssModDev = {
                 // https://github.com/facebookincubator/create-react-app/issues/2677
                 ident: 'postcss',
                 plugins: () => [
+                    require('postcss-rtl'),
                     require('postcss-flexbugs-fixes'),
                     require('autoprefixer')({
                         browsers: [

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -1,0 +1,122 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: i18next-conv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"POT-Creation-Date: 2018-06-11T17:30:30.072Z\n"
+"PO-Revision-Date: 2018-06-11T17:30:30.072Z\n"
+
+msgid "Please provide a valid date"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Complete"
+msgstr ""
+
+msgid "Warnings found"
+msgstr ""
+
+msgid "Abort"
+msgstr ""
+
+msgid "Save"
+msgstr ""
+
+msgid "Sort"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "Clear"
+msgstr ""
+
+msgid "No results"
+msgstr ""
+
+msgid "Online"
+msgstr ""
+
+msgid "Offline"
+msgstr ""
+
+msgid "Syncing"
+msgstr ""
+
+msgid "Event could not be loaded. Are you sure it exists?"
+msgstr ""
+
+msgid "Event could not be loaded"
+msgstr ""
+
+msgid "Organisation unit could not be loaded"
+msgstr ""
+
+msgid "No events to display"
+msgstr ""
+
+msgid "Rows per page"
+msgstr ""
+
+msgid "Could not get organisation unit"
+msgstr ""
+
+msgid "Program doesn't exist"
+msgstr ""
+
+msgid "Select a registering unit and program above to get started"
+msgstr ""
+
+msgid "Select a program to start reporting"
+msgstr ""
+
+msgid "Select a registering unit to start reporting"
+msgstr ""
+
+msgid "New event"
+msgstr ""
+
+msgid "Saving to"
+msgstr ""
+
+msgid "in"
+msgstr ""
+
+msgid ""
+"This is not an event program or the metadata is corrupt. See log for "
+"details."
+msgstr ""
+
+msgid "Reset"
+msgstr ""
+
+msgid "New"
+msgstr ""
+
+msgid "Find"
+msgstr ""
+
+msgid "An error has occured. See log for details"
+msgstr ""
+
+msgid "Error saving event"
+msgstr ""
+
+msgid "Could not save event. See log for details"
+msgstr ""
+
+msgid "Choose one or more dates..."
+msgstr ""
+
+msgid "Choose a date..."
+msgstr ""
+
+msgid "Today"
+msgstr ""

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "redux-devtools-extension": "^2.13.2"
   },
   "manifest.webapp": {
-    "name": "Dashboards app",
+    "name": "Capture app",
     "icons": {
       "48": "icon.png"
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "scripts": {
     "start": "react-app-rewired start",
-    "build": "yarn localize && node scripts/build.js",
+    "build": "yarn localize && react-app-rewired build",
     "postbuild": "mkdirp buildzip/ && pushd build && bestzip ../buildzip/NewCaptureApp.zip * && popd",
     "test": "react-app-rewired test --env=jsdom",
     "test:debug": "react-app-rewired --inspect-brk test --runInBand --env=jsdom",
@@ -86,22 +86,24 @@
     "redux-devtools-extension": "^2.13.2"
   },
   "manifest.webapp": {
-    "name": "Capture app",
+    "version": "0.1",
+    "name": "Capture",
+    "description": "Capture App",
+    "launch_path": "index.html",
     "icons": {
-      "48": "icon.png"
+      "16": "/assets/icons/track16.png",
+      "48": "/assets/icons/track48.png",
+      "128": "/assets/icons/track128.png"
     },
     "developer": {
-      "url": "",
-      "name": "DHIS2"
+      "name": "HISP",
+      "url": "http://dhis2.org"
     },
-    "dhis2": {
-      "apiVersion": "30"
-    },
+    "default_locale": "en",
     "activities": {
       "dhis": {
-        "href": ".."
+          "href": "../../.."
       }
-    },
-    "description": "New Capture app"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
+    "@dhis2/d2-i18n": "^1.0.3",
+    "@dhis2/d2-i18n-extract": "^1.0.7",
+    "@dhis2/d2-i18n-generate": "^1.0.18",
     "@dhis2/d2-ui-app": "^1.0.4",
     "@dhis2/d2-ui-core": "^1.2.0",
     "@dhis2/d2-ui-forms": "1",
@@ -14,14 +17,17 @@
     "classnames": "^2.2.5",
     "create-react-class": "^15.6.3",
     "d2": "30",
+    "d2-manifest": "^1.0.0",
     "d2-utilizr": "^0.2.15",
     "date-fns": "^1.29.0",
     "fake-indexeddb": "^2.0.4",
     "html-webpack-plugin": "^3.2.0",
+    "husky": "^1.0.0-rc.8",
     "jest-localstorage-mock": "^2.2.0",
     "jquery": "^3.3.1",
     "loglevel": "^1.6.1",
     "moment": "^2.22.1",
+    "postcss-rtl": "^1.2.3",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
@@ -42,13 +48,21 @@
   },
   "scripts": {
     "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
+    "build": "yarn localize && node scripts/build.js",
     "postbuild": "mkdirp buildzip/ && pushd build && bestzip ../buildzip/NewCaptureApp.zip * && popd",
     "test": "react-app-rewired test --env=jsdom",
     "test:debug": "react-app-rewired --inspect-brk test --runInBand --env=jsdom",
     "eject": "react-scripts eject",
     "add-flow-types": "flow-typed install",
+    "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
+    "localize": "yarn extract-pot && d2-i18n-generate -n NAMESPACE -p ./i18n/ -o ./src/locales/",
+    "prestart": "yarn localize && d2-manifest package.json ./public/manifest.webapp",
     "docs": "NODE_ENV=development jsdoc -c jsdoc-conf.json"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "yarn extract-pot && CI=true yarn test && git add -A ."
+    }
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.24.1",
@@ -70,5 +84,24 @@
     "mkdirp": "^0.5.1",
     "react-app-rewired": "^1.5.0",
     "redux-devtools-extension": "^2.13.2"
+  },
+  "manifest.webapp": {
+    "name": "Dashboards app",
+    "icons": {
+      "48": "icon.png"
+    },
+    "developer": {
+      "url": "",
+      "name": "DHIS2"
+    },
+    "dhis2": {
+      "apiVersion": "30"
+    },
+    "activities": {
+      "dhis": {
+        "href": ".."
+      }
+    },
+    "description": "New Capture app"
   }
 }

--- a/public/manifest.webapp
+++ b/public/manifest.webapp
@@ -1,21 +1,23 @@
 {
-    "version": "0.1",
-    "name": "Capture",
-    "description": "Capture App",
-    "launch_path": "index.html",
-    "icons": {
-        "16": "/assets/icons/track16.png",
-        "48": "/assets/icons/track48.png",
-        "128": "/assets/icons/track128.png"
-    },
-    "developer": {
-        "name": "HISP",
-        "url": "http://dhis2.org"
-    },
-    "default_locale": "en",
-    "activities": {
-        "dhis": {
-            "href": "../../.."
-        }
+  "launch_path": "index.html",
+  "default_locale": "en",
+  "activities": {
+    "dhis": {
+      "href": ".."
     }
+  },
+  "appType": "APP",
+  "name": "Dashboards app",
+  "version": "0.1.0",
+  "icons": {
+    "48": "icon.png"
+  },
+  "developer": {
+    "name": "DHIS2"
+  },
+  "dhis2": {
+    "apiVersion": "30"
+  },
+  "description": "New Capture app",
+  "manifest_generated_at": "Mon Jun 11 2018 19:17:34 GMT+0200 (Central European Summer Time)"
 }

--- a/public/manifest.webapp
+++ b/public/manifest.webapp
@@ -3,21 +3,21 @@
   "default_locale": "en",
   "activities": {
     "dhis": {
-      "href": ".."
+      "href": "../../.."
     }
   },
   "appType": "APP",
-  "name": "Dashboards app",
-  "version": "0.1.0",
+  "name": "Capture",
+  "version": "0.1",
+  "description": "Capture App",
   "icons": {
-    "48": "icon.png"
+    "16": "/assets/icons/track16.png",
+    "48": "/assets/icons/track48.png",
+    "128": "/assets/icons/track128.png"
   },
   "developer": {
-    "name": "DHIS2"
+    "name": "HISP",
+    "url": "http://dhis2.org"
   },
-  "dhis2": {
-    "apiVersion": "30"
-  },
-  "description": "New Capture app",
-  "manifest_generated_at": "Mon Jun 11 2018 19:17:34 GMT+0200 (Central European Summer Time)"
+  "manifest_generated_at": "Thu Jun 14 2018 08:11:29 GMT+0200 (DST)"
 }

--- a/public/manifest.webapp
+++ b/public/manifest.webapp
@@ -19,5 +19,5 @@
     "name": "HISP",
     "url": "http://dhis2.org"
   },
-  "manifest_generated_at": "Thu Jun 14 2018 08:11:29 GMT+0200 (DST)"
+  "manifest_generated_at": "Thu Jun 14 2018 08:16:13 GMT+0200 (DST)"
 }

--- a/src/components/EventCaptureForm/EventCaptureForm.component.js
+++ b/src/components/EventCaptureForm/EventCaptureForm.component.js
@@ -16,9 +16,10 @@ import QuickSelector from 'capture-core/components/QuickSelector/QuickSelector.c
 import withDefaultShouldUpdateInterface from
     'capture-core/components/DataEntry/eventField/withDefaultShouldUpdateInterface';
 import isValidDate from 'capture-core/utils/validators/date.validator';
-import { getTranslation } from 'capture-core/d2/d2Instance';
 import { formatterOptions } from 'capture-core/utils/string/format.const';
 import { placements } from 'capture-core/components/DataEntry/eventField/eventField.const';
+
+import i18n from '@dhis2/d2-i18n';
 
 const getSaveOptions = () => ({
     color: 'primary',
@@ -53,12 +54,11 @@ const buildReportDateSettingsFn = () => {
             {
                 validator: Validators.wordToValidatorMap.get('required'),
                 message:
-                    getTranslation(
-                        Validators.wordToValidatorMap.get('required').message, formatterOptions.CAPITALIZE_FIRST_LETTER),
+                    i18n.t(Validators.wordToValidatorMap.get('required').message),
             },
             {
                 validator: preValidateDate,
-                message: getTranslation('value_should_be_a_valid_date', formatterOptions.CAPITALIZE_FIRST_LETTER),
+                message: i18n.t('Please provide a valid date'),
             },
         ],
     });

--- a/src/core_modules/capture-core/src/components/D2Form/field/validators.js
+++ b/src/core_modules/capture-core/src/components/D2Form/field/validators.js
@@ -6,8 +6,7 @@ import isString from 'd2-utilizr/src/isString';
 import isValidDate from '../../../utils/validators/date.validator';
 import isValidDateTime from '../../../utils/validators/dateTime.validator';
 import isValidTime from '../../../utils/validators/time.validator';
-import { getTranslation } from '../../../d2/d2Instance';
-import { formatterOptions } from '../../../utils/string/format.const';
+import i18n from '@dhis2/d2-i18n';
 import MetaDataElement from '../../../metaData/DataElement/DataElement';
 import elementTypes from '../../../metaData/DataElement/elementTypes';
 
@@ -28,13 +27,13 @@ const wordValidatorKeys = {
 };
 
 const errorMessages = {
-    INTEGER: 'value_should_be_an_integer',
-    POSITIVE_INTEGER: 'value_should_be_a_positive_integer',
-    ZERO_OR_POSITIVE_INTEGER: 'value_should_be_zero_or_a_positive_integer',
-    DATE: 'value_should_be_a_valid_date',
-    DATETIME: 'value_should_be_a_valid_datetime',
-    TIME: 'value_should_be_a_valid_time',
-    PERCENTAGE: 'value_should_be_a_valid_percentage',
+    INTEGER: 'Please provide a valid integer',
+    POSITIVE_INTEGER: 'Please provide a positive integer',
+    ZERO_OR_POSITIVE_INTEGER: 'Please provide zero or a positive integer',
+    DATE: 'Please provide a valid date',
+    DATETIME: 'Please provide a valid date and time',
+    TIME: 'Please provide a valid time',
+    PERCENTAGE: 'Please provide a valid percentage',
 };
 
 const isCompulsoryRequirementMet = Validators.wordToValidatorMap.get(wordValidatorKeys.COMPULSORY);
@@ -81,42 +80,39 @@ const validatorsForTypes = {
     [elementTypes.NUMBER]: () => ({
         validator: Validators.wordToValidatorMap.get(wordValidatorKeys.NUMBER),
         message:
-            getTranslation(
-                Validators.wordToValidatorMap.get(wordValidatorKeys.NUMBER).message,
-                formatterOptions.CAPITALIZE_FIRST_LETTER,
-            ),
+            i18n.t(Validators.wordToValidatorMap.get(wordValidatorKeys.NUMBER).message),
     }),
     [elementTypes.INTEGER]: () => ({
         validator: isInteger,
-        message: getTranslation(errorMessages.INTEGER, formatterOptions.CAPITALIZE_FIRST_LETTER),
+        message: i18n.t(errorMessages.INTEGER),
     }),
     [elementTypes.INTEGER_POSITIVE]: () => ({
         validator: isPositiveInteger,
-        message: getTranslation(errorMessages.POSITIVE_INTEGER, formatterOptions.CAPITALIZE_FIRST_LETTER),
+        message: i18n.t(errorMessages.POSITIVE_INTEGER),
     }),
     [elementTypes.INTEGER_ZERO_OR_POSITIVE]: () => ({
         validator: isZeroOrPositiveInteger,
-        message: getTranslation(errorMessages.ZERO_OR_POSITIVE_INTEGER, formatterOptions.CAPITALIZE_FIRST_LETTER),
+        message: i18n.t(errorMessages.ZERO_OR_POSITIVE_INTEGER),
     }),
     [elementTypes.TIME]: () => ({
         validator: isValidTime,
-        message: getTranslation(errorMessages.TIME, formatterOptions.CAPITALIZE_FIRST_LETTER),
+        message: i18n.t(errorMessages.TIME),
     }),
     [elementTypes.DATE]: () => ({
         validator: isValidDate,
-        message: getTranslation(errorMessages.DATE, formatterOptions.CAPITALIZE_FIRST_LETTER),
+        message: i18n.t(errorMessages.DATE),
     }),
     [elementTypes.DATETIME]: () => ({
         validator: isValidDateTime,
-        message: getTranslation(errorMessages.DATETIME, formatterOptions.CAPITALIZE_FIRST_LETTER),
+        message: i18n.t(errorMessages.DATETIME),
     }),
     [elementTypes.EMAIL]: () => ({
         validator: Validators.wordToValidatorMap.get(wordValidatorKeys.EMAIL),
-        message: getTranslation(Validators.wordToValidatorMap.get(wordValidatorKeys.EMAIL).message),
+        message: i18n.t(Validators.wordToValidatorMap.get(wordValidatorKeys.EMAIL).message),
     }),
     [elementTypes.PERCENTAGE]: () => ({
         validator: isValidPercentage,
-        message: getTranslation(errorMessages.PERCENTAGE, formatterOptions.CAPITALIZE_FIRST_LETTER),
+        message: i18n.t(errorMessages.PERCENTAGE),
     }),
 };
 
@@ -154,11 +150,10 @@ function buildCompulsoryValidator(metaData: MetaDataElement): Array<ValidatorCon
         {
             validator: isCompulsoryRequirementMetWrapper,
             message:
-                getTranslation(
+                i18n.t(
                     Validators.wordToValidatorMap.get(
                         wordValidatorKeys.COMPULSORY,
-                    ).message,
-                    formatterOptions.CAPITALIZE_FIRST_LETTER,
+                    ).message
                 ),
         },
     ] :

--- a/src/core_modules/capture-core/src/components/DataEntry/withCancelButton.js
+++ b/src/core_modules/capture-core/src/components/DataEntry/withCancelButton.js
@@ -1,8 +1,7 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { getTranslation } from '../../d2/d2Instance';
-import { formatterOptions } from '../../utils/string/format.const';
+import i18n from '@dhis2/d2-i18n';
 import ProgressButton from '../Buttons/ProgressButton.component';
 import getDataEntryKey from './common/getDataEntryKey';
 
@@ -30,7 +29,7 @@ const getCancelButton = (InnerComponent: React.ComponentType<any>, optionsFn?: ?
                     color={options.color || 'primary'}
                     inProgress={finalInProgress}
                 >
-                    { getTranslation('cancel', formatterOptions.CAPITALIZE_FIRST_LETTER) }
+                    { i18n.t('Cancel') }
                 </ProgressButton>
             }
             {...passOnProps}

--- a/src/core_modules/capture-core/src/components/DataEntry/withCompleteButton.js
+++ b/src/core_modules/capture-core/src/components/DataEntry/withCompleteButton.js
@@ -14,7 +14,7 @@ import Button from '../Buttons/Button.component';
 import ProgressButton from '../Buttons/ProgressButton.component';
 import DataEntry from './DataEntry.component';
 import errorCreator from '../../utils/errorCreator';
-import { getTranslation } from '../../d2/d2Instance';
+import i18n from '@dhis2/d2-i18n';
 import { formatterOptions } from '../../utils/string/format.const';
 import { startCompleteEvent, completeValidationFailed, completeAbort } from './actions/dataEntry.actions';
 import getDataEntryKey from './common/getDataEntryKey';
@@ -220,7 +220,7 @@ const getCompleteButton = (InnerComponent: React.ComponentType<any>, optionFn?: 
                                 color={options.color || 'primary'}
                                 inProgress={!!finalInProgress}
                             >
-                                { getTranslation('complete', formatterOptions.CAPITALIZE_FIRST_LETTER) }
+                                { i18n.t('Complete') }
                             </ProgressButton>
                         }
                         {...passOnProps}
@@ -231,7 +231,7 @@ const getCompleteButton = (InnerComponent: React.ComponentType<any>, optionFn?: 
                         onClose={this.handleCloseDialog}
                     >
                         <DialogTitle id="complete-dialog-title">
-                            {getTranslation('warnings_found')}
+                            {i18n.t('Warnings found')}
                         </DialogTitle>
                         <DialogContent>
                             <DialogContentText>
@@ -240,10 +240,10 @@ const getCompleteButton = (InnerComponent: React.ComponentType<any>, optionFn?: 
                         </DialogContent>
                         <DialogActions>
                             <Button onClick={this.handleCloseDialog} color="primary">
-                                {getTranslation('abort')}
+                                {i18n.t('Abort')}
                             </Button>
                             <Button onClick={this.handleCompleteDialog} color="primary" autoFocus>
-                                {getTranslation('complete')}
+                                {i18n.t('Complete')}
                             </Button>
                         </DialogActions>
                     </Dialog>

--- a/src/core_modules/capture-core/src/components/DataEntry/withSaveButton.js
+++ b/src/core_modules/capture-core/src/components/DataEntry/withSaveButton.js
@@ -14,8 +14,7 @@ import Button from '../Buttons/Button.component';
 import ProgressButton from '../Buttons/ProgressButton.component';
 import DataEntry from './DataEntry.component';
 import errorCreator from '../../utils/errorCreator';
-import { getTranslation } from '../../d2/d2Instance';
-import { formatterOptions } from '../../utils/string/format.const';
+import i18n from '@dhis2/d2-i18n';
 import { saveValidationFailed, saveAbort } from './actions/dataEntry.actions';
 import getDataEntryKey from './common/getDataEntryKey';
 import RenderFoundation from '../../metaData/RenderFoundation/RenderFoundation';
@@ -223,7 +222,7 @@ const getSaveButton = (InnerComponent: React.ComponentType<any>, optionFn?: ?Opt
                                 color={options.color || 'primary'}
                                 inProgress={!!finalInProgress}
                             >
-                                { getTranslation('save', formatterOptions.CAPITALIZE_FIRST_LETTER) }
+                                { i18n.t('Save') }
                             </ProgressButton>
                         }
                         {...passOnProps}
@@ -233,7 +232,7 @@ const getSaveButton = (InnerComponent: React.ComponentType<any>, optionFn?: ?Opt
                         onClose={this.handleCloseDialog}
                     >
                         <DialogTitle id="complete-dialog-title">
-                            {getTranslation('warnings_found')}
+                            {i18n.t('Warnings found')}
                         </DialogTitle>
                         <DialogContent>
                             <DialogContentText>
@@ -242,12 +241,11 @@ const getSaveButton = (InnerComponent: React.ComponentType<any>, optionFn?: ?Opt
                         </DialogContent>
                         <DialogActions>
                             <Button onClick={this.handleCloseDialog} color="primary">
-                                {getTranslation('abort')}
+                                {i18n.t('Abort')}
                             </Button>
                             <Button onClick={this.handleSaveDialog} color="primary" autoFocus>
-                                {getTranslation('save')}
-                            </Button>
-                        </DialogActions>
+                                {i18n.t('Save')}
+                            </Button> </DialogActions>
                     </Dialog>
                 </div>
             );

--- a/src/core_modules/capture-core/src/components/DataTable/SortLabelWrapper.component.js
+++ b/src/core_modules/capture-core/src/components/DataTable/SortLabelWrapper.component.js
@@ -5,8 +5,7 @@ import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 import { withStyles } from '@material-ui/core/styles';
 
-import { getTranslation } from '../../d2/d2Instance';
-import { formatterOptions } from '../../utils/string/format.const';
+import i18n from '@dhis2/d2-i18n';
 import getTableComponents from '../d2Ui/dataTable/getTableComponents';
 import sortLabelAdapter from '../d2UiReactAdapters/dataTable/sortLabel.adapter';
 
@@ -60,7 +59,7 @@ class SortLabelWrapper extends React.Component<Props> {
 
             return (
                 <Tooltip
-                    title={getTranslation('sort', formatterOptions.CAPITALIZE_FIRST_LETTER)}
+                    title={i18n.t('Sort')}
                     placement={'bottom'}
                     enterDelay={300}
                 >
@@ -84,7 +83,7 @@ class SortLabelWrapper extends React.Component<Props> {
                 {...this.props}
             >
                 <Tooltip
-                    title={getTranslation('sort', formatterOptions.CAPITALIZE_FIRST_LETTER)}
+                    title={i18n.t('Sort')}
                     placement={'bottom'}
                     enterDelay={300}
                 >

--- a/src/core_modules/capture-core/src/components/FormFields/Generic/D2TrueFalse.component.js
+++ b/src/core_modules/capture-core/src/components/FormFields/Generic/D2TrueFalse.component.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { getTranslation } from '../../../d2/d2Instance';
-import { formatterOptions } from '../../../utils/string/format.const';
+import i18n from '@dhis2/d2-i18n';
 
 import SingleSelectBoxes from '../Options/SingleSelectBoxes/SingleSelectBoxes.component';
 import OptionSet from '../../../metaData/OptionSet/OptionSet';
@@ -12,14 +11,9 @@ type Props = {
 };
 
 class D2TrueFalse extends Component<Props> {
-    static uiTexts = {
-        YES: 'boolean_true',
-        NO: 'boolean_false',
-    };
-
     static getOptions() {
-        const trueText = getTranslation(D2TrueFalse.uiTexts.YES, formatterOptions.CAPITALIZE_FIRST_LETTER);
-        const falseText = getTranslation(D2TrueFalse.uiTexts.NO, formatterOptions.CAPITALIZE_FIRST_LETTER);
+        const trueText = i18n.t('Yes');
+        const falseText = i18n.t('No');
 
         const optionSet = new OptionSet();
         optionSet.addOption(new Option((_this) => { _this.text = trueText; _this.value = 'true'; }));

--- a/src/core_modules/capture-core/src/components/FormFields/Options/SelectVirtualized/withTranslations.js
+++ b/src/core_modules/capture-core/src/components/FormFields/Options/SelectVirtualized/withTranslations.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react';
-import { getTranslation } from '../../../../d2/d2Instance';
-import { formatterOptions } from '../../../../utils/string/format.const';
+import i18n from '@dhis2/d2-i18n';
 
 type Props = {
 
@@ -9,8 +8,8 @@ type Props = {
 
 function buildTranslations() {
     return {
-        clearText: getTranslation('dropdown_clear', formatterOptions.CAPITALIZE_FIRST_LETTER),
-        noResults: getTranslation('dropdown_no_results', formatterOptions.CAPITALIZE_FIRST_LETTER),
+        clearText: i18n.t('Clear'),
+        noResults: i18n.t('No results'),
     };
 }
 

--- a/src/core_modules/capture-core/src/components/NetworkStatusBadge/NetworkStatusBadge.component.js
+++ b/src/core_modules/capture-core/src/components/NetworkStatusBadge/NetworkStatusBadge.component.js
@@ -5,7 +5,8 @@ import React, { PureComponent } from 'react';
 import Sync from '@material-ui/icons/Sync';
 import Grow from '@material-ui/core/Grow'
 import { withStyles } from '@material-ui/core/styles';
-import * as moment from 'moment';
+import moment from '../../utils/moment/momentResolver';
+import i18n from '@dhis2/d2-i18n';
 
 const styles = theme => ({
     offlineIcon: {
@@ -67,27 +68,27 @@ const styles = theme => ({
 const RightSection = (props) =>
     <div className={`${props.classes.flex} ${props.classes.badgeSection}`}>
         <OnlineIcon status={props.status ? props.classes.onlineIcon : props.classes.offlineIcon } />
-        <p className={props.classes.text}>{ props.status ? 'Online' : 'Offline' }</p>
+        <p className={props.classes.text}>{ props.status ? i18n.t('Online') : i18n.t('Offline') }</p>
     </div>
 
 class LeftSection extends PureComponent {
 
     constructor(props) {
         super(props)
-        this.state = {offlineTimer: moment(Date.now()).locale('en').fromNow()}
+        this.state = {offlineTimer: moment(Date.now()).fromNow()}
     }
 
     componentDidUpdate (prevProps, prevState) {
         if (this.props.statusTimer === 0) {
             clearInterval(this.timer)
             this.timer = null
-            this.setState({offlineTimer: moment(Date.now()).locale('en').fromNow()})
+            this.setState({offlineTimer: moment(Date.now()).fromNow()})
             return
         }
         
         if (this.props.statusTimer > 0 && !this.timer) {
             this.timer = setInterval(() => {
-                const t1 = moment(this.props.statusTimer).locale('en').fromNow()
+                const t1 = moment(this.props.statusTimer).fromNow()
                 this.setState({offlineTimer: t1})
             }, 60*1000)
             return
@@ -106,13 +107,13 @@ class LeftSection extends PureComponent {
             content = (
                 <div className={props.classes.flex}>
                     <Sync className={props.classes.icon}/>
-                    <p className={props.classes.text}>Syncing</p>
+                    <p className={props.classes.text}>{i18n.t('Syncing')}</p>
                 </div>
             )
         }
 
         if (!props.status) {
-            content = <span>{props.syncList.length} offline events. Last synced: {this.state.offlineTimer}</span>
+            content = <span>{props.syncList.length} {i18n.t('offline events. Last synced:')} {this.state.offlineTimer}</span>
         }
 
         const show = !!content

--- a/src/core_modules/capture-core/src/components/Pages/EditEvent/DataEntry/EditEventDataEntry.component.js
+++ b/src/core_modules/capture-core/src/components/Pages/EditEvent/DataEntry/EditEventDataEntry.component.js
@@ -2,8 +2,7 @@
 import React, { Component } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { Validators } from '@dhis2/d2-ui-forms';
-import { getTranslation } from '../../../../d2/d2Instance';
-import { formatterOptions } from '../../../../utils/string/format.const';
+import i18n from '@dhis2/d2-i18n';
 import DataEntry from '../../../../components/DataEntry/DataEntry.container';
 import withSaveButton from '../../../../components/DataEntry/withSaveButton';
 import withCancelButton from '../../../../components/DataEntry/withCancelButton';
@@ -60,13 +59,13 @@ const buildReportDateSettingsFn = () => {
             {
                 validator: Validators.wordToValidatorMap.get('required'),
                 message:
-                    getTranslation(
+                    i18n.t(
                         Validators.wordToValidatorMap.get('required').message,
-                        formatterOptions.CAPITALIZE_FIRST_LETTER),
+                    ),
             },
             {
                 validator: preValidateDate,
-                message: getTranslation('value_should_be_a_valid_date', formatterOptions.CAPITALIZE_FIRST_LETTER),
+                message: i18n.t('Please provide a valid date'),
             },
         ],
     });

--- a/src/core_modules/capture-core/src/components/Pages/EditEvent/epics/editEvent.epics.js
+++ b/src/core_modules/capture-core/src/components/Pages/EditEvent/epics/editEvent.epics.js
@@ -5,7 +5,7 @@ import errorCreator from '../../../../utils/errorCreator';
 import getErrorMessageAndDetails from '../../../../utils/errors/getErrorMessageAndDetails';
 import getOrganisationUnitApiSpec from '../../../../api/apiSpecifications/organisationUnit.apiSpecificationGetter';
 
-import { getTranslation } from '../../../../d2/d2Instance';
+import i18n from '@dhis2/d2-i18n';
 import {
     actionTypes as editEventActionTypes,
     eventFromUrlCouldNotBeRetrieved,
@@ -46,7 +46,7 @@ export const getEventFromUrlEpic = (action$: InputObservable) =>
                 .then((eventContainer) => {
                     if (!eventContainer) {
                         return eventFromUrlCouldNotBeRetrieved(
-                            getTranslation('error_loading_event_from_url_for_edit_event_user_message'));
+                            i18n.t('Event could not be loaded. Are you sure it exists?'));
                     }
                     return eventFromUrlRetrieved(eventContainer);
                 })
@@ -55,9 +55,9 @@ export const getEventFromUrlEpic = (action$: InputObservable) =>
                     log.error(
                         errorCreator(
                             message ||
-                            getTranslation('error_loading_event_from_url_for_edit_event_log_message'))(details));
+                            i18n.t('Event could not be loaded'))(details));
                     return eventFromUrlCouldNotBeRetrieved(
-                        getTranslation('error_loading_event_from_url_for_edit_event_user_message'));
+                        i18n.t('Event could not be loaded. Are you sure it exists?'));
                 });
         });
 
@@ -74,7 +74,7 @@ export const getOrgUnitOnUrlUpdateEpic = (action$: InputObservable) =>
                     const { message, details } = getErrorMessageAndDetails(error);
                     log.error(errorCreator(
                         message ||
-                        getTranslation('error_loading_orgunit_for_url_log_message'))(details));
+                        i18n.t('Organisation unit could not be loaded'))(details));
                     return orgUnitCouldNotBeRetrievedOnUrlUpdate(eventContainer);
                 });
         });

--- a/src/core_modules/capture-core/src/components/Pages/MainPage/EventsList/EventsList.component.js
+++ b/src/core_modules/capture-core/src/components/Pages/MainPage/EventsList/EventsList.component.js
@@ -8,8 +8,7 @@ import IconButton from '@material-ui/core/IconButton';
 
 import classNames from 'classnames';
 
-import { getTranslation } from '../../../../d2/d2Instance';
-import { formatterOptions } from '../../../../utils/string/format.const';
+import i18n from '@dhis2/d2-i18n';
 import elementTypes from '../../../../metaData/DataElement/elementTypes';
 
 import getTableComponents from '../../../d2Ui/dataTable/getTableComponents';
@@ -198,7 +197,7 @@ class EventsList extends Component<Props> {
                         colSpan={columnsCount}
                         className={classNames(classes.cell, classes.bodyCell)}
                     >
-                        {getTranslation('no_events_to_display', formatterOptions.CAPITALIZE_FIRST_LETTER)}
+                        {i18n.t('No events to display')}
                     </Cell>
                 </Row>
             );
@@ -285,7 +284,7 @@ class EventsList extends Component<Props> {
                     className={classes.paginationContainer}
                 >
                     <EventListPagination
-                        rowsCountSelectorLabel={getTranslation('rows_per_page', formatterOptions.CAPITALIZE_FIRST_LETTER)}
+                        rowsCountSelectorLabel={i18n.t('Rows per page')}
                         onGetLabelDisplayedRows={this.getPaginationLabelDisplayedRows}
                     />
                 </div>

--- a/src/core_modules/capture-core/src/components/Pages/MainPage/MainPage.component.js
+++ b/src/core_modules/capture-core/src/components/Pages/MainPage/MainPage.component.js
@@ -6,7 +6,6 @@ import React, { Component } from 'react';
 
 import withLoadHandler from './withLoadHandler';
 import EventsList from './EventsList/EventsList.container';
-import QuickSelector from '../../QuickSelector/QuickSelector.container';
 import TempSelector from './TempSelector.container';
 
 type Props = {

--- a/src/core_modules/capture-core/src/components/Pages/MainPage/mainSelections.epics.js
+++ b/src/core_modules/capture-core/src/components/Pages/MainPage/mainSelections.epics.js
@@ -2,14 +2,14 @@
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/filter';
-import { getApi, getTranslation } from '../../../d2/d2Instance';
+import { getApi } from '../../../d2/d2Instance';
+import i18n from '@dhis2/d2-i18n';
 import {
     actionTypes,
     mainSelectionCompleted,
     orgUnitDataRetrived,
     setCurrentOrgUnitBasedOnUrl,
     errorRetrievingOrgUnitBasedOnUrl,
-    invalidOrgUnitFromUrl,
     setEmptyOrgUnitBasedOnUrl,
     validSelectionsFromUrl,
     invalidSelectionsFromUrl,
@@ -49,7 +49,7 @@ export const mainSelectionsFromUrlGetOrgUnitDataEpic = (action$: InputObservable
             .then(response => setCurrentOrgUnitBasedOnUrl({ id: response.id, name: response.displayName }),
             )
             .catch(() =>
-                errorRetrievingOrgUnitBasedOnUrl(getTranslation('could_not_get_organisation_unit')),
+                errorRetrievingOrgUnitBasedOnUrl(i18n.t('Could not get organisation unit')),
             ),
         );
 
@@ -65,7 +65,7 @@ export const mainSelectionsFromUrlValidationEpic = (action$: InputObservable, st
         .map(() => {
             const { programId } = store.getState().currentSelections;
             if (programId && !programCollection.has(programId)) {
-                return invalidSelectionsFromUrl(getTranslation('program_doesnt_exist'));
+                return invalidSelectionsFromUrl(i18n.t("Program doesn't exist"));
             }
             return validSelectionsFromUrl();
         });

--- a/src/core_modules/capture-core/src/components/Pages/NewEvent/DataEntry/DataEntrySelectionsIncomplete.component.js
+++ b/src/core_modules/capture-core/src/components/Pages/NewEvent/DataEntry/DataEntrySelectionsIncomplete.component.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Button from '../../../Buttons/Button.component';
-import { getTranslation } from '../../../../d2/d2Instance';
+import i18n from '@dhis2/d2-i18n';
 
 const getStyles = () => ({
     contents: {
@@ -34,11 +34,11 @@ class DataEntrySelectionsIncomplete extends Component<Props> {
         const { isProgramSelected, isOrgUnitSelected } = this.props;
 
         if (!isProgramSelected && !isOrgUnitSelected) {
-            text = getTranslation('select_a_registering_unit_and_program_to_get_started');
+            text = i18n.t('Select a registering unit and program above to get started');
         } else if (!isProgramSelected) {
-            text = getTranslation('select_a_program_to_start_reporting');
+            text = i18n.t('Select a program to start reporting');
         } else {
-            text = getTranslation('select_a_registering_unit_to_start_reporting');
+            text = i18n.t('Select a registering unit to start reporting');
         }
 
         return text;
@@ -64,14 +64,14 @@ class DataEntrySelectionsIncomplete extends Component<Props> {
                         color="primary"
                         disabled
                     >
-                        {getTranslation('save')}
+                        {i18n.t('Save')}
                     </Button>
                     <Button
                         variant="raised"
                         color="secondary"
                         onClick={onCancel}
                     >
-                        {getTranslation('cancel')}
+                        {i18n.t('Cancel')}
                     </Button>
                 </div>
             </div>

--- a/src/core_modules/capture-core/src/components/Pages/NewEvent/DataEntry/DataEntryWrapper.component.js
+++ b/src/core_modules/capture-core/src/components/Pages/NewEvent/DataEntry/DataEntryWrapper.component.js
@@ -3,8 +3,7 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import NewEventDataEntry from './NewEventDataEntry.container';
 import DataEntrySelectionsIncomplete from './DataEntrySelectionsIncomplete.container';
-import { getTranslation } from '../../../../d2/d2Instance';
-import { formatterOptions } from '../../../../utils/string/format.const';
+import i18n from '@dhis2/d2-i18n';
 
 const getStyles = theme => ({
     headerContainer: {
@@ -37,7 +36,7 @@ class DataEntryWrapper extends React.Component<Props> {
                 <div
                     className={this.props.classes.header}
                 >
-                    {getTranslation('new_event_header', formatterOptions.CAPITALIZE_FIRST_LETTER)}
+                    {i18n.t('New event')}
                 </div>
                 <div>
                     {/* print form? */ }

--- a/src/core_modules/capture-core/src/components/Pages/NewEvent/DataEntry/NewEventDataEntry.component.js
+++ b/src/core_modules/capture-core/src/components/Pages/NewEvent/DataEntry/NewEventDataEntry.component.js
@@ -3,8 +3,7 @@ import React, { Component } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import InfoIcon from '@material-ui/icons/InfoOutline';
 import { Validators } from '@dhis2/d2-ui-forms';
-import { getTranslation } from '../../../../d2/d2Instance';
-import { formatterOptions } from '../../../../utils/string/format.const';
+import i18n from '@dhis2/d2-i18n';
 import DataEntry from '../../../../components/DataEntry/DataEntry.container';
 import withSaveButton from '../../../../components/DataEntry/withSaveButton';
 import withCancelButton from '../../../../components/DataEntry/withCancelButton';
@@ -73,13 +72,13 @@ const buildReportDateSettingsFn = () => {
             {
                 validator: Validators.wordToValidatorMap.get('required'),
                 message:
-                    getTranslation(
-                        Validators.wordToValidatorMap.get('required').message,
-                        formatterOptions.CAPITALIZE_FIRST_LETTER),
+                    i18n.t(
+                        Validators.wordToValidatorMap.get('required').message
+                    ),
             },
             {
                 validator: preValidateDate,
-                message: getTranslation('value_should_be_a_valid_date', formatterOptions.CAPITALIZE_FIRST_LETTER),
+                message: i18n.t('Please provide a valid date'),
             },
         ],
     });
@@ -134,8 +133,8 @@ type Props = {
 class NewEventDataEntry extends Component<Props> {
     getSavingText() {
         const { classes, orgUnitName, programName } = this.props;
-        const firstPart = `${getTranslation('saving_to', formatterOptions.CAPITALIZE_FIRST_LETTER)} `;
-        const secondPart = ` ${getTranslation('in')} `;
+        const firstPart = `${i18n.t('Saving to')} `;
+        const secondPart = ` ${i18n.t('in')} `;
 
         return (
             <span>

--- a/src/core_modules/capture-core/src/components/Pages/NewEvent/DataEntry/NewEventDataEntry.container.js
+++ b/src/core_modules/capture-core/src/components/Pages/NewEvent/DataEntry/NewEventDataEntry.container.js
@@ -15,8 +15,7 @@ import {
 import RenderFoundation from '../../../../metaData/RenderFoundation/RenderFoundation';
 import withLoadingIndicator from '../../../../HOC/withLoadingIndicator';
 import withErrorMessageHandler from '../../../../HOC/withErrorMessageHandler';
-import { getTranslation } from '../../../../d2/d2Instance';
-import { formatterOptions } from '../../../../utils/string/format.const';
+import i18n from '@dhis2/d2-i18n';
 
 const makeMapStateToProps = () => {
     const programNameSelector = makeProgramNameSelector();
@@ -28,7 +27,7 @@ const makeMapStateToProps = () => {
         return {
             ready: !state.newEventPage.dataEntryIsLoading,
             error: !formFoundation ?
-                getTranslation('not_event_program_or_metadata_error', formatterOptions.CAPITALIZE_FIRST_LETTER) : null,
+                i18n.t('This is not an event program or the metadata is corrupt. See log for details.') : null,
             formFoundation,
             programName: programNameSelector(state),
             orgUnitName: state.organisationUnits[state.currentSelections.orgUnitId] &&

--- a/src/core_modules/capture-core/src/components/Pages/NewEvent/epics/newEventSelections.epics.js
+++ b/src/core_modules/capture-core/src/components/Pages/NewEvent/epics/newEventSelections.epics.js
@@ -2,7 +2,8 @@
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/filter';
-import { getApi, getTranslation } from '../../../../d2/d2Instance';
+import { getApi } from '../../../../d2/d2Instance';
+import i18n from '@dhis2/d2-i18n';
 import {
     actionTypes,
     setCurrentOrgUnitBasedOnUrl,
@@ -22,7 +23,7 @@ export const selectionsFromUrlGetOrgUnitDataForNewEventEpic = (action$: InputObs
             .then(response => setCurrentOrgUnitBasedOnUrl({ id: response.id, name: response.displayName }),
             )
             .catch(() =>
-                errorRetrievingOrgUnitBasedOnUrl(getTranslation('could_not_get_organisation_unit')),
+                errorRetrievingOrgUnitBasedOnUrl(i18n.t('Could not get organisation unit')),
             ),
         );
 
@@ -39,7 +40,7 @@ export const selectionsFromUrlValidationForNewEventEpic = (action$: InputObserva
             const { programId } = store.getState().currentSelections;
 
             if (programId && !programCollection.has(programId)) {
-                return invalidSelectionsFromUrl(getTranslation('program_doesnt_exist'));
+                return invalidSelectionsFromUrl(i18n.t("Program doesn't exist"));
             }
 
             return validSelectionsFromUrl();

--- a/src/core_modules/capture-core/src/components/QuickSelector/ActionButtons.component.js
+++ b/src/core_modules/capture-core/src/components/QuickSelector/ActionButtons.component.js
@@ -6,7 +6,7 @@ import Button from '@material-ui/core/Button';
 import AddIcon from '@material-ui/icons/AddCircleOutline';
 import SearchIcon from '@material-ui/icons/Search';
 
-import { getTranslation } from '../../d2/d2Instance';
+import i18n from '@dhis2/d2-i18n';
 
 const styles = () => ({
     container: {
@@ -49,7 +49,7 @@ class ActionButtons extends Component<Props> {
                         color="primary"
                         className={this.props.classes.leftButton}
                     >
-                        { getTranslation('reset') }
+                        { i18n.t('Reset') }
                     </Button>
                 </div>
             );
@@ -61,21 +61,21 @@ class ActionButtons extends Component<Props> {
                     color="primary"
                     className={this.props.classes.leftButton}
                 >
-                    { getTranslation('reset') }
+                    { i18n.t('Reset') }
                 </Button>
                 <Button
                     onClick={this.handleClick}
                     color="primary"
                 >
                     <AddIcon className={this.props.classes.rightButton} />
-                    { getTranslation('new') }
+                    { i18n.t('New') }
                 </Button>
                 <Button
                     onClick={this.handleClick}
                     color="primary"
                 >
                     <SearchIcon className={this.props.classes.rightButton} />
-                    { getTranslation('find') }
+                    { i18n.t('Find') }
                 </Button>
             </div>
         );

--- a/src/core_modules/capture-core/src/converters/helpers/formToClient.js
+++ b/src/core_modules/capture-core/src/converters/helpers/formToClient.js
@@ -2,8 +2,8 @@
 import log from 'loglevel';
 
 import errorCreator from '../../utils/errorCreator';
-import { getTranslation } from '../../d2/d2Instance';
 import programCollection from '../../metaDataMemoryStores/programCollection/programCollection';
+import i18n from '@dhis2/d2-i18n';
 import RenderFoundation from '../../metaData/RenderFoundation/RenderFoundation';
 import { convertValue } from '../formToClient';
 
@@ -24,13 +24,13 @@ export function convertStateFormValuesToClient(eventId: string, state: Object) {
     const program = programCollection.get(event.programId);
     if (!program) {
         log.error(errorCreator(errorMessages.PROGRAM_NOT_FOUND)({ eventId, event }));
-        return { error: getTranslation('generic_error'), values: null, stage: null };
+        return { error: i18n.t('An error has occured. See log for details'), values: null, stage: null };
     }
 
     const stage = program.getStage(event.programStageId);
     if (!stage) {
         log.error(errorCreator(errorMessages.STAGE_NOT_FOUND)({ eventId, event }));
-        return { error: getTranslation('generic_error'), values: null, stage: null };
+        return { error: i18n.t('An error has occured. See log for details'), values: null, stage: null };
     }
 
     const convertedValues = convertFormValuesToClient(formValues, stage);

--- a/src/core_modules/capture-core/src/d2/d2Instance.js
+++ b/src/core_modules/capture-core/src/d2/d2Instance.js
@@ -1,7 +1,5 @@
 // @flow
 import log from 'loglevel';
-import format from '../utils/string/format';
-import { formatterOptions } from '../utils/string/format.const';
 
 let d2Instance: D2;
 
@@ -14,16 +12,6 @@ const getD2 = () => {
         log.error('please set d2 before using it');
     }
     return d2Instance;
-};
-
-export const getTranslation = (text: string, formatterOption?: $Values<typeof formatterOptions>) => {
-    const translatedText = getD2().i18n.getTranslation(text);
-
-    if (formatterOption && translatedText && translatedText.charAt(0) !== '*') {
-        return format(translatedText, formatterOption);
-    }
-
-    return translatedText;
 };
 
 export const getApi = () => getD2().Api.getApi();

--- a/src/core_modules/capture-core/src/metaData/helpers/EventProgram/getProgramAndStageFromEvent.js
+++ b/src/core_modules/capture-core/src/metaData/helpers/EventProgram/getProgramAndStageFromEvent.js
@@ -3,11 +3,12 @@ import log from 'loglevel';
 
 import errorCreator from '../../../utils/errorCreator';
 import programCollection from '../../../metaDataMemoryStores/programCollection/programCollection';
-import { getTranslation } from '../../../d2/d2Instance';
+import i18n from '@dhis2/d2-i18n';
 
 const errorMessages = {
     PROGRAM_NOT_FOUND: 'Program not found',
     STAGE_NOT_FOUND: 'Stage not found',
+    GENERIC_ERROR: 'An error has occured. See log for details'
 };
 
 export default function getProgramAndStageFromEvent(event: Event) {
@@ -15,13 +16,13 @@ export default function getProgramAndStageFromEvent(event: Event) {
     const program = programCollection.get(event.programId);
     if (!program) {
         log.error(errorCreator(errorMessages.PROGRAM_NOT_FOUND)({ eventId, event }));
-        return { error: getTranslation('generic_error'), stage: null, program: null };
+        return { error: i18n.t(errorMessages.GENERIC_ERROR), stage: null, program: null };
     }
 
     const stage = program.getStage(event.programStageId);
     if (!stage) {
         log.error(errorCreator(errorMessages.STAGE_NOT_FOUND)({ eventId, event }));
-        return { error: getTranslation('generic_error'), stage: null, program: null };
+        return { error: i18n.t(errorMessages.GENERIC_ERROR), stage: null, program: null };
     }
 
     return { stage, program, error: null };

--- a/src/core_modules/capture-core/src/metaData/helpers/EventProgram/getProgramAndStageFromProgramId.js
+++ b/src/core_modules/capture-core/src/metaData/helpers/EventProgram/getProgramAndStageFromProgramId.js
@@ -3,24 +3,25 @@ import log from 'loglevel';
 
 import errorCreator from '../../../utils/errorCreator';
 import programCollection from '../../../metaDataMemoryStores/programCollection/programCollection';
-import { getTranslation } from '../../../d2/d2Instance';
+import i18n from '@dhis2/d2-i18n';
 
 const errorMessages = {
     PROGRAM_NOT_FOUND: 'Program not found',
     STAGE_NOT_FOUND: 'Stage not found',
+    GENERIC_ERROR: 'An error has occured. See log for details'
 };
 
 export default function getProgramAndStageFromProgramId(programId: string) {   
     const program = programCollection.get(programId);
     if (!program) {
         log.error(errorCreator(errorMessages.PROGRAM_NOT_FOUND)({ programId }));
-        return { error: getTranslation('generic_error'), stage: null, program: null };
+        return { error: i18n.t(errorMessages.GENERIC_ERROR), stage: null, program: null };
     }
 
     const stage = program.getStage();
     if (!stage) {
         log.error(errorCreator(errorMessages.STAGE_NOT_FOUND)({ program, programId }));
-        return { error: getTranslation('generic_error'), stage: null, program: null };
+        return { error: i18n.t(errorMessages.GENERIC_ERROR), stage: null, program: null };
     }
 
     return { stage, program, error: null };

--- a/src/core_modules/capture-core/src/metaData/helpers/getStageFromEvent.js
+++ b/src/core_modules/capture-core/src/metaData/helpers/getStageFromEvent.js
@@ -3,11 +3,12 @@ import log from 'loglevel';
 
 import errorCreator from '../../utils/errorCreator';
 import programCollection from '../../metaDataMemoryStores/programCollection/programCollection';
-import { getTranslation } from '../../d2/d2Instance';
+import i18n from '@dhis2/d2-i18n';
 
 const errorMessages = {
     PROGRAM_NOT_FOUND: 'Program not found',
     STAGE_NOT_FOUND: 'Stage not found',
+    GENERIC_ERROR: 'An error has occured. See log for details'
 };
 
 export default function getStageFromEvent(event: Event) {
@@ -15,13 +16,13 @@ export default function getStageFromEvent(event: Event) {
     const program = programCollection.get(event.programId);
     if (!program) {
         log.error(errorCreator(errorMessages.PROGRAM_NOT_FOUND)({ eventId, event }));
-        return { error: getTranslation('generic_error'), stage: null };
+        return { error: i18n.t(errorMessages.GENERIC_ERROR), stage: null };
     }
 
     const stage = program.getStage(event.programStageId);
     if (!stage) {
         log.error(errorCreator(errorMessages.STAGE_NOT_FOUND)({ eventId, event }));
-        return { error: getTranslation('generic_error'), stage: null };
+        return { error: i18n.t(errorMessages.GENERIC_ERROR), stage: null };
     }
 
     return { stage, error: null };

--- a/src/core_modules/capture-core/src/metaData/helpers/getStageFromProgramIdForEventProgram.js
+++ b/src/core_modules/capture-core/src/metaData/helpers/getStageFromProgramIdForEventProgram.js
@@ -3,25 +3,26 @@ import log from 'loglevel';
 
 import errorCreator from '../../utils/errorCreator';
 import programCollection from '../../metaDataMemoryStores/programCollection/programCollection';
-import { getTranslation } from '../../d2/d2Instance';
+import i18n from '@dhis2/d2-i18n';
 
 const errorMessages = {
     PROGRAM_NOT_FOUND: 'Program not found',
     STAGE_NOT_FOUND: 'Stage not found',
+    GENERIC_ERROR: 'An error has occured. See log for details'
 };
 
 export default function getStageForEventProgram(programId: string) {
     const program = programCollection.get(programId);
     if (!program) {
         log.error(errorCreator(errorMessages.PROGRAM_NOT_FOUND)({ programId }));
-        return { error: getTranslation('generic_error'), stage: null };
+        return { error: i18n.t(errorMessages.GENERIC_ERROR), stage: null };
     }
 
     // $FlowSuppress
     const stage = program.getStage();
     if (!stage) {
         log.error(errorCreator(errorMessages.STAGE_NOT_FOUND)({ programId }));
-        return { error: getTranslation('generic_error'), stage: null };
+        return { error: i18n.t(errorMessages.GENERIC_ERROR), stage: null };
     }
 
     return { stage, error: null };

--- a/src/core_modules/capture-core/src/reducers/descriptions/dataEntry.reducerDescription.js
+++ b/src/core_modules/capture-core/src/reducers/descriptions/dataEntry.reducerDescription.js
@@ -4,7 +4,6 @@ import { createReducerDescription } from '../../trackerRedux/trackerReducer';
 import { actionTypes } from '../../components/DataEntry/actions/dataEntry.actions';
 import { actionTypes as loadNewActionTypes } from '../../components/DataEntry/actions/dataEntryLoadNew.actions';
 import { actionTypes as loadEditActionTypes } from '../../components/DataEntry/actions/dataEntryLoadEdit.actions';
-import { actionTypes as rulesEngineActionTypes } from '../../rulesEngineActionsCreator/rulesEngine.actions';
 
 import getDataEntryKey from '../../components/DataEntry/common/getDataEntryKey';
 

--- a/src/core_modules/capture-core/src/reducers/descriptions/feedback.reducerDescription.js
+++ b/src/core_modules/capture-core/src/reducers/descriptions/feedback.reducerDescription.js
@@ -4,7 +4,7 @@ import log from 'loglevel';
 import isString from 'd2-utilizr/lib/isString';
 import isObject from 'd2-utilizr/lib/isObject';
 import errorCreator from '../../utils/errorCreator';
-import { getTranslation } from '../../d2/d2Instance';
+import i18n from '@dhis2/d2-i18n';
 import { createReducerDescription } from '../../trackerRedux/trackerReducer';
 import { actionTypes as feedbackActionTypes } from '../../components/FeedbackBar/actions/feedback.actions';
 import { actionTypes as dataEntryActionTypes } from '../../components/DataEntry/actions/dataEntry.actions';
@@ -51,10 +51,10 @@ export const feedbackDesc = createReducerDescription({
         const error = action.payload;
         const errorMessage = isString(error) ? error : error.message;
         const errorObject = isObject(error) ? error : null;
-        log.error(errorCreator(errorMessage || getTranslation('error_saving_event_log'))(errorObject));
+        log.error(errorCreator(errorMessage || i18n.t('Error saving event'))(errorObject));
         const newState = [
             ...state,
-            getErrorFeedback(getTranslation('error_saving_event_user')),
+            getErrorFeedback(i18n.t('Could not save event. See log for details')),
         ];
         return newState;
     },
@@ -62,10 +62,10 @@ export const feedbackDesc = createReducerDescription({
         const error = action.payload;
         const errorMessage = isString(error) ? error : error.message;
         const errorObject = isObject(error) ? error : null;
-        log.error(errorCreator(errorMessage || getTranslation('error_saving_event_log'))(errorObject));
+        log.error(errorCreator(errorMessage || i18n.t('Error saving event'))(errorObject));
         const newState = [
             ...state,
-            getErrorFeedback(getTranslation('error_saving_event_user')),
+            getErrorFeedback(i18n.t('Could not save event. See log for details')),
         ];
         return newState;
     },

--- a/src/core_modules/capture-core/src/rulesEngineActionsCreator/rulesEngineActionsCreatorForEvent.js
+++ b/src/core_modules/capture-core/src/rulesEngineActionsCreator/rulesEngineActionsCreatorForEvent.js
@@ -8,8 +8,7 @@ import RulesEngine from '../RulesEngine/RulesEngine';
 import inputValueConverter from './inputValueConverter';
 import outputRulesEffectsValueConverter from './rulesEffectsValueConverter';
 import momentConverter from './momentConverter';
-import { getTranslation } from '../d2/d2Instance';
-
+import i18n from '@dhis2/d2-i18n';
 import errorCreator from '../utils/errorCreator';
 import Program from '../metaData/Program/Program';
 import TrackerProgram from '../metaData/Program/TrackerProgram';
@@ -48,7 +47,7 @@ export type FieldData = {
 };
 
 const rulesEngine =
-    new RulesEngine(inputValueConverter, momentConverter, getTranslation, outputRulesEffectsValueConverter);
+    new RulesEngine(inputValueConverter, momentConverter, i18n.t, outputRulesEffectsValueConverter);
 
 const errorMessages = {
     PROGRAM_NOT_FOUND: 'Program not found in loadAndExecuteRulesForEvent',

--- a/src/core_modules/capture-core/src/utils/localeData/CurrentLocaleData.js
+++ b/src/core_modules/capture-core/src/utils/localeData/CurrentLocaleData.js
@@ -1,6 +1,5 @@
 // @flow
 export type LocaleDataType = {
-    dateFnsLocale: Object,
     weekDaysShort: Array<string>,
     weekDays: Array<string>,
     selectDatesText: string,

--- a/src/core_modules/capture-core/src/utils/localeData/CurrentLocaleData.js
+++ b/src/core_modules/capture-core/src/utils/localeData/CurrentLocaleData.js
@@ -1,5 +1,6 @@
 // @flow
 export type LocaleDataType = {
+    dateFnsLocale: Object,
     weekDaysShort: Array<string>,
     weekDays: Array<string>,
     selectDatesText: string,

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
+import './locales';
 import './init/entry';

--- a/src/init/entry.js
+++ b/src/init/entry.js
@@ -5,7 +5,6 @@ import { render } from 'react-dom';
 import log from 'loglevel';
 import 'typeface-roboto';
 import createHistory from 'history/createHashHistory';
-import type { HashHistory } from 'history/createHashHistory';
 
 import D2UIApp from '@dhis2/d2-ui-app';
 import { LoadingMask } from '@dhis2/d2-ui-core';

--- a/src/init/init.js
+++ b/src/init/init.js
@@ -51,15 +51,26 @@ function changeLocale(locale) {
 }
 
 function setLocaleData(uiLocale: string) { //eslint-disable-line
+    // this should be the user locale
     const locale = 'en';
 
     changeLocale(locale);
+
+    let dateFnLocale;
+    try {
+        // this should be replaced with a dynamic import
+        dateFnLocale = require(`date-fns/locale/${locale}`);
+    } catch (error) {
+        log.error(`could not get date-fns locale for ${locale}`);
+        dateFnLocale = require('date-fns/locale/en');
+    }
     
     const weekdays = moment.weekdays();
     const weekdaysShort = moment.weekdaysShort();
     // $FlowSuppress
     const firstDayOfWeek = moment.localeData()._week.dow; //eslint-disable-line
     const localeData: LocaleDataType = {
+        dateFnsLocale: dateFnLocale,
         weekDays: weekdays,
         weekDaysShort: weekdaysShort,
         calendarFormatHeaderLong: 'dddd D MMM',

--- a/src/init/init.js
+++ b/src/init/init.js
@@ -5,10 +5,9 @@ import { init, config, getUserSettings, getManifest } from 'd2/lib/d2';
 import environments from 'capture-core/constants/environments';
 import moment from 'capture-core/utils/moment/momentResolver';
 import CurrentLocaleData from 'capture-core/utils/localeData/CurrentLocaleData';
-import { setD2, getTranslation } from 'capture-core/d2/d2Instance';
+import { setD2 } from 'capture-core/d2/d2Instance';
+import i18n from '@dhis2/d2-i18n';
 import { formatterOptions } from 'capture-core/utils/string/format.const';
-
-import 'moment/locale/nb';
 
 import loadMetaData from 'capture-core/metaDataStoreLoaders/baseLoader/metaDataLoader';
 import buildMetaData from 'capture-core/metaDataMemoryStoreBuilders/baseBuilder/metaDataBuilder';
@@ -39,58 +38,36 @@ async function initializeManifest() {
     log.info(`Loading: ${manifest.name} v${manifest.version}`);
 }
 
-function configI18n(keyUiLocale: string) {
-    const locale = keyUiLocale || 'en';
-    config.i18n.sources.add(`i18n/module/i18n_module_${locale}.properties`);
-    return keyUiLocale;
+function isLangRTL(code) {
+    const langs = ['ar', 'fa', 'ur']
+    const prefixed = langs.map(c => `${c}-`)
+    return langs.includes(code) || prefixed.filter(c => code.startsWith(c)).length > 0
 }
 
-// TODO: Make api-requests?
-function getLocaleSpecs(locale: string) {
-    const fallbackLocale = 'en';
-    let calculatedLocale = locale;
-    try {
-        if (locale !== 'en') {
-            require(`moment/locale/${locale}`);
-        }
-    } catch (error) {
-        log.error(`could not get moment locale for ${locale}`);
-        calculatedLocale = fallbackLocale;
-    }
-
-    let dateFnLocale;
-    try {
-        dateFnLocale = require(`date-fns/locale/${locale}`);
-    } catch (error) {
-        log.error(`could not get date-fns locale for ${locale}`);
-        dateFnLocale = require('date-fns/locale/en');
-        calculatedLocale = fallbackLocale;
-    }
-
-    return {
-        calculatedLocale,
-        dateFnLocale,
-    };
+function changeLocale(locale) {
+    moment.locale(locale)
+    i18n.changeLanguage(locale)
+    document.body.setAttribute('dir', isLangRTL(locale) ? 'rtl' : 'ltr')
 }
 
 function setLocaleData(uiLocale: string) { //eslint-disable-line
     const locale = 'en';
-    const { calculatedLocale, dateFnLocale } = getLocaleSpecs(locale);
-    moment.locale(calculatedLocale);
+
+    changeLocale(locale);
+    
     const weekdays = moment.weekdays();
     const weekdaysShort = moment.weekdaysShort();
     // $FlowSuppress
     const firstDayOfWeek = moment.localeData()._week.dow; //eslint-disable-line
     const localeData: LocaleDataType = {
-        dateFnsLocale: dateFnLocale,
         weekDays: weekdays,
         weekDaysShort: weekdaysShort,
         calendarFormatHeaderLong: 'dddd D MMM',
         calendarFormatHeaderShort: 'D MMM',
-        selectDatesText: getTranslation('choose_one_or_more_dates', formatterOptions.CAPITALIZE_FIRST_LETTER),
-        selectDateText: getTranslation('choose_a_date', formatterOptions.CAPITALIZE_FIRST_LETTER),
-        todayLabelShort: getTranslation('today', formatterOptions.CAPITALIZE_FIRST_LETTER),
-        todayLabelLong: getTranslation('today', formatterOptions.CAPITALIZE_FIRST_LETTER),
+        selectDatesText: i18n.t('Choose one or more dates...'),
+        selectDateText: i18n.t('Choose a date...'),
+        todayLabelShort: i18n.t('Today'),
+        todayLabelLong: i18n.t('Today'),
         weekStartsOn: firstDayOfWeek,
     };
 
@@ -114,7 +91,6 @@ export async function initialize() {
 
     await initializeManifest();
     const userSettings = await getUserSettings();
-    configI18n(userSettings.keyUiLocale);
     const d2 = await init();
     setD2(d2);
     // const systemSettings = await getSystemSettings(d2);

--- a/src/init/init.js
+++ b/src/init/init.js
@@ -7,7 +7,6 @@ import moment from 'capture-core/utils/moment/momentResolver';
 import CurrentLocaleData from 'capture-core/utils/localeData/CurrentLocaleData';
 import { setD2 } from 'capture-core/d2/d2Instance';
 import i18n from '@dhis2/d2-i18n';
-import { formatterOptions } from 'capture-core/utils/string/format.const';
 
 import loadMetaData from 'capture-core/metaDataStoreLoaders/baseLoader/metaDataLoader';
 import buildMetaData from 'capture-core/metaDataMemoryStoreBuilders/baseBuilder/metaDataBuilder';
@@ -56,33 +55,48 @@ function setLocaleData(uiLocale: string) { //eslint-disable-line
 
     changeLocale(locale);
 
-    let dateFnLocale;
-    try {
-        // this should be replaced with a dynamic import
-        dateFnLocale = require(`date-fns/locale/${locale}`);
-    } catch (error) {
-        log.error(`could not get date-fns locale for ${locale}`);
-        dateFnLocale = require('date-fns/locale/en');
-    }
-    
     const weekdays = moment.weekdays();
     const weekdaysShort = moment.weekdaysShort();
     // $FlowSuppress
     const firstDayOfWeek = moment.localeData()._week.dow; //eslint-disable-line
-    const localeData: LocaleDataType = {
-        dateFnsLocale: dateFnLocale,
-        weekDays: weekdays,
-        weekDaysShort: weekdaysShort,
-        calendarFormatHeaderLong: 'dddd D MMM',
-        calendarFormatHeaderShort: 'D MMM',
-        selectDatesText: i18n.t('Choose one or more dates...'),
-        selectDateText: i18n.t('Choose a date...'),
-        todayLabelShort: i18n.t('Today'),
-        todayLabelLong: i18n.t('Today'),
-        weekStartsOn: firstDayOfWeek,
-    };
 
-    CurrentLocaleData.set(localeData);
+    import(`date-fns/locale/${locale}`).then(dateFnLocale => {
+        const localeData: LocaleDataType = {
+            dateFnsLocale: dateFnLocale,
+            weekDays: weekdays,
+            weekDaysShort: weekdaysShort,
+            calendarFormatHeaderLong: 'dddd D MMM',
+            calendarFormatHeaderShort: 'D MMM',
+            selectDatesText: i18n.t('Choose one or more dates...'),
+            selectDateText: i18n.t('Choose a date...'),
+            todayLabelShort: i18n.t('Today'),
+            todayLabelLong: i18n.t('Today'),
+            weekStartsOn: firstDayOfWeek,
+        };
+
+        log.info(`got date-fns locale for ${locale}`);
+        CurrentLocaleData.set(localeData);
+    }).catch(e => {
+        log.error(`could not get date-fns locale for ${locale}`);
+        import('date-fns/locale/en').then(dateFnLocale => {
+            const localeData: LocaleDataType = {
+                dateFnsLocale: dateFnLocale,
+                weekDays: weekdays,
+                weekDaysShort: weekdaysShort,
+                calendarFormatHeaderLong: 'dddd D MMM',
+                calendarFormatHeaderShort: 'D MMM',
+                selectDatesText: i18n.t('Choose one or more dates...'),
+                selectDateText: i18n.t('Choose a date...'),
+                todayLabelShort: i18n.t('Today'),
+                todayLabelLong: i18n.t('Today'),
+                weekStartsOn: firstDayOfWeek,
+            };
+
+            CurrentLocaleData.set(localeData);
+        }).catch(e => {
+            log.error(`could not get the fallback date-fns locale for ${locale}`);
+        })
+    })
 }
 
 /*

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,30 @@
     core-js "^2.5.3"
     regenerator-runtime "^0.11.1"
 
+"@dhis2/d2-i18n-extract@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n-extract/-/d2-i18n-extract-1.0.7.tgz#805c92c75f5d3678a047374a551bda5f7571d7f3"
+  dependencies:
+    argparse "^1.0.10"
+    i18next-conv "^6.0.0"
+    i18next-scanner "^2.4.4"
+
+"@dhis2/d2-i18n-generate@^1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n-generate/-/d2-i18n-generate-1.0.18.tgz#e3426d381030856232fbe1e2097b8ca2aebe90f3"
+  dependencies:
+    argparse "^1.0.10"
+    handlebars "^4.0.11"
+    i18next-conv "^6.0.0"
+    moment "^2.22.1"
+    rimraf "^2.6.2"
+
+"@dhis2/d2-i18n@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.3.tgz#2d309bc1f6cf85433056f573cbcc410d791415a1"
+  dependencies:
+    i18next "^10.3"
+
 "@dhis2/d2-ui-app@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-app/-/d2-ui-app-1.0.4.tgz#05bba43dfb1ba868f08f9c3010fbba29551f6952"
@@ -306,6 +330,12 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+append-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/append-buffer/-/append-buffer-1.0.2.tgz#d8220cf466081525efea50614f3de6514dfa58f1"
+  dependencies:
+    buffer-equal "^1.0.0"
+
 append-transform@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
@@ -350,7 +380,7 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-argparse@^1.0.7:
+argparse@^1.0.10, argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
@@ -501,6 +531,10 @@ asynckit@^0.4.0:
 atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
+
+author-regex@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-0.2.1.tgz#8bdefaac6065a931799bec07eeef51b940e08f3c"
 
 autoprefixer@7.1.6:
   version "7.1.6"
@@ -1647,6 +1681,10 @@ buffer-crc32@~0.2.1:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
 
+buffer-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
+
 buffer-from@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
@@ -1864,7 +1902,7 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -2032,9 +2070,38 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
+clone-buffer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
+
+clone-deep@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-3.0.1.tgz#7d1a4b88a3cf0bc2da84696ba712b349a6506a44"
+  dependencies:
+    for-own "^1.0.0"
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
+    shallow-clone "^2.0.2"
+
+clone-stats@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-1.0.0.tgz#b3782dff8bb5474e18b9b6bf0fdfe782f8777680"
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+
+clone@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
+
+cloneable-readable@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cloneable-readable/-/cloneable-readable-1.1.2.tgz#d591dee4a8f8bc15da43ce97dceeba13d43e2a65"
+  dependencies:
+    inherits "^2.0.1"
+    process-nextick-args "^2.0.0"
+    readable-stream "^2.3.5"
 
 cmd-shim@^2.0.2, cmd-shim@~2.0.2:
   version "2.0.2"
@@ -2104,9 +2171,17 @@ colors@0.5.x:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
+colors@^1.0.3:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.0.tgz#5f20c9fef6945cb1134260aab33bfbdc8295e04e"
+
 colors@^1.1.2:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.5.tgz#89c7ad9a374bc030df8013241f68136ed8835afc"
+
+colors@~0.6.0-1:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.6.2.tgz#2423fe6678ac0c5dae8852e5d0e5be08c997abcc"
 
 colors@~1.1.2:
   version "1.1.2"
@@ -2125,9 +2200,13 @@ combined-stream@1.0.6, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.15.x, commander@^2.11.0, commander@~2.15.0:
+commander@2.15.x, commander@^2.11.0, commander@^2.13.0, commander@^2.15.1, commander@~2.15.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
+commander@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -2284,6 +2363,14 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     os-homedir "^1.0.1"
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
+
+cosmiconfig@^5.0.2:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
 
 crc32-stream@~0.4.0:
   version "0.4.0"
@@ -2500,6 +2587,17 @@ currently-unhandled@^0.4.1:
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
+
+d2-manifest@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d2-manifest/-/d2-manifest-1.0.0.tgz#19d4a4c4e8151442ab730e932c9c2170be9ebcc9"
+  dependencies:
+    author-regex "^0.2.1"
+    colors "^1.0.3"
+    lodash.isplainobject "^4.0.3"
+    loglevel "^1.4.0"
+    minimist "^1.1.0"
+    readline-sync "^1.4.1"
 
 d2-utilizr@^0.2.15:
   version "0.2.15"
@@ -2905,6 +3003,10 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
+editions@^1.1.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.4.tgz#3662cb592347c3168eb8e498a0ff73271d67f50b"
+
 editor@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/editor/-/editor-1.0.0.tgz#60c7f87bd62bcc6a894fa8ccd6afb7823a24f742"
@@ -2941,7 +3043,7 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
-encoding@^0.1.11:
+encoding@^0.1.11, encoding@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   dependencies:
@@ -2969,6 +3071,10 @@ enhanced-resolve@~0.9.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.2.0"
     tapable "^0.1.8"
+
+ensure-array@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ensure-array/-/ensure-array-1.0.0.tgz#317e9fc632c656bb849eb649133528e205b23abc"
 
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
@@ -3015,6 +3121,10 @@ enzyme@^3.3.0:
     raf "^3.4.0"
     rst-selector-parser "^2.2.3"
 
+eol@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/eol/-/eol-0.9.1.tgz#f701912f504074be35c6117a5c4ade49cd547acd"
+
 err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
@@ -3025,7 +3135,7 @@ errno@^0.1.3, errno@~0.1.7:
   dependencies:
     prr "~1.0.1"
 
-error-ex@^1.2.0:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
@@ -3495,6 +3605,18 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -3796,6 +3918,13 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+findup@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/findup/-/findup-0.1.5.tgz#8ad929a3393bac627957a7e5de4623b06b0e2ceb"
+  dependencies:
+    colors "~0.6.0-1"
+    commander "~2.1.0"
+
 flat-cache@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
@@ -3833,7 +3962,7 @@ flow-typed@^2.4.0:
     which "^1.3.0"
     yargs "^4.2.0"
 
-flush-write-stream@^1.0.0:
+flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.3.tgz#c5d586ef38af6097650b49bc41b55fabb19f35bd"
   dependencies:
@@ -3853,6 +3982,12 @@ for-in@^1.0.1, for-in@^1.0.2:
 for-own@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
+  dependencies:
+    for-in "^1.0.1"
+
+for-own@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
   dependencies:
     for-in "^1.0.1"
 
@@ -3931,6 +4066,13 @@ fs-minipass@^1.2.5:
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
   dependencies:
     minipass "^2.2.1"
+
+fs-mkdirp-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz#0b7815fc3201c6a69e14db98ce098c16935259eb"
+  dependencies:
+    graceful-fs "^4.1.11"
+    through2 "^2.0.3"
 
 fs-vacuum@^1.2.10, fs-vacuum@~1.2.10:
   version "1.2.10"
@@ -4023,6 +4165,10 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -4036,6 +4182,13 @@ getpass@^0.1.1:
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
   dependencies:
     assert-plus "^1.0.0"
+
+gettext-parser@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/gettext-parser/-/gettext-parser-1.3.1.tgz#74b7a99e4b5fa8daab11fa515e8a582480448a12"
+  dependencies:
+    encoding "^0.1.12"
+    safe-buffer "^5.1.1"
 
 gitbook-plugin-github@^2.0.0:
   version "2.0.0"
@@ -4066,6 +4219,21 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
+
+glob-stream@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/glob-stream/-/glob-stream-6.1.0.tgz#7045c99413b3eb94888d83ab46d0b404cc7bdde4"
+  dependencies:
+    extend "^3.0.0"
+    glob "^7.1.1"
+    glob-parent "^3.1.0"
+    is-negated-glob "^1.0.0"
+    ordered-read-streams "^1.0.0"
+    pumpify "^1.3.5"
+    readable-stream "^2.1.5"
+    remove-trailing-separator "^1.0.1"
+    to-absolute-glob "^2.0.0"
+    unique-stream "^2.0.2"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.2:
   version "7.1.2"
@@ -4183,13 +4351,19 @@ got@^7.1.0:
     url-parse-lax "^1.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@~4.1.11:
+graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@~4.1.11:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+
+gulp-sort@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-sort/-/gulp-sort-2.0.0.tgz#c6762a2f1f0de0a3fc595a21599d3fac8dba1aca"
+  dependencies:
+    through2 "^2.0.1"
 
 gzip-size@3.0.0:
   version "3.0.0"
@@ -4201,7 +4375,7 @@ handle-thing@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
 
-handlebars@^4.0.3:
+handlebars@^4.0.11, handlebars@^4.0.3:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
   dependencies:
@@ -4423,7 +4597,7 @@ html-webpack-plugin@^3.2.0:
     toposort "^1.0.0"
     util.promisify "1.0.0"
 
-htmlparser2@^3.9.1:
+htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -4522,9 +4696,59 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+husky@^1.0.0-rc.8:
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.0.0-rc.8.tgz#2fa25d0b89269f5b8bfa1ca001370fdb058e8792"
+  dependencies:
+    cosmiconfig "^5.0.2"
+    execa "^0.9.0"
+    find-up "^2.1.0"
+    get-stdin "^6.0.0"
+    is-ci "^1.1.0"
+    pkg-dir "^2.0.0"
+    pupa "^1.0.0"
+    read-pkg "^3.0.0"
+    run-node "^1.0.0"
+    slash "^2.0.0"
+
 hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
+
+i18next-conv@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/i18next-conv/-/i18next-conv-6.0.1.tgz#d34f5d0378a7a504e4d0e057301129b3047f4ab1"
+  dependencies:
+    bluebird "^3.5.1"
+    chalk "^2.4.1"
+    commander "^2.15.1"
+    gettext-parser "^1.3.1"
+    mkdirp "^0.5.1"
+    node-gettext "^2.0.0"
+
+i18next-scanner@^2.4.4:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/i18next-scanner/-/i18next-scanner-2.5.0.tgz#475f716e241f614f425e243698843572f6bae182"
+  dependencies:
+    chalk "^2.3.0"
+    clone-deep "^3.0.1"
+    commander "^2.13.0"
+    deepmerge "^2.0.1"
+    ensure-array "^1.0.0"
+    eol "^0.9.1"
+    esprima "^4.0.0"
+    gulp-sort "^2.0.0"
+    htmlparser2 "^3.9.2"
+    lodash "^4.0.0"
+    parse5 "^4.0.0"
+    sortobject "^1.1.1"
+    through2 "^2.0.3"
+    vinyl "^2.1.0"
+    vinyl-fs "^3.0.1"
+
+i18next@^10.3:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-10.6.0.tgz#90ffd9f9bc617f34b9a12e037260f524445f7684"
 
 iconv-lite@0.4.19:
   version "0.4.19"
@@ -4708,6 +4932,13 @@ is-absolute@^0.2.3:
     is-relative "^0.2.1"
     is-windows "^0.2.0"
 
+is-absolute@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-1.0.0.tgz#395e1ae84b11f26ad1795e73c17378e48a301576"
+  dependencies:
+    is-relative "^1.0.0"
+    is-windows "^1.0.1"
+
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -4748,7 +4979,7 @@ is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
-is-ci@^1.0.10:
+is-ci@^1.0.10, is-ci@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
   dependencies:
@@ -4810,7 +5041,7 @@ is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
 
-is-extendable@^1.0.1:
+is-extendable@^1.0.0, is-extendable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
   dependencies:
@@ -4872,6 +5103,10 @@ is-installed-globally@^0.1.0:
   dependencies:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
+
+is-negated-glob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-negated-glob/-/is-negated-glob-1.0.0.tgz#6910bca5da8c95e784b5751b976cf5a10fee36d2"
 
 is-npm@^1.0.0:
   version "1.0.0"
@@ -4965,6 +5200,12 @@ is-relative@^0.2.1:
   dependencies:
     is-unc-path "^0.1.1"
 
+is-relative@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-1.0.0.tgz#a1bb6935ce8c5dba1e8b9754b9b2dcc020e2260d"
+  dependencies:
+    is-unc-path "^1.0.0"
+
 is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
@@ -5009,9 +5250,19 @@ is-unc-path@^0.1.1:
   dependencies:
     unc-path-regex "^0.1.0"
 
-is-utf8@^0.2.0:
+is-unc-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-unc-path/-/is-unc-path-1.0.0.tgz#d731e8898ed090a12c352ad2eaed5095ad322c9d"
+  dependencies:
+    unc-path-regex "^0.1.2"
+
+is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-valid-glob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-1.0.0.tgz#29bf3eff701be2d4d315dbacc39bc39fe8f601aa"
 
 is-windows@^0.2.0:
   version "0.2.0"
@@ -5373,6 +5624,13 @@ js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.9.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.9.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -5477,7 +5735,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
-json-stable-stringify@^1.0.1:
+json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
@@ -5669,6 +5927,12 @@ lazy-property@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lazy-property/-/lazy-property-1.0.0.tgz#84ddc4b370679ba8bd4cdcfa4c06b43d57111147"
 
+lazystream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
+  dependencies:
+    readable-stream "^2.0.5"
+
 lazystream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-0.1.0.tgz#1b25d63c772a4c20f0a5ed0a9d77f484b6e16920"
@@ -5680,6 +5944,12 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
+
+lead@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lead/-/lead-1.0.0.tgz#6f14f99a37be3a9dd784f5495690e5903466ee42"
+  dependencies:
+    flush-write-stream "^1.0.2"
 
 leven@^2.1.0:
   version "2.1.0"
@@ -5751,6 +6021,15 @@ load-json-file@^2.0.0:
     graceful-fs "^4.1.2"
     parse-json "^2.2.0"
     pify "^2.0.0"
+    strip-bom "^3.0.0"
+
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
     strip-bom "^3.0.0"
 
 loader-fs-cache@^1.0.0:
@@ -5872,6 +6151,10 @@ lodash.isobject@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
 
+lodash.isplainobject@^4.0.3:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.isset@^4.3.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.isset/-/lodash.isset-4.4.2.tgz#d5eecc56b7a97ab588509e4795b3541b1cdb67bb"
@@ -5921,7 +6204,7 @@ lodash.without@~4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
 
-"lodash@>=3.5 <5", lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -5929,7 +6212,7 @@ lodash@^3.10.1, lodash@~3.10.0, lodash@~3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-loglevel@^1.4.1, loglevel@^1.6.1:
+loglevel@^1.4.0, loglevel@^1.4.1, loglevel@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
@@ -6277,7 +6560,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -6349,6 +6632,13 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+mixin-object@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mixin-object/-/mixin-object-3.0.0.tgz#55091196c9cf744f4c7956fb7021da38c736c440"
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.0"
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -6472,6 +6762,12 @@ node-fetch@^1.0.1:
 node-forge@0.7.5:
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.5.tgz#6c152c345ce11c52f465c2abd957e8639cd674df"
+
+node-gettext@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/node-gettext/-/node-gettext-2.0.0.tgz#f1dc1237cdc546f51593da340304b8beba5b8525"
+  dependencies:
+    lodash.get "^4.4.2"
 
 node-gyp@^3.6.2:
   version "3.6.2"
@@ -6602,6 +6898,12 @@ normalize-url@^1.4.0:
     prepend-http "^1.0.0"
     query-string "^4.1.0"
     sort-keys "^1.0.0"
+
+now-and-later@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/now-and-later/-/now-and-later-2.0.0.tgz#bc61cbb456d79cb32207ce47ca05136ff2e7d6ee"
+  dependencies:
+    once "^1.3.2"
 
 npm-audit-report@^1.0.8:
   version "1.1.0"
@@ -6961,7 +7263,7 @@ on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
-once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0, once@~1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.3.3, once@^1.4.0, once@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
@@ -7006,6 +7308,12 @@ optionator@^0.8.1, optionator@^0.8.2:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     wordwrap "~1.0.0"
+
+ordered-read-streams@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz#77c0cb37c41525d64166d990ffad7ec6a0e1363e"
+  dependencies:
+    readable-stream "^2.0.1"
 
 original@>=0.0.5:
   version "1.0.0"
@@ -7190,6 +7498,13 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -7203,6 +7518,10 @@ parse5@^3.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
   dependencies:
     "@types/node" "*"
+
+parse5@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
 
 parseurl@~1.3.2:
   version "1.3.2"
@@ -7269,6 +7588,12 @@ path-type@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
     pify "^2.0.0"
+
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  dependencies:
+    pify "^3.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.16"
@@ -7564,6 +7889,12 @@ postcss-reduce-transforms@^1.0.3:
     postcss "^5.0.8"
     postcss-value-parser "^3.0.1"
 
+postcss-rtl@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-rtl/-/postcss-rtl-1.2.3.tgz#69e7691d2b4f13ee70ce994d6ade90357889b48e"
+  dependencies:
+    rtlcss "^2.2.1"
+
 postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90"
@@ -7610,7 +7941,7 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.13:
+postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.13, postcss@^6.0.14:
   version "6.0.22"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
   dependencies:
@@ -7652,13 +7983,13 @@ private@^0.1.6, private@^0.1.7, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
+process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
-
-process-nextick-args@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
 process@^0.11.10:
   version "0.11.10"
@@ -7773,6 +8104,14 @@ pumpify@^1.3.3:
     inherits "^2.0.3"
     pump "^2.0.0"
 
+pumpify@^1.3.5:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/pumpify/-/pumpify-1.5.1.tgz#36513be246ab27570b1a374a5ce278bfd74370ce"
+  dependencies:
+    duplexify "^3.6.0"
+    inherits "^2.0.3"
+    pump "^2.0.0"
+
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
@@ -7784,6 +8123,10 @@ punycode@^1.2.4, punycode@^1.4.1:
 punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
+
+pupa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pupa/-/pupa-1.0.0.tgz#9a9568a5af7e657b8462a6e9d5328743560ceff6"
 
 q@^1.1.2:
   version "1.5.1"
@@ -8229,13 +8572,21 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
+
 read@1, read@~1.0.1, read@~1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -8305,6 +8656,10 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
+
+readline-sync@^1.4.1:
+  version "1.4.9"
+  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.9.tgz#3eda8e65f23cd2a17e61301b1f0003396af5ecda"
 
 realistic-structured-clone@^2.0.1:
   version "2.0.2"
@@ -8492,6 +8847,21 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
+remove-bom-buffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz#c2bf1e377520d324f623892e33c10cac2c252b53"
+  dependencies:
+    is-buffer "^1.1.5"
+    is-utf8 "^0.2.1"
+
+remove-bom-stream@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz#05f1a593f16e42e1fb90ebf59de8e569525f9523"
+  dependencies:
+    remove-bom-buffer "^3.0.0"
+    safe-buffer "^5.1.0"
+    through2 "^2.0.3"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -8519,6 +8889,10 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
+
+replace-ext@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
 request@2, request@^2.74.0, request@^2.79.0, request@^2.85.0:
   version "2.85.0"
@@ -8605,6 +8979,12 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
 
+resolve-options@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/resolve-options/-/resolve-options-1.1.0.tgz#32bb9e39c06d67338dc9378c0d6d6074566ad131"
+  dependencies:
+    value-or-function "^3.0.0"
+
 resolve-pathname@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
@@ -8674,11 +9054,25 @@ rst-selector-parser@^2.2.3:
     lodash.flattendeep "^4.4.0"
     nearley "^2.7.10"
 
+rtlcss@^2.2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/rtlcss/-/rtlcss-2.3.0.tgz#9fffed884f94717b75b3ccffc22ab6044f430c5a"
+  dependencies:
+    chalk "^2.3.0"
+    findup "^0.1.5"
+    mkdirp "^0.5.1"
+    postcss "^6.0.14"
+    strip-json-comments "^2.0.0"
+
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
     is-promise "^2.1.0"
+
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -8867,6 +9261,14 @@ sha@~2.0.1:
     graceful-fs "^4.1.2"
     readable-stream "^2.0.2"
 
+shallow-clone@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-2.0.2.tgz#7f6e9cf3b64e37d5f4afb0f648a0204da556b872"
+  dependencies:
+    is-extendable "^1.0.1"
+    kind-of "^6.0.2"
+    mixin-object "^3.0.0"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -8909,6 +9311,10 @@ simple-assign@^0.1.0:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
 
 slice-ansi@1.0.0:
   version "1.0.0"
@@ -9023,6 +9429,12 @@ sorted-union-stream@~2.1.3:
   dependencies:
     from2 "^1.3.0"
     stream-iterate "^1.1.0"
+
+sortobject@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sortobject/-/sortobject-1.1.1.tgz#4f695d4d44ed0a4c06482c34c2582a2dcdc2ab34"
+  dependencies:
+    editions "^1.1.1"
 
 source-list-map@^2.0.0:
   version "2.0.0"
@@ -9270,7 +9682,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1, strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -9461,7 +9873,14 @@ throat@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
 
-through2@^2.0.0:
+through2-filter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/through2-filter/-/through2-filter-2.0.0.tgz#60bc55a0dacb76085db1f9dae99ab43f83d622ec"
+  dependencies:
+    through2 "~2.0.0"
+    xtend "~4.0.0"
+
+through2@^2.0.0, through2@^2.0.1, through2@^2.0.3, through2@~2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:
@@ -9504,6 +9923,13 @@ tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
 
+to-absolute-glob@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz#1865f43d9e74b0822db9f145b78cff7d0f7c849b"
+  dependencies:
+    is-absolute "^1.0.0"
+    is-negated-glob "^1.0.0"
+
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
@@ -9533,6 +9959,12 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+to-through@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-through/-/to-through-2.0.0.tgz#fc92adaba072647bc0b67d6b03664aa195093af6"
+  dependencies:
+    through2 "^2.0.3"
 
 toposort@^1.0.0:
   version "1.0.7"
@@ -9654,7 +10086,7 @@ umask@^1.1.0, umask@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
 
-unc-path-regex@^0.1.0:
+unc-path-regex@^0.1.0, unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
 
@@ -9710,6 +10142,13 @@ unique-slug@^2.0.0:
   resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.0.tgz#db6676e7c7cc0629878ff196097c78855ae9f4ab"
   dependencies:
     imurmurhash "^0.1.4"
+
+unique-stream@^2.0.2:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/unique-stream/-/unique-stream-2.2.1.tgz#5aa003cfbe94c5ff866c4e7d668bb1c4dbadb369"
+  dependencies:
+    json-stable-stringify "^1.0.0"
+    through2-filter "^2.0.0"
 
 unique-string@^1.0.0:
   version "1.0.0"
@@ -9890,6 +10329,10 @@ value-equal@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
 
+value-or-function@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/value-or-function/-/value-or-function-3.0.0.tgz#1c243a50b595c1be54a754bfece8563b9ff8d813"
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -9905,6 +10348,51 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vinyl-fs@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vinyl-fs/-/vinyl-fs-3.0.3.tgz#c85849405f67428feabbbd5c5dbdd64f47d31bc7"
+  dependencies:
+    fs-mkdirp-stream "^1.0.0"
+    glob-stream "^6.1.0"
+    graceful-fs "^4.0.0"
+    is-valid-glob "^1.0.0"
+    lazystream "^1.0.0"
+    lead "^1.0.0"
+    object.assign "^4.0.4"
+    pumpify "^1.3.5"
+    readable-stream "^2.3.3"
+    remove-bom-buffer "^3.0.0"
+    remove-bom-stream "^1.2.0"
+    resolve-options "^1.1.0"
+    through2 "^2.0.0"
+    to-through "^2.0.0"
+    value-or-function "^3.0.0"
+    vinyl "^2.0.0"
+    vinyl-sourcemap "^1.1.0"
+
+vinyl-sourcemap@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz#92a800593a38703a8cdb11d8b300ad4be63b3e16"
+  dependencies:
+    append-buffer "^1.0.2"
+    convert-source-map "^1.5.0"
+    graceful-fs "^4.1.6"
+    normalize-path "^2.1.1"
+    now-and-later "^2.0.0"
+    remove-bom-buffer "^3.0.0"
+    vinyl "^2.0.0"
+
+vinyl@^2.0.0, vinyl@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/vinyl/-/vinyl-2.1.0.tgz#021f9c2cf951d6b939943c89eb5ee5add4fd924c"
+  dependencies:
+    clone "^2.1.1"
+    clone-buffer "^1.0.0"
+    clone-stats "^1.0.0"
+    cloneable-readable "^1.0.0"
+    remove-trailing-separator "^1.0.1"
+    replace-ext "^1.0.0"
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -10172,7 +10660,7 @@ xmlcreate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-1.0.2.tgz#fa6bf762a60a413fb3dd8f4b03c5b269238d308f"
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
This PR adds integration to `d2-i18n` and migrates all localised strings already in the application to the new format.

Some strings, like the messages from `@dhis2/d2-ui-forms` depends on that library integrating d2-i18n and emitting translated strings to display. Not exactly sure how that's going to work right now.