### PR TITLE
fix: DHIS2-8612 moment locale using non european glyphs fix

### DIFF
--- a/src/core_modules/capture-core-utils/date/date.utils.js
+++ b/src/core_modules/capture-core-utils/date/date.utils.js
@@ -1,74 +1,15 @@
 // @flow
-import moment from '../moment/momentResolver';
 
-export const displayTypes = {
-    SHORT: 'short',
-    MEDIUM: 'medium',
-    LONG: 'long',
-};
-
-export function getMonthName(monthNumber: number) {
-    const date = moment([0, monthNumber - 1]);
-    return date.format('MMMM');
+/**
+ * Some locales are using numeral glyphs other than european. This method ensures the moment format method returns a value in european glyphs
+ * @param {*} momentDate: the moment instance
+ * @param {string} format: the moment format
+ * @returns {string} A formatted string with european glyphs
+ */
+export function getFormattedStringFromMomentUsingEuropeanGlyphs(
+    momentDate: moment$Moment,
+    format: string = 'YYYY-MM-DD',
+) {
+    const europeanMoment = momentDate.clone().locale('en');
+    return europeanMoment.format(format);
 }
-
-export function adjustUtcIsoDateToLocal(utcISO8601: string) {
-    const localDate = moment(utcISO8601, 'YYYY-MM-DD');
-    const isoString = localDate.toISOString();
-    return isoString;
-}
-
-export function adjustLocalMomentDateToUtc(momentDateLocal: any) {
-    const momentDateUTC = moment(Date.UTC(momentDateLocal.year(), momentDateLocal.month(), momentDateLocal.date()));
-    return momentDateUTC;
-}
-
-export function adjustLocalIsoDateToUtc(localISO8601: string) {
-    const momentLocale = moment(localISO8601);
-    const momentUtc = adjustLocalMomentDateToUtc(momentLocale);
-    return momentUtc.toISOString();
-}
-
-export const displayDate = (() => {
-    const typeToMomentConverter = {
-        [displayTypes.SHORT]: 'l',
-        [displayTypes.MEDIUM]: 'L',
-        [displayTypes.LONG]: 'LL',
-    };
-
-    return (ISOString: string | Date, displayType?: ?$Values<typeof displayTypes>) => {
-        const date = moment(ISOString);
-        return date.format((displayType && typeToMomentConverter[displayType]) || typeToMomentConverter[displayTypes.MEDIUM]);
-    };
-})();
-
-export const displayDateTime = (() => {
-    const typeToMomentConverter = {
-        [displayTypes.SHORT]: 'LLL',
-        [displayTypes.MEDIUM]: 'llll',
-        [displayTypes.LONG]: 'LLLL',
-    };
-
-    return (ISOString: string | Date, displayType?: ?$Values<typeof displayTypes>) => {
-        const date = moment(ISOString);
-        return date.format((displayType && typeToMomentConverter[displayType]) || typeToMomentConverter[displayTypes.MEDIUM]);
-    };
-})();
-
-export const displayTime = (() => {
-    const typeToMomentConverter = {
-        [displayTypes.SHORT]: 'LT',
-        [displayTypes.MEDIUM]: 'LTS',
-        [displayTypes.LONG]: 'LTS',
-    };
-
-    return (ISOString: string | Date, displayType?: ?$Values<typeof displayTypes>) => {
-        const date = moment(ISOString);
-        return date.format((displayType && typeToMomentConverter[displayType]) || typeToMomentConverter[displayTypes.MEDIUM]);
-    };
-})();
-
-export const RulesEngineDateUtils = {
-    format: (IsoString: string) => moment(IsoString).format('L'),
-    getToday: () => moment().format('L'),
-};

--- a/src/core_modules/capture-core-utils/date/index.js
+++ b/src/core_modules/capture-core-utils/date/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { getFormattedStringFromMomentUsingEuropeanGlyphs } from './date.utils';

--- a/src/core_modules/capture-core/components/Pages/EditEvent/DataEntry/epics/saveEditSingleEvent.epics.js
+++ b/src/core_modules/capture-core/components/Pages/EditEvent/DataEntry/epics/saveEditSingleEvent.epics.js
@@ -1,6 +1,7 @@
 // @flow
 import { push } from 'connected-react-router';
-import moment from 'capture-core-utils/moment/momentResolver';
+import { moment } from 'capture-core-utils/moment';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from 'capture-core-utils/date';
 import {
     actionTypes as editEventDataEntryActionTypes,
     startSaveEditEventAfterReturnedToMainPage,
@@ -39,7 +40,7 @@ export const saveEditEventEpic = (action$: InputObservable, store: ReduxStore) =
             const mainDataServerValues: Object = convertMainEventClientToServer(mainDataClientValues);
 
             if (mainDataServerValues.status === 'COMPLETED' && !prevEventMainData.completedDate) {
-                mainDataServerValues.completedDate = moment().format('YYYY-MM-DD');
+                mainDataServerValues.completedDate = getFormattedStringFromMomentUsingEuropeanGlyphs(moment());
             }
 
             const serverData = {

--- a/src/core_modules/capture-core/components/Pages/MainPage/WorkingLists/epics/eventsQueryArgsBuilder/filterConverters/dateConverter.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/WorkingLists/epics/eventsQueryArgsBuilder/filterConverters/dateConverter.js
@@ -1,11 +1,13 @@
 // @flow
 import { createSelector } from 'reselect';
 import { moment } from 'capture-core-utils/moment';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from 'capture-core-utils/date';
+
 import type {
     DateFilterData,
     RelativeDateFilterData,
     AbsoluteDateFilterData,
-} from '../../../eventList.types';
+} from '../../../../EventsList/eventList.types';
 
 const periods = {
     TODAY: 'TODAY',
@@ -19,15 +21,14 @@ const periods = {
 };
 
 const selectors = {};
-const formatDateForFilterRequest = (dateMoment: moment$Moment) => dateMoment.format('YYYY-MM-DD');
 const relativeConvertersForPeriods = {
     [periods.TODAY]: () => {
         const startDate = moment();
         const endDate = startDate;
 
         return [
-            `ge:${formatDateForFilterRequest(startDate)}`,
-            `le:${formatDateForFilterRequest(endDate)}`,
+            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
+            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
         ];
     },
     [periods.THIS_WEEK]: () => {
@@ -35,8 +36,8 @@ const relativeConvertersForPeriods = {
         const endDate = moment().endOf('week');
 
         return [
-            `ge:${formatDateForFilterRequest(startDate)}`,
-            `le:${formatDateForFilterRequest(endDate)}`,
+            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
+            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
         ];
     },
     [periods.THIS_MONTH]: () => {
@@ -44,8 +45,8 @@ const relativeConvertersForPeriods = {
         const endDate = moment().endOf('month');
 
         return [
-            `ge:${formatDateForFilterRequest(startDate)}`,
-            `le:${formatDateForFilterRequest(endDate)}`,
+            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
+            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
         ];
     },
     [periods.THIS_YEAR]: () => {
@@ -53,8 +54,8 @@ const relativeConvertersForPeriods = {
         const endDate = moment().endOf('year');
 
         return [
-            `ge:${formatDateForFilterRequest(startDate)}`,
-            `le:${formatDateForFilterRequest(endDate)}`,
+            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
+            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
         ];
     },
     [periods.LAST_WEEK]: () => {
@@ -62,8 +63,8 @@ const relativeConvertersForPeriods = {
         const endDate = moment().subtract(1, 'weeks').endOf('week');
 
         return [
-            `ge:${formatDateForFilterRequest(startDate)}`,
-            `le:${formatDateForFilterRequest(endDate)}`,
+            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
+            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
         ];
     },
     [periods.LAST_MONTH]: () => {
@@ -71,8 +72,8 @@ const relativeConvertersForPeriods = {
         const endDate = moment().subtract(1, 'months').endOf('month');
 
         return [
-            `ge:${formatDateForFilterRequest(startDate)}`,
-            `le:${formatDateForFilterRequest(endDate)}`,
+            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
+            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
         ];
     },
     [periods.LAST_3_MONTHS]: () => {
@@ -80,8 +81,8 @@ const relativeConvertersForPeriods = {
         const endDate = moment().subtract(1, 'months').endOf('month');
 
         return [
-            `ge:${formatDateForFilterRequest(startDate)}`,
-            `le:${formatDateForFilterRequest(endDate)}`,
+            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
+            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
         ];
     },
 };
@@ -117,12 +118,12 @@ function convertRelativeDate(
 function convertAbsoluteDate(sourceValue: AbsoluteDateFilterData) {
     const requestData = [];
     if (sourceValue.ge) {
-        const fromFilterRequest = formatDateForFilterRequest(moment(sourceValue.ge));
+        const fromFilterRequest = getFormattedStringFromMomentUsingEuropeanGlyphs(moment(sourceValue.ge));
         requestData.push(`ge:${fromFilterRequest}`);
     }
 
     if (sourceValue.le) {
-        const toFilterRequest = formatDateForFilterRequest(moment(sourceValue.le));
+        const toFilterRequest = getFormattedStringFromMomentUsingEuropeanGlyphs(moment(sourceValue.le));
         requestData.push(`le:${toFilterRequest}`);
     }
     return requestData;

--- a/src/core_modules/capture-core/components/Pages/NewEvent/DataEntry/epics/getConvertedNewSingleEvent.js
+++ b/src/core_modules/capture-core/components/Pages/NewEvent/DataEntry/epics/getConvertedNewSingleEvent.js
@@ -1,9 +1,10 @@
 // @flow
-import moment from 'capture-core-utils/moment/momentResolver';
+import { moment } from 'capture-core-utils/moment';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from 'capture-core-utils/date';
 import convertDataEntryToClientValues from '../../../../DataEntry/common/convertDataEntryToClientValues';
 import { convertValue as convertToServerValue } from '../../../../../converters/clientToServer';
 import { convertMainEventClientToServer } from '../../../../../events/mainConverters';
-import RenderFoundation from '../../../../../metaData/RenderFoundation/RenderFoundation';
+import { RenderFoundation } from '../../../../../metaData';
 
 const getApiCategoriesArgument = (categories: ?{ [id: string]: string}) => {
     if (!categories) {
@@ -24,7 +25,7 @@ export const getNewEventServerData = (state: ReduxState, formFoundation: RenderF
     const mainDataServerValues: Object = convertMainEventClientToServer(mainDataClientValues);
 
     if (mainDataServerValues.status === 'COMPLETED') {
-        mainDataServerValues.completedDate = moment().format('YYYY-MM-DD');
+        mainDataServerValues.completedDate = getFormattedStringFromMomentUsingEuropeanGlyphs(moment());
     }
 
     return {

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/exposedHelpers/getRelationshipNewTei.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/exposedHelpers/getRelationshipNewTei.js
@@ -1,6 +1,7 @@
 // @flow
 import uuid from 'd2-utilizr/src/uuid';
-import moment from 'capture-core-utils/moment/momentResolver';
+import { moment } from 'capture-core-utils/moment';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from 'capture-core-utils/date';
 import {
     getTrackerProgramThrowIfNotFound,
     getTrackedEntityTypeThrowIfNotFound,
@@ -103,7 +104,7 @@ export default function getRelationshipNewTei(dataEntryId: string, itemId: strin
         program: programId,
         status: 'ACTIVE',
         orgUnit: orgUnit.id,
-        incidentDate: moment().format('YYYY-MM-DD'),
+        incidentDate: getFormattedStringFromMomentUsingEuropeanGlyphs(moment()),
         ...serverValuesForMainValues,
     } : null;
 

--- a/src/core_modules/capture-core/components/Pages/ViewEvent/EventDetailsSection/EditEventDataEntry/editEventDataEntry.epics.js
+++ b/src/core_modules/capture-core/components/Pages/ViewEvent/EventDetailsSection/EditEventDataEntry/editEventDataEntry.epics.js
@@ -2,6 +2,7 @@
 import { ActionsObservable } from 'redux-observable';
 import { batchActions } from 'redux-batched-actions';
 import { moment } from 'capture-core-utils/moment';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from 'capture-core-utils/date';
 import { convertValue as convertToServerValue } from '../../../../../converters/clientToServer';
 import { getProgramAndStageFromEvent } from '../../../../../metaData';
 import { openEventForEditInDataEntry } from '../../../EditEvent/DataEntry/editEventDataEntry.actions';
@@ -76,7 +77,7 @@ export const saveEditedEventEpic = (action$: InputObservable, store: ReduxStore)
             const mainDataServerValues: Object = convertMainEventClientToServer(mainDataClientValues);
 
             if (mainDataServerValues.status === 'COMPLETED' && !prevEventMainData.completedDate) {
-                mainDataServerValues.completedDate = moment().format('YYYY-MM-DD');
+                mainDataServerValues.completedDate = getFormattedStringFromMomentUsingEuropeanGlyphs(moment());
             }
 
             const { eventContainer: prevEventContainer } = state.viewEventPage.loadedValues;

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/converters/momentConverter.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/converters/momentConverter.js
@@ -1,7 +1,8 @@
 // @flow
 /* eslint-disable class-methods-use-this */
 import moment from 'moment';
-import type { IMomentConverter } from '../RulesEngine/rulesEngine.types';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from 'capture-core-utils/date';
+import type { IMomentConverter } from 'capture-core-utils/RulesEngine/rulesEngine.types';
 
 const momentFormat = 'YYYY-MM-DD';
 
@@ -10,7 +11,7 @@ class RulesMomentConverter implements IMomentConverter {
         return moment(rulesEngineValue, momentFormat);
     }
     momentToRulesDate(momentObject: moment$Moment): string {
-        return momentObject.format(momentFormat);
+        return getFormattedStringFromMomentUsingEuropeanGlyphs(momentObject);
     }
 }
 


### PR DESCRIPTION
This is the v34 backport of the [DHIS2-8612](https://jira.dhis2.org/browse/DHIS2-8612) JIRA issue.

Resolved some issues caused by using a moment locale with non european glyphs.
- Saving an event when the event was marked for completion caused the post request to fail due to the complete date being posted using non european glyphs.
- Filtering a view using a date field caused the filtering to fail.
- Program rules would interpret dates wrong.