### PR TITLE
Allow D2 to initialize before setting up the Redux Store

### DIFF
--- a/src/init/entry.js
+++ b/src/init/entry.js
@@ -23,7 +23,7 @@ import { startupDataLoad } from './entry.actions';
 
 const DOM_ID = 'app';
 
-async function runApp(domElement: HTMLElement, store: ReduxStore, history: HashHistory) {
+async function runApp(domElement: HTMLElement) {
     render(
         <D2UIApp>
             <LoadingMask />
@@ -33,6 +33,10 @@ async function runApp(domElement: HTMLElement, store: ReduxStore, history: HashH
 
     try {
         await initialize();
+
+        const history = createHistory();
+        const store = getStore(history);
+
         store.dispatch(startupDataLoad());
 
         // START TEST
@@ -63,7 +67,5 @@ const domElement = document.getElementById(DOM_ID);
 if (!domElement) {
     log.error(`html element with id ${DOM_ID} is missing in index file`);
 } else {
-    const history = createHistory();
-    const store = getStore(history);
-    runApp(domElement, store, history);
+    runApp(domElement);
 }


### PR DESCRIPTION
When hydrating the persisted state, e.g. in the situation where:

    1. User inputs events offline
    2. User closes tab with capture app
    3. User re-opens capture app

We have the state persisted, and as soon as the Store is initialised
redux-offline will try to run the events in the outbox to sync them. At
this point D2 *has* to be available or the App will crash.

The `initialize` function does not depend on any state so it can be run
before the `getStore` functions. We still get the loader while d2 loads.