### PR TITLE
fix: DHIS2-8612 moment locale using non european glyphs fix

### DIFF
--- a/src/core_modules/capture-core/src/components/FiltersForTypes/Date/DateFilter.component.js
+++ b/src/core_modules/capture-core/src/components/FiltersForTypes/Date/DateFilter.component.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from '../../../utils/date';
 import SelectBoxes from '../../FormFields/Options/SingleSelectBoxes/SingleSelectBoxes.component';
 import { orientations } from '../../FormFields/Options/SingleSelectBoxes/singleSelectBoxes.const';
 import OptionSet from '../../../metaData/OptionSet/OptionSet';
@@ -115,7 +116,7 @@ class DateFilter extends Component<Props, State> implements UpdatableFilterConte
     ]);
 
     static formatDateForFilterRequest(dateMoment: moment$Moment) {
-        return dateMoment.format('YYYY-MM-DD');
+        return getFormattedStringFromMomentUsingEuropeanGlyphs(dateMoment, 'YYYY-MM-DD');
     }
 
     static convertDateFilterValueToClientValue(formValue: string): string {

--- a/src/core_modules/capture-core/src/components/Pages/EditEvent/DataEntry/epics/saveEditSingleEvent.epics.js
+++ b/src/core_modules/capture-core/src/components/Pages/EditEvent/DataEntry/epics/saveEditSingleEvent.epics.js
@@ -1,6 +1,7 @@
 // @flow
 import { push } from 'react-router-redux';
 import moment from '../../../../../utils/moment/momentResolver';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from '../../../../../utils/date';
 import {
     actionTypes as editEventDataEntryActionTypes,
     startSaveEditEventAfterReturnedToMainPage,
@@ -39,7 +40,7 @@ export const saveEditEventEpic = (action$: InputObservable, store: ReduxStore) =
             const mainDataServerValues: Object = convertMainEventClientToServerWithKeysMap(mainDataClientValues);
 
             if (mainDataServerValues.status === 'COMPLETED' && !prevEventMainData.completedDate) {
-                mainDataServerValues.completedDate = moment().format('YYYY-MM-DD');
+                mainDataServerValues.completedDate = getFormattedStringFromMomentUsingEuropeanGlyphs(moment(), 'YYYY-MM-DD');
             }
 
             const serverData = {

--- a/src/core_modules/capture-core/src/components/Pages/NewEvent/DataEntry/epics/getConvertedNewSingleEvent.js
+++ b/src/core_modules/capture-core/src/components/Pages/NewEvent/DataEntry/epics/getConvertedNewSingleEvent.js
@@ -1,5 +1,6 @@
 // @flow
 import moment from '../../../../../utils/moment/momentResolver';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from '../../../../../utils/date';
 import convertDataEntryToClientValues from '../../../../DataEntry/common/convertDataEntryToClientValues';
 import { convertValue as convertToServerValue } from '../../../../../converters/clientToServer';
 import { convertMainEventClientToServerWithKeysMap } from '../../../../../events/mainEventConverter';
@@ -24,7 +25,7 @@ export const getNewEventServerData = (state: ReduxState, formFoundation: RenderF
     const mainDataServerValues: Object = convertMainEventClientToServerWithKeysMap(mainDataClientValues);
 
     if (mainDataServerValues.status === 'COMPLETED') {
-        mainDataServerValues.completedDate = moment().format('YYYY-MM-DD');
+        mainDataServerValues.completedDate = getFormattedStringFromMomentUsingEuropeanGlyphs(moment(), 'YYYY-MM-DD');
     }
 
     return {

--- a/src/core_modules/capture-core/src/components/Pages/NewRelationship/RegisterTei/exposedHelpers/getRelationshipNewTei.js
+++ b/src/core_modules/capture-core/src/components/Pages/NewRelationship/RegisterTei/exposedHelpers/getRelationshipNewTei.js
@@ -1,6 +1,7 @@
 // @flow
 import uuid from 'd2-utilizr/src/uuid';
 import moment from '../../../../../utils/moment/momentResolver';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from '../../../../../utils/date';
 import {
     getTrackerProgramThrowIfNotFound,
     getTrackedEntityTypeThrowIfNotFound,
@@ -103,7 +104,7 @@ export default function getRelationshipNewTei(dataEntryId: string, itemId: strin
         program: programId,
         status: 'ACTIVE',
         orgUnit: orgUnit.id,
-        incidentDate: moment().format('YYYY-MM-DD'),
+        incidentDate: getFormattedStringFromMomentUsingEuropeanGlyphs(moment(), 'YYYY-MM-DD'),
         ...serverValuesForMainValues,
     } : null;
 

--- a/src/core_modules/capture-core/src/components/Pages/ViewEvent/EventDetailsSection/EditEventDataEntry/editEventDataEntry.epics.js
+++ b/src/core_modules/capture-core/src/components/Pages/ViewEvent/EventDetailsSection/EditEventDataEntry/editEventDataEntry.epics.js
@@ -1,6 +1,7 @@
 // @flow
 import { ActionsObservable } from 'redux-observable';
 import { batchActions } from 'redux-batched-actions';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from '../../../../../utils/date';
 import { convertValue as convertToServerValue } from '../../../../../converters/clientToServer';
 import { getProgramAndStageFromEvent } from '../../../../../metaData';
 import { openEventForEditInDataEntry } from '../../../EditEvent/DataEntry/editEventDataEntry.actions';
@@ -74,7 +75,7 @@ export const saveEditedEventEpic = (action$: InputObservable, store: ReduxStore)
             const mainDataServerValues: Object = convertMainEventClientToServerWithKeysMap(mainDataClientValues);
 
             if (mainDataServerValues.status === 'COMPLETED' && !prevEventMainData.completedDate) {
-                mainDataServerValues.completedDate = moment().format('YYYY-MM-DD');
+                mainDataServerValues.completedDate = getFormattedStringFromMomentUsingEuropeanGlyphs(moment(), 'YYYY-MM-DD');
             }
 
             const prevEventContainer = state.viewEventPage.eventContainer;

--- a/src/core_modules/capture-core/src/rulesEngineActionsCreator/converters/momentConverter.js
+++ b/src/core_modules/capture-core/src/rulesEngineActionsCreator/converters/momentConverter.js
@@ -1,7 +1,8 @@
 // @flow
 /* eslint-disable class-methods-use-this */
 import moment from 'moment';
-import type { IMomentConverter } from '../RulesEngine/rulesEngine.types';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from '../../utils/date';
+import type { IMomentConverter } from 'capture-core-utils/RulesEngine/rulesEngine.types';
 
 const momentFormat = 'YYYY-MM-DD';
 
@@ -10,7 +11,7 @@ class RulesMomentConverter implements IMomentConverter {
         return moment(rulesEngineValue, momentFormat);
     }
     momentToRulesDate(momentObject: moment$Moment): string {
-        return momentObject.format(momentFormat);
+        return getFormattedStringFromMomentUsingEuropeanGlyphs(momentObject, momentFormat);
     }
 }
 

--- a/src/core_modules/capture-core/src/utils/date/date.utils.js
+++ b/src/core_modules/capture-core/src/utils/date/date.utils.js
@@ -7,10 +7,18 @@ export const displayTypes = {
     LONG: 'long',
 };
 
-export function getMonthName(monthNumber: number) {
-    const date = moment([0, monthNumber - 1]);
-    return date.format('MMMM');
+/**
+ * Some locales are using numeral glyphs other than european. This method ensures the moment format method returns a value in european glyphs
+ * @param {*} momentDate: the moment instance
+ * @param {string} format: the moment format
+ * @returns {string} A formatted string with european glyphs
+ */
+export function getFormattedStringFromMomentUsingEuropeanGlyphs(momentDate: moment$Moment, format: string) {
+    const europeanMoment = momentDate.clone();
+    europeanMoment.locale('en');
+    return europeanMoment.format(format);
 }
+
 
 export function adjustUtcIsoDateToLocal(utcISO8601: string) {
     const localDate = moment(utcISO8601, 'YYYY-MM-DD');
@@ -67,8 +75,3 @@ export const displayTime = (() => {
         return date.format((displayType && typeToMomentConverter[displayType]) || typeToMomentConverter[displayTypes.MEDIUM]);
     };
 })();
-
-export const RulesEngineDateUtils = {
-    format: (IsoString: string) => moment(IsoString).format('L'),
-    getToday: () => moment().format('L'),
-};

--- a/src/core_modules/capture-core/src/utils/date/index.js
+++ b/src/core_modules/capture-core/src/utils/date/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { getFormattedStringFromMomentUsingEuropeanGlyphs } from './date.utils';

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -33,6 +33,7 @@ import ukTranslations from './uk/translations.json';
 import urTranslations from './ur/translations.json';
 import viTranslations from './vi/translations.json';
 import zhTranslations from './zh/translations.json';
+import zh_CNTranslations from './zh_CN/translations.json';
 
 const namespace = 'NAMESPACE';
 moment.locale('en');
@@ -51,6 +52,7 @@ i18n.addResources('uk', namespace, ukTranslations);
 i18n.addResources('ur', namespace, urTranslations);
 i18n.addResources('vi', namespace, viTranslations);
 i18n.addResources('zh', namespace, zhTranslations);
+i18n.addResources('zh_CN', namespace, zh_CNTranslations);
 
 i18n.setDefaultNamespace(namespace);
 i18n.changeLanguage('en');


### PR DESCRIPTION
Resolved some issues caused by using a moment locale with non european glyphs.
- Saving an event when the event was marked for completion caused the post request to fail due to the complete date being posted using non european glyphs.
- Filtering a view using a date field caused the filtering to fail.
- Program rules would interpret dates wrong.