### PR TITLE
fix: sanitises the long and lat value to be a six decimal

### DIFF
--- a/src/core_modules/capture-ui/CoordinateField/CoordinateField.component.js
+++ b/src/core_modules/capture-ui/CoordinateField/CoordinateField.component.js
@@ -56,7 +56,7 @@ export default class D2Coordinate extends React.Component<Props, State> {
         };
     }
 
-    toSixDecimal = value => parseFloat(value).toFixed(6)
+    toSixDecimal = value => parseFloat(value) && parseFloat(value).toFixed(6)
 
     handleBlur = (key: string, value: any) => {
         const newValue = { ...this.props.value, [key]: this.toSixDecimal(value) };

--- a/src/core_modules/capture-ui/CoordinateField/CoordinateField.component.js
+++ b/src/core_modules/capture-ui/CoordinateField/CoordinateField.component.js
@@ -56,7 +56,7 @@ export default class D2Coordinate extends React.Component<Props, State> {
         };
     }
 
-    toSixDecimal = value => parseFloat(value) && parseFloat(value).toFixed(6)
+    toSixDecimal = (value: string) => (parseFloat(value) ? parseFloat(value).toFixed(6) : null)
 
     handleBlur = (key: string, value: any) => {
         const newValue = { ...this.props.value, [key]: this.toSixDecimal(value) };

--- a/src/core_modules/capture-ui/CoordinateField/CoordinateField.component.js
+++ b/src/core_modules/capture-ui/CoordinateField/CoordinateField.component.js
@@ -56,8 +56,10 @@ export default class D2Coordinate extends React.Component<Props, State> {
         };
     }
 
+    toSixDecimal = value => parseFloat(value).toFixed(6)
+
     handleBlur = (key: string, value: any) => {
-        const newValue = { ...this.props.value, [key]: value };
+        const newValue = { ...this.props.value, [key]: this.toSixDecimal(value) };
         if (!newValue.latitude && !newValue.longitude) {
             this.props.onBlur(null);
             return;

--- a/src/core_modules/capture-ui/CoordinateField/CoordinateField.component.js
+++ b/src/core_modules/capture-ui/CoordinateField/CoordinateField.component.js
@@ -93,8 +93,8 @@ export default class D2Coordinate extends React.Component<Props, State> {
     }
 
     onMapPositionChange = (mapCoordinates: any) => {
-        const latlng = mapCoordinates.latlng;
-        this.setMapPosition([latlng.lat, latlng.lng], mapCoordinates.target.getZoom());
+        const { lat, lng } = mapCoordinates.latlng;
+        this.setMapPosition([this.toSixDecimal(lat), this.toSixDecimal(lng)], mapCoordinates.target.getZoom());
     }
 
     setMapPosition = (position: Array<any>, zoom: number) => {


### PR DESCRIPTION
Hey @JoakimSM  👋 👋 

As we talked and after your suggestions which were very helpful I am opening this PR which addresses the https://jira.dhis2.org/browse/DHIS2-7300. 

We are dealing with two cases here as you already know. 
* The first case where the user opens the map and drops a pin on the map. When the user closes the map then the `lat` and `long` will be put in the input form. In this case we sanitise the values on the `onMapPositionChange `
* The second case is when the user adds the value manually in the input. Here we sanitise the value on the blur event of the input. This way the user can type as much decimals as they like and when they "leave" the input then the value gets sanitised to 6 decimals. 


Let me know your thoughts or suggestions!! 
