### PR TITLE
fix: DHIS2-7348 switches the order of long and lat when adding a new Event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ npm-debug.log
 # generated localization files
 src/locales/
 public/manifest.webapp
+
+.idea

--- a/src/core_modules/capture-ui/CoordinateField/CoordinateField.component.js
+++ b/src/core_modules/capture-ui/CoordinateField/CoordinateField.component.js
@@ -259,10 +259,10 @@ export default class D2Coordinate extends React.Component<Props, State> {
                         {this.renderClearButton()}
                     </div>
                     <div className={defaultClasses.inputContainer}>
-                        {this.renderLatitude()}
+                        {this.renderLongitude()}
                     </div>
                     <div className={defaultClasses.inputContainer}>
-                        {this.renderLongitude()}
+                        {this.renderLatitude()}
                     </div>
                 </div>
             </div>
@@ -276,10 +276,10 @@ export default class D2Coordinate extends React.Component<Props, State> {
                     {this.renderMapDialog()}
                     {this.renderMapIcon()}
                     <div className={defaultClasses.inputContainer}>
-                        {this.renderLatitude()}
+                        {this.renderLongitude()}
                     </div>
                     <div className={defaultClasses.inputContainer}>
-                        {this.renderLongitude()}
+                        {this.renderLatitude()}
                     </div>
                     {this.renderClearButton()}
                 </div>


### PR DESCRIPTION
closes: https://jira.dhis2.org/browse/DHIS2-7348

@JoakimSM 👋 

As the ticket describes and you very well know already I have changed the order that long and lat is being displayed in the new event page. This way the metadata regarding long and lat on the new event page are in the same order as in the table where it's been displayed. 

Have a look when you got the time

A visual representation:
![image](https://user-images.githubusercontent.com/4181674/78658894-138e2b80-78cb-11ea-8d7c-db9a61c99902.png)

PS. Webstorm generates some files that dont need to be added in the code base therefore its been ignored.