### PR TITLE
fix: husky pre-commit the translations files

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn extract-pot && git add -A ."
+      "pre-commit": "yarn extract-pot && git add ./i18n/"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
@JoakimSM as we talked this morning in this PR I am changing the pre-commit command that comes with husky to commit only i18n related files. 

Let me know what you think!