### PR TITLE
chore: adds configuration for dependabot from application-platform

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,16 @@
+version: 1
+
+update_configs:
+  - package_manager: 'javascript'
+    directory: '/'
+    update_schedule: 'daily'
+    version_requirement_updates: 'increase_versions'
+    target_branch: 'master'
+    automerged_updates:
+      - match:
+          dependency_name: '@dhis2/*'
+          dependency_type: 'all'
+          update_type: 'semver:minor'
+      - match:
+          dependency_type: 'all'
+          update_type: 'security:patch'


### PR DESCRIPTION
Hey @JoakimSM  👋 Please have a look at those rules when you find the time 😃.

Are copied from the [`data-visualiser-app`](https://github.com/dhis2/data-visualizer-app/blob/master/.dependabot/config.yml) and  are the default ones that the [`app-platform`](https://github.com/dhis2/data-visualizer-app/blob/master/.dependabot/config.yml) would generate when you execute [`init`](https://platform.dhis2.nu/#/scripts/init) script.

closes: https://jira.dhis2.org/browse/TECH-349

Please let me know your thoughts! 


