### PR TITLE
refactor: on RulesEngine class 03

### DIFF
--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
@@ -23,7 +23,7 @@ import type {
 } from './rulesEngine.types';
 
 type ExecutionService = {
-    executeRules: (
+    internalExecuteRules: (
         programRulesContainer: ProgramRulesContainer,
         executingEvent: ?EventData | {},
         events: ?EventsDataContainer,
@@ -85,7 +85,7 @@ export default class RulesEngine {
             eventsContainer = null;
         }
 
-        const effects = this.executionService.executeRules(
+        const effects = this.executionService.internalExecuteRules(
             programRulesContainer,
             executingEvent,
             eventsContainer,
@@ -98,9 +98,7 @@ export default class RulesEngine {
             { debug: true },
         );
 
-        const processedEffects = effects ?
-            this.onProcessRulesEffects(effects, processType, dataElements, trackedEntityAttributes) :
-            null;
+        const processedEffects = effects ? this.onProcessRulesEffects(effects, processType, dataElements, trackedEntityAttributes) : null;
         return processedEffects;
     }
 }

--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
@@ -53,11 +53,8 @@ export default class RulesEngine {
         inputConverterObject: IConvertInputRulesValue,
         momentConverter: IMomentConverter,
         outputRulesConverterObject: IConvertOutputRulesEffectsValue) {
-        // Convert the input values from a form into values that the rule engine understands
         const valueProcessor = new ValueProcessor(inputConverterObject);
         const dateUtils = getDateUtils(momentConverter);
-
-        // creates the variables for us
         const variableService = new VariableService(valueProcessor.processValue, dateUtils);
         this.executionService = getExecutionService(variableService, dateUtils);
         this.onProcessRulesEffects = getRulesEffectsProcessor(

--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
@@ -2,7 +2,6 @@
 import VariableService from './VariableService/VariableService';
 import ValueProcessor from './ValueProcessor/ValueProcessor';
 import getExecutionService from './executionService/executionService';
-import getDateUtils from './dateUtils/dateUtils';
 import getRulesEffectsProcessor from './rulesEffectsProcessor/rulesEffectsProcessor';
 import processTypes from './rulesEffectsProcessor/processTypes.const';
 
@@ -10,7 +9,6 @@ import type {
     OutputEffect,
     IConvertInputRulesValue,
     IConvertOutputRulesEffectsValue,
-    IMomentConverter,
     ProgramRulesContainer,
     EventData,
     EventsData,
@@ -23,7 +21,6 @@ import type {
     EventsDataContainer,
     TEIValues,
 } from './rulesEngine.types';
-
 
 type ExecutionService = {
     executeRules: (
@@ -51,15 +48,12 @@ export default class RulesEngine {
 
     constructor(
         inputConverterObject: IConvertInputRulesValue,
-        momentConverter: IMomentConverter,
         outputRulesConverterObject: IConvertOutputRulesEffectsValue) {
         const valueProcessor = new ValueProcessor(inputConverterObject);
-        const dateUtils = getDateUtils(momentConverter);
-        const variableService = new VariableService(valueProcessor.processValue, dateUtils);
-        this.executionService = getExecutionService(variableService, dateUtils);
-        this.onProcessRulesEffects = getRulesEffectsProcessor(
-            this.executionService.convertDataToBaseOutputValue,
-            outputRulesConverterObject);
+        const variableService = new VariableService(valueProcessor.processValue);
+
+        this.executionService = getExecutionService(variableService);
+        this.onProcessRulesEffects = getRulesEffectsProcessor(this.executionService.convertDataToBaseOutputValue, outputRulesConverterObject);
     }
 
     executeRules(

--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
@@ -53,8 +53,11 @@ export default class RulesEngine {
         inputConverterObject: IConvertInputRulesValue,
         momentConverter: IMomentConverter,
         outputRulesConverterObject: IConvertOutputRulesEffectsValue) {
+        // Convert the input values from a form into values that the rule engine understands
         const valueProcessor = new ValueProcessor(inputConverterObject);
         const dateUtils = getDateUtils(momentConverter);
+
+        // creates the variables for us
         const variableService = new VariableService(valueProcessor.processValue, dateUtils);
         this.executionService = getExecutionService(variableService, dateUtils);
         this.onProcessRulesEffects = getRulesEffectsProcessor(

--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
@@ -76,7 +76,6 @@ export default class RulesEngine {
             eventsContainer = null;
         }
 
-
         return this.executionService.getEffects(
             programRulesContainer,
             executingEvent,

--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
@@ -15,36 +15,34 @@ import type {
     OptionSets,
     TrackedEntityAttributes,
     Enrollment,
-    ProgramRuleEffect,
     EventsDataContainer,
     TEIValues,
 } from './rulesEngine.types';
 
 type ExecutionService = {
-    internalExecuteRules: (
-        programRulesContainer: ProgramRulesContainer,
-        executingEvent: ?EventData | {},
-        events: ?EventsDataContainer,
-        dataElements: ?DataElements,
-        trackedEntityAttributes: ?TrackedEntityAttributes,
-        selectedTrackedEntityAttributes: ?TEIValues,
-        selectedEnrollment: ?Enrollment,
-        selectedOrgUnit: OrgUnit,
-        optionSets: ?OptionSets,
-        processType: string,
-        flags: Object,
-    ) => ?Array<ProgramRuleEffect>,
-    convertDataToBaseOutputValue: (data: any, valueType: string) => any,
+    getEffects: (
+      programRulesContainer: ProgramRulesContainer,
+      executingEvent: ?EventData | {},
+      events: ?EventsDataContainer,
+      dataElements: ?DataElements,
+      trackedEntityAttributes: ?TrackedEntityAttributes,
+      selectedTrackedEntityAttributes: ?TEIValues,
+      selectedEnrollment: ?Enrollment,
+      selectedOrgUnit: OrgUnit,
+      optionSets: ?OptionSets,
+      processType: string,
+      flags: Object,
+    ) => ?Array<OutputEffect>
 };
 
 export default class RulesEngine {
-    getEffects: ExecutionService;
+    executionService: ExecutionService;
 
     constructor() {
         const valueProcessor = new ValueProcessor(inputValueConverter);
         const variableService = new VariableService(valueProcessor.processValue);
 
-        this.getEffects = getExecutionService(variableService);
+        this.executionService = getExecutionService(variableService);
     }
 
     executeRules(
@@ -79,7 +77,7 @@ export default class RulesEngine {
         }
 
 
-        return this.getEffects(
+        return this.executionService.getEffects(
             programRulesContainer,
             executingEvent,
             eventsContainer,

--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
@@ -45,7 +45,7 @@ export default class RulesEngine {
       effects: Array<ProgramRuleEffect>,
       processType: $Values<typeof processTypes>,
       dataElements: ?DataElements,
-      trackedEntityAttributes?: ?TrackedEntityAttributes) => Array<?OutputEffect>;
+      trackedEntityAttributes?: ?TrackedEntityAttributes) => ?Array<OutputEffect>;
 
     constructor() {
         const valueProcessor = new ValueProcessor(inputValueConverter);
@@ -69,7 +69,7 @@ export default class RulesEngine {
         selectedOrgUnit: OrgUnit,
         optionSets: ?OptionSets,
         processType: $Values<typeof processTypes>,
-    ): ?Array<?OutputEffect> {
+    ): ?Array<OutputEffect> {
         let eventsContainer;
         if (eventsData && eventsData.length > 0) {
             const eventsDataByStage = eventsData.reduce((accEventsByStage, event) => {

--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.js
@@ -4,11 +4,11 @@ import ValueProcessor from './ValueProcessor/ValueProcessor';
 import getExecutionService from './executionService/executionService';
 import getRulesEffectsProcessor from './rulesEffectsProcessor/rulesEffectsProcessor';
 import processTypes from './rulesEffectsProcessor/processTypes.const';
+import inputValueConverter from './converters/inputValueConverter';
+import rulesEffectsValueConverter from './converters/rulesEffectsValueConverter';
 
 import type {
     OutputEffect,
-    IConvertInputRulesValue,
-    IConvertOutputRulesEffectsValue,
     ProgramRulesContainer,
     EventData,
     EventsData,
@@ -46,14 +46,12 @@ export default class RulesEngine {
         dataElements: ?DataElements,
         trackedEntityAttributes?: ?TrackedEntityAttributes) => ?Array<OutputEffect>;
 
-    constructor(
-        inputConverterObject: IConvertInputRulesValue,
-        outputRulesConverterObject: IConvertOutputRulesEffectsValue) {
-        const valueProcessor = new ValueProcessor(inputConverterObject);
+    constructor() {
+        const valueProcessor = new ValueProcessor(inputValueConverter);
         const variableService = new VariableService(valueProcessor.processValue);
 
         this.executionService = getExecutionService(variableService);
-        this.onProcessRulesEffects = getRulesEffectsProcessor(this.executionService.convertDataToBaseOutputValue, outputRulesConverterObject);
+        this.onProcessRulesEffects = getRulesEffectsProcessor(this.executionService.convertDataToBaseOutputValue, rulesEffectsValueConverter);
     }
 
     executeRules(

--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.test.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.test.js
@@ -1,4 +1,3 @@
-// @flow
 import { RulesEngine, processTypes } from '../RulesEngine';
 import { prepareEventData } from '../../capture-core/rulesEngineActionsCreator/runRulesForSingleEvent';
 
@@ -40,12 +39,13 @@ const programs = [
 programs.forEach(({ program, foundation, orgUnit }) => {
     test('Tests on runRulesForSingleEvent function', () => {
         const rulesEngine = new RulesEngine();
-
-        const { optionSets, dataElementsInProgram, programRulesVariables, programRules, constants } = prepareEventData(program, foundation);
-
-        // returns an array of effects that need to take place in the UI.
-        const rulesEffects = rulesEngine.executeRules({ programRulesVariables, programRules, constants }, null, null, dataElementsInProgram, null, null, null, orgUnit, optionSets, processTypes.EVENT);
-
+        let rulesEffects = null;
+        const data = prepareEventData(program, foundation);
+        if (data) {
+            const { optionSets, dataElementsInProgram, programRulesVariables, programRules, constants } = data;
+            // returns an array of effects that need to take place in the UI.
+            rulesEffects = rulesEngine.executeRules({ programRulesVariables, programRules, constants }, null, null, dataElementsInProgram, null, null, null, orgUnit, optionSets, processTypes.EVENT);
+        }
         expect(rulesEffects).toMatchSnapshot();
     });
 });

--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.test.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.test.js
@@ -1,6 +1,6 @@
 // @flow
-import RulesEngine from '../RulesEngine/RulesEngine';
-import runRulesForSingleEvent from '../../capture-core/rulesEngineActionsCreator/runRulesForSingleEvent';
+import { RulesEngine, processTypes } from '../RulesEngine';
+import { prepareForExecution } from '../../capture-core/rulesEngineActionsCreator/runRulesForSingleEvent';
 
 const programs = [
     {
@@ -41,7 +41,10 @@ programs.forEach(({ program, foundation, orgUnit }) => {
     test('Tests on runRulesForSingleEvent function', () => {
         const rulesEngine = new RulesEngine();
 
-        const rulesEffects = runRulesForSingleEvent(rulesEngine, program, foundation, orgUnit);
+        const { optionSets, dataElementsInProgram, programRulesVariables, programRules, constants } = prepareForExecution(program, foundation);
+
+        // returns an array of effects that need to take place in the UI.
+        const rulesEffects = rulesEngine.executeRules({ programRulesVariables, programRules, constants }, null, null, dataElementsInProgram, null, null, null, orgUnit, optionSets, processTypes.EVENT);
 
         expect(rulesEffects).toMatchSnapshot();
     });

--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.test.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.test.js
@@ -1,6 +1,6 @@
 // @flow
 import { RulesEngine, processTypes } from '../RulesEngine';
-import { prepareForExecution } from '../../capture-core/rulesEngineActionsCreator/runRulesForSingleEvent';
+import { prepareEventData } from '../../capture-core/rulesEngineActionsCreator/runRulesForSingleEvent';
 
 const programs = [
     {
@@ -41,7 +41,7 @@ programs.forEach(({ program, foundation, orgUnit }) => {
     test('Tests on runRulesForSingleEvent function', () => {
         const rulesEngine = new RulesEngine();
 
-        const { optionSets, dataElementsInProgram, programRulesVariables, programRules, constants } = prepareForExecution(program, foundation);
+        const { optionSets, dataElementsInProgram, programRulesVariables, programRules, constants } = prepareEventData(program, foundation);
 
         // returns an array of effects that need to take place in the UI.
         const rulesEffects = rulesEngine.executeRules({ programRulesVariables, programRules, constants }, null, null, dataElementsInProgram, null, null, null, orgUnit, optionSets, processTypes.EVENT);

--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.test.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.test.js
@@ -1,5 +1,5 @@
-import { RulesEngine, processTypes } from '../RulesEngine';
-import { prepareEventData } from '../../capture-core/rulesEngineActionsCreator/runRulesForSingleEvent';
+import { RulesEngine } from '../RulesEngine';
+import runRulesForSingleEvent from '../../capture-core/rulesEngineActionsCreator/runRulesForSingleEvent';
 
 const programs = [
     {
@@ -39,13 +39,9 @@ const programs = [
 programs.forEach(({ program, foundation, orgUnit }) => {
     test('Tests on runRulesForSingleEvent function', () => {
         const rulesEngine = new RulesEngine();
-        let rulesEffects = null;
-        const data = prepareEventData(program, foundation);
-        if (data) {
-            const { optionSets, dataElementsInProgram, programRulesVariables, programRules, constants } = data;
-            // returns an array of effects that need to take place in the UI.
-            rulesEffects = rulesEngine.executeRules({ programRulesVariables, programRules, constants }, null, null, dataElementsInProgram, null, null, null, orgUnit, optionSets, processTypes.EVENT);
-        }
+
+        const rulesEffects = runRulesForSingleEvent(rulesEngine, program, foundation, orgUnit);
+
         expect(rulesEffects).toMatchSnapshot();
     });
 });

--- a/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.test.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/RulesEngine.test.js
@@ -1,8 +1,5 @@
 // @flow
 import RulesEngine from '../RulesEngine/RulesEngine';
-import inputValueConverter from '../../capture-core/rulesEngineActionsCreator/converters/inputValueConverter';
-import momentConverter from '../../capture-core/rulesEngineActionsCreator/converters/momentConverter';
-import outputRulesEffectsValueConverter from '../../capture-core/rulesEngineActionsCreator/converters/rulesEffectsValueConverter';
 import runRulesForSingleEvent from '../../capture-core/rulesEngineActionsCreator/runRulesForSingleEvent';
 
 const programs = [
@@ -42,7 +39,7 @@ const programs = [
 
 programs.forEach(({ program, foundation, orgUnit }) => {
     test('Tests on runRulesForSingleEvent function', () => {
-        const rulesEngine = new RulesEngine(inputValueConverter, momentConverter, outputRulesEffectsValueConverter);
+        const rulesEngine = new RulesEngine();
 
         const rulesEffects = runRulesForSingleEvent(rulesEngine, program, foundation, orgUnit);
 

--- a/src/core_modules/capture-core-utils/RulesEngine/VariableService/VariableService.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/VariableService/VariableService.js
@@ -5,7 +5,7 @@ import OptionSetHelper from '../OptionSetHelper/OptionSetHelper';
 import typeKeys from '../typeKeys.const';
 import variablePrefixes from '../variablePrefixes';
 import getDateUtils from '../dateUtils/dateUtils';
-import momentConverter from '../../../capture-core/rulesEngineActionsCreator/converters/momentConverter';
+import momentConverter from '../converters/momentConverter';
 
 import type {
     ProgramRulesContainer,

--- a/src/core_modules/capture-core-utils/RulesEngine/VariableService/VariableService.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/VariableService/VariableService.js
@@ -4,6 +4,8 @@ import log from 'loglevel';
 import OptionSetHelper from '../OptionSetHelper/OptionSetHelper';
 import typeKeys from '../typeKeys.const';
 import variablePrefixes from '../variablePrefixes';
+import getDateUtils from '../dateUtils/dateUtils';
+import momentConverter from '../../../capture-core/rulesEngineActionsCreator/converters/momentConverter';
 
 import type {
     ProgramRulesContainer,
@@ -77,18 +79,12 @@ export default class VariableService {
             : value;
     }
 
-    /*
-    static getDataElementValueOrCode(useCodeForOptionSet, event, dataElementId, allDes, optionSets) {
-        return VariableService.getDataElementValueOrCodeForValue(useCodeForOptionSet, event[dataElementId], dataElementId, allDes, optionSets);
-    }
-    */
-
     onProcessValue: (value: any, type: $Values<typeof typeKeys>) => any;
     dateUtils: DateUtils;
     mapSourceTypeToGetterFn: { [sourceType: string]: (programVariable: ProgramRuleVariable, sourceData: SourceData) => ?Variable };
-    constructor(onProcessValue: (value: any, type: $Values<typeof typeKeys>) => any, dateUtils: DateUtils) {
+    constructor(onProcessValue: (value: any, type: $Values<typeof typeKeys>) => any) {
         this.onProcessValue = onProcessValue;
-        this.dateUtils = dateUtils;
+        this.dateUtils = getDateUtils(momentConverter);
 
         this.mapSourceTypeToGetterFn = {
             [variableSourceTypes.DATAELEMENT_CURRENT_EVENT]: this.getVariableForCurrentEvent,
@@ -357,7 +353,7 @@ export default class VariableService {
 
         const allValues = stageEvents
             .map(event =>
-                VariableService.getDataElementValueForVariable(event[dataElementId], dataElementId, programVariable.useNameForOptionSet, sourceData.dataElements, sourceData.optionSets)
+                VariableService.getDataElementValueForVariable(event[dataElementId], dataElementId, programVariable.useNameForOptionSet, sourceData.dataElements, sourceData.optionSets),
             )
             .filter(value => !!value || value === false || value === 0);
 
@@ -399,7 +395,7 @@ export default class VariableService {
 
         const allValues = events
             .map(event =>
-                VariableService.getDataElementValueForVariable(event[dataElementId], dataElementId, programVariable.useNameForOptionSet, sourceData.dataElements, sourceData.optionSets)
+                VariableService.getDataElementValueForVariable(event[dataElementId], dataElementId, programVariable.useNameForOptionSet, sourceData.dataElements, sourceData.optionSets),
             )
             .filter(value => !!value || value === false || value === 0);
 

--- a/src/core_modules/capture-core-utils/RulesEngine/converters/inputValueConverter.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/converters/inputValueConverter.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-disable class-methods-use-this */
-import { moment } from 'capture-core-utils/moment';
-import type { IConvertInputRulesValue } from 'capture-core-utils/RulesEngine/rulesEngine.types';
+import { moment } from '../../moment';
+import type { IConvertInputRulesValue } from '../rulesEngine.types';
 
 const dateMomentFormat = 'YYYY-MM-DD';
 

--- a/src/core_modules/capture-core-utils/RulesEngine/converters/momentConverter.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/converters/momentConverter.js
@@ -1,7 +1,7 @@
 // @flow
 import moment from 'moment';
-import { getFormattedStringFromMomentUsingEuropeanGlyphs } from 'capture-core-utils/date';
-import type { IMomentConverter } from 'capture-core-utils/RulesEngine/rulesEngine.types';
+import { getFormattedStringFromMomentUsingEuropeanGlyphs } from '../../date';
+import type { IMomentConverter } from '../rulesEngine.types';
 
 const momentFormat = 'YYYY-MM-DD';
 

--- a/src/core_modules/capture-core-utils/RulesEngine/converters/rulesEffectsValueConverter.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/converters/rulesEffectsValueConverter.js
@@ -1,8 +1,8 @@
 // @flow
 /* eslint-disable class-methods-use-this */
 import moment from 'moment';
-import { convertMomentToDateFormatString } from '../../utils/converters/date';
-import type { IConvertOutputRulesEffectsValue } from '../RulesEngine/rulesEngine.types';
+import { convertMomentToDateFormatString } from '../../../capture-core/utils/converters/date';
+import type { IConvertOutputRulesEffectsValue } from '../rulesEngine.types';
 
 const dateMomentFormat = 'YYYY-MM-DD';
 

--- a/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
@@ -604,7 +604,7 @@ export default function getExecutionService(variableService) {
      * @param {*} optionSets all optionsets(matedata)
      * @param {*} flag execution flags
      */
-    return (programRulesContainer, executingEvent, evs, allDataElements, allTrackedEntityAttributes, selectedEntity, selectedEnrollment, selectedOrgUnit, optionSets, processType, flag) => {
+    function getEffects (programRulesContainer, executingEvent, evs, allDataElements, allTrackedEntityAttributes, selectedEntity, selectedEnrollment, selectedOrgUnit, optionSets, processType, flag) {
         const { programRules } = programRulesContainer;
         if (!programRules) {
             return null;
@@ -655,4 +655,5 @@ export default function getExecutionService(variableService) {
 
         return processRulesEffects(effects, processType, allDataElements, allTrackedEntityAttributes);
     };
+    return { getEffects }
 }

--- a/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import log from 'loglevel';
 import isDefined from 'd2-utilizr/lib/isDefined';
 import isString from 'd2-utilizr/lib/isString';
@@ -8,7 +9,6 @@ import getDateUtils from '../dateUtils/dateUtils';
 import momentConverter from '../converters/momentConverter';
 import getRulesEffectsProcessor from '../rulesEffectsProcessor/rulesEffectsProcessor';
 import rulesEffectsValueConverter from '../converters/rulesEffectsValueConverter';
-
 
 export default function getExecutionService(variableService) {
     const dateUtils = getDateUtils(momentConverter);
@@ -591,7 +591,6 @@ export default function getExecutionService(variableService) {
 
         return effect;
     };
-
 
     /**
      *

--- a/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
@@ -608,7 +608,7 @@ export default function getExecutionService(variableService, dateUtils) {
      */
     const internalExecuteRules = (programRulesContainer, executingEvent, evs, allDataElements, allTrackedEntityAttributes, selectedEntity, selectedEnrollment, selectedOrgUnit, optionSets, flag) => {
         const { programRules } = programRulesContainer;
-        if (programRules.length === 0) {
+        if (programRules.length === 0 || !programRules) {
             return null;
         }
 

--- a/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
@@ -610,8 +610,7 @@ export default function getExecutionService(variableService) {
 
         const variablesHash = variableService.getVariables(programRulesContainer, executingEvent, evs, allDataElements, allTrackedEntityAttributes, selectedEntity, selectedEnrollment, selectedOrgUnit, optionSets);
 
-        return programRules
-        .sort((a, b) => {
+        return programRules.sort((a, b) => {
             if (!a.priority && !b.priority) {
                 return 0;
             }
@@ -647,7 +646,7 @@ export default function getExecutionService(variableService) {
             return ruleEffects;
         })
         .filter(ruleEffectsForRule => ruleEffectsForRule)
-        .reduce((accRuleEffects, effectsForRule) => [...accRuleEffects, ...effectsForRule], [])
+        .reduce((accRuleEffects, effectsForRule) => [...accRuleEffects, ...effectsForRule], []);
     };
 
     return { getEffects,  convertDataToBaseOutputValue: convertRuleEffectDataToOutputBaseValue, }

--- a/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
@@ -656,12 +656,7 @@ export default function getExecutionService(variableService, dateUtils) {
     };
 
     return {
-        executeRules(programRulesContainer, executingEvent, evs, allDataElements, allTrackedEntityAttributes, selectedEntity, selectedEnrollment, selectedOrgUnit, optionSets, flags) {
-            if (!programRulesContainer.programRules) {
-                return null;
-            }
-            return internalExecuteRules(programRulesContainer, executingEvent, evs, allDataElements, allTrackedEntityAttributes, selectedEntity, selectedEnrollment, selectedOrgUnit, optionSets, flags);
-        },
+        internalExecuteRules,
         convertDataToBaseOutputValue: convertRuleEffectDataToOutputBaseValue,
     };
 }

--- a/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
@@ -608,13 +608,11 @@ export default function getExecutionService(variableService, dateUtils) {
      */
     return (programRulesContainer, executingEvent, evs, allDataElements, allTrackedEntityAttributes, selectedEntity, selectedEnrollment, selectedOrgUnit, optionSets, processType, flag) => {
         const { programRules } = programRulesContainer;
-        if (programRules.length === 0 || !programRules) {
+        if (!programRules) {
             return null;
         }
 
         const variablesHash = variableService.getVariables(programRulesContainer, executingEvent, evs, allDataElements, allTrackedEntityAttributes, selectedEntity, selectedEnrollment, selectedOrgUnit, optionSets);
-
-        // console.log(variableHash)
 
         const effects = programRules
             .sort((a, b) => {

--- a/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import log from 'loglevel';
 import isDefined from 'd2-utilizr/lib/isDefined';
 import isString from 'd2-utilizr/lib/isString';
@@ -6,14 +5,14 @@ import getZScoreWFA from './zScoreWFA';
 import trimQuotes from '../commonUtils/trimQuotes';
 import typeKeys from '../typeKeys.const';
 import getDateUtils from '../dateUtils/dateUtils';
-import momentConverter from '../../../capture-core/rulesEngineActionsCreator/converters/momentConverter';
+import momentConverter from '../converters/momentConverter';
+import getRulesEffectsProcessor from '../rulesEffectsProcessor/rulesEffectsProcessor';
+import rulesEffectsValueConverter from '../converters/rulesEffectsValueConverter';
 
 
 export default function getExecutionService(variableService) {
     const dateUtils = getDateUtils(momentConverter);
 
-
-export default function getExecutionService(variableService, dateUtils) {
     const replaceVariables = (expression, variablesHash) => {
         // replaces the variables in an expression with actual variable values.
 
@@ -25,11 +24,11 @@ export default function getExecutionService(variableService, dateUtils) {
             variablespresent.forEach((variablepresent) => {
                 // First strip away any prefix and postfix signs from the variable name:
                 variablepresent = variablepresent
-                .replace('#{', '')
-                .replace('A{', '')
-                .replace('C{', '')
-                .replace('V{', '')
-                .replace('}', '');
+                    .replace('#{', '')
+                    .replace('A{', '')
+                    .replace('C{', '')
+                    .replace('V{', '')
+                    .replace('}', '');
 
                 if (isDefined(variablesHash[variablepresent])) {
                     // Replace all occurrences of the variable name(hence using regex replacement):

--- a/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
@@ -5,6 +5,13 @@ import isString from 'd2-utilizr/lib/isString';
 import getZScoreWFA from './zScoreWFA';
 import trimQuotes from '../commonUtils/trimQuotes';
 import typeKeys from '../typeKeys.const';
+import getDateUtils from '../dateUtils/dateUtils';
+import momentConverter from '../../../capture-core/rulesEngineActionsCreator/converters/momentConverter';
+
+
+export default function getExecutionService(variableService) {
+    const dateUtils = getDateUtils(momentConverter);
+
 
 export default function getExecutionService(variableService, dateUtils) {
     const replaceVariables = (expression, variablesHash) => {

--- a/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/executionService/executionService.js
@@ -606,7 +606,7 @@ export default function getExecutionService(variableService, dateUtils) {
      * @param {*} optionSets all optionsets(matedata)
      * @param {*} flag execution flags
      */
-    const internalExecuteRules = (programRulesContainer, executingEvent, evs, allDataElements, allTrackedEntityAttributes, selectedEntity, selectedEnrollment, selectedOrgUnit, optionSets, flag) => {
+    return (programRulesContainer, executingEvent, evs, allDataElements, allTrackedEntityAttributes, selectedEntity, selectedEnrollment, selectedOrgUnit, optionSets, processType, flag) => {
         const { programRules } = programRulesContainer;
         if (programRules.length === 0 || !programRules) {
             return null;
@@ -616,7 +616,8 @@ export default function getExecutionService(variableService, dateUtils) {
 
         // console.log(variableHash)
 
-        return programRules.sort((a, b) => {
+        const effects = programRules
+            .sort((a, b) => {
                 if (!a.priority && !b.priority) {
                     return 0;
                 }
@@ -653,10 +654,9 @@ export default function getExecutionService(variableService, dateUtils) {
             })
             .filter(ruleEffectsForRule => ruleEffectsForRule)
             .reduce((accRuleEffects, effectsForRule) => [...accRuleEffects, ...effectsForRule], []);
-    };
 
-    return {
-        internalExecuteRules,
-        convertDataToBaseOutputValue: convertRuleEffectDataToOutputBaseValue,
+        const processRulesEffects = getRulesEffectsProcessor(convertRuleEffectDataToOutputBaseValue, rulesEffectsValueConverter);
+
+        return processRulesEffects(effects, processType, allDataElements, allTrackedEntityAttributes);
     };
 }

--- a/src/core_modules/capture-core-utils/RulesEngine/rulesEffectsProcessor/rulesEffectsProcessor.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/rulesEffectsProcessor/rulesEffectsProcessor.js
@@ -271,7 +271,9 @@ export default function getRulesEffectsProcessor(
                 processType,
                 dataElements,
                 trackedEntityAttributes,
-            ));
+            ))
+            // when mapActionsToProcessor function returns `null` we filter those value out.
+            .filter(keepTruthyValues => keepTruthyValues);
     }
 
     return processRulesEffects;

--- a/src/core_modules/capture-core-utils/RulesEngine/rulesEffectsProcessor/rulesEffectsProcessor.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/rulesEffectsProcessor/rulesEffectsProcessor.js
@@ -14,7 +14,7 @@ import type {
     GeneralErrorEffect,
     GeneralWarningEffect,
     CompulsoryEffect,
-    OutputEffect
+    OutputEffect,
 } from '../rulesEngine.types';
 
 const mapProcessTypeToIdentifierName = {
@@ -260,22 +260,22 @@ export default function getRulesEffectsProcessor(
         effects: Array<ProgramRuleEffect>,
         processType: $Values<typeof processTypes>,
         dataElements: ?DataElements,
-        trackedEntityAttributes: ?TrackedEntityAttributes): Array<?OutputEffect> {
+        trackedEntityAttributes: ?TrackedEntityAttributes): ?Array<OutputEffect> {
         const processIdName = mapProcessTypeToIdentifierName[processType];
 
+        if (!effects) {
+            return null;
+        }
+
         return effects
-            .map((effect) => {
-                const action = effect.action;
-                return mapActionsToProcessor[action] ?
-                    mapActionsToProcessor[action](
-                        effect,
-                        processIdName,
-                        processType,
-                        dataElements,
-                        trackedEntityAttributes,
-                    ) : null;
-            })
-            .filter(effect => effect);
+            .filter(({ action }) => mapActionsToProcessor[action])
+            .map(effect => mapActionsToProcessor[effect.action](
+                effect,
+                processIdName,
+                processType,
+                dataElements,
+                trackedEntityAttributes,
+            ));
     }
 
     return processRulesEffects;

--- a/src/core_modules/capture-core-utils/RulesEngine/rulesEffectsProcessor/rulesEffectsProcessor.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/rulesEffectsProcessor/rulesEffectsProcessor.js
@@ -263,10 +263,6 @@ export default function getRulesEffectsProcessor(
         trackedEntityAttributes: ?TrackedEntityAttributes): ?Array<OutputEffect> {
         const processIdName = mapProcessTypeToIdentifierName[processType];
 
-        if (!effects) {
-            return null;
-        }
-
         return effects
             .filter(({ action }) => mapActionsToProcessor[action])
             .map(effect => mapActionsToProcessor[effect.action](

--- a/src/core_modules/capture-core-utils/RulesEngine/rulesEffectsProcessor/rulesEffectsProcessor.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/rulesEffectsProcessor/rulesEffectsProcessor.js
@@ -14,6 +14,7 @@ import type {
     GeneralErrorEffect,
     GeneralWarningEffect,
     CompulsoryEffect,
+    OutputEffect
 } from '../rulesEngine.types';
 
 const mapProcessTypeToIdentifierName = {
@@ -259,7 +260,7 @@ export default function getRulesEffectsProcessor(
         effects: Array<ProgramRuleEffect>,
         processType: $Values<typeof processTypes>,
         dataElements: ?DataElements,
-        trackedEntityAttributes: ?TrackedEntityAttributes) {
+        trackedEntityAttributes: ?TrackedEntityAttributes): Array<?OutputEffect> {
         const processIdName = mapProcessTypeToIdentifierName[processType];
 
         return effects

--- a/src/core_modules/capture-core-utils/RulesEngine/rulesEngine.types.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/rulesEngine.types.js
@@ -144,18 +144,6 @@ export type DataElement = {
 
 export type DataElements = { [elementId: string]: DataElement };
 
-export type RuleVariable = {
-    variableValue: any,
-    useCodeForOptionSet: boolean,
-    variableType: string,
-    hasValue: boolean,
-    variableEventDate: ?string,
-    variablePrefix: string,
-    allValues: ?Array<any>,
-};
-
-export type RuleVariables = { [string]: RuleVariable };
-
 export type TrackedEntityAttribute = {
     id: string,
     valueType: string,

--- a/src/core_modules/capture-core-utils/RulesEngine/rulesEngine.types.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/rulesEngine.types.js
@@ -144,6 +144,18 @@ export type DataElement = {
 
 export type DataElements = { [elementId: string]: DataElement };
 
+export type RuleVariable = {
+    variableValue: any,
+    useCodeForOptionSet: boolean,
+    variableType: string,
+    hasValue: boolean,
+    variableEventDate: ?string,
+    variablePrefix: string,
+    allValues: ?Array<any>,
+};
+
+export type RuleVariables = { [string]: RuleVariable };
+
 export type TrackedEntityAttribute = {
     id: string,
     valueType: string,

--- a/src/core_modules/capture-core-utils/RulesEngine/rulesEngine.types.js
+++ b/src/core_modules/capture-core-utils/RulesEngine/rulesEngine.types.js
@@ -127,6 +127,8 @@ export type EventValues = {
     [elementId: string]: any,
 };
 
+export type InputEvent = EventValues | {};
+
 export type EventData = EventMain & EventValues;
 
 export type EventsData = Array<EventData>;

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/postProcessRulesEffects.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/postProcessRulesEffects.js
@@ -170,7 +170,7 @@ function filterSectionsHideEffects(
 }
 
 export default function postProcessRulesEffects(
-    rulesEffects: ?Array<OutputEffect>,
+    rulesEffects: Array<OutputEffect>,
     foundation: ?RenderFoundation) {
     if (!rulesEffects || !foundation) {
         return null;

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
@@ -2,18 +2,15 @@
 /**
  * @module rulesEngineActionsCreator
  */
-import { RulesEngine } from 'capture-core-utils/RulesEngine';
 import { RenderFoundation, Program, TrackerProgram } from '../metaData';
-import inputValueConverter from './converters/inputValueConverter';
-import outputRulesEffectsValueConverter from './converters/rulesEffectsValueConverter';
 import runRulesForSingleEvent from './runRulesForSingleEvent';
 import runRulesForTEI from './runRulesForTEI';
 import postProcessRulesEffects from './postProcessRulesEffects';
 import { updateRulesEffects } from './rulesEngine.actions';
+import { RulesEngine } from '../../capture-core-utils/RulesEngine';
+import type { OutputEffect, EventData, Enrollment, TEIValues } from '../../capture-core-utils/RulesEngine/rulesEngine.types';
 
-import type { OutputEffect, EventData, Enrollment, TEIValues } from 'capture-core-utils/RulesEngine/rulesEngine.types';
-
-const rulesEngine = new RulesEngine(inputValueConverter, outputRulesEffectsValueConverter);
+const rulesEngine = new RulesEngine();
 
 function getRulesActions(
     rulesEffects: ?Array<OutputEffect>,

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
@@ -3,12 +3,17 @@
  * @module rulesEngineActionsCreator
  */
 import { RenderFoundation, Program, TrackerProgram } from '../metaData';
-import { prepareForExecution } from './runRulesForSingleEvent';
+import { prepareEventData } from './runRulesForSingleEvent';
 import runRulesForTEI from './runRulesForTEI';
 import postProcessRulesEffects from './postProcessRulesEffects';
 import { updateRulesEffects } from './rulesEngine.actions';
 import { RulesEngine, processTypes } from '../../capture-core-utils/RulesEngine';
-import type { OutputEffect, EventData, Enrollment, TEIValues } from '../../capture-core-utils/RulesEngine/rulesEngine.types';
+import type {
+    OutputEffect,
+    EventData,
+    Enrollment,
+    TEIValues,
+} from '../../capture-core-utils/RulesEngine/rulesEngine.types';
 
 const rulesEngine = new RulesEngine();
 
@@ -26,14 +31,29 @@ export function getRulesActionsForEvent(
     foundation: ?RenderFoundation,
     formId: string,
     orgUnit: Object,
-    currentEventData: ?EventData  | {} = {},
+    currentEventData: ?EventData | {} = {},
     allEventsData: ?Array<EventData>,
 ) {
-    const { optionSets, dataElementsInProgram, programRulesVariables, programRules, constants } = prepareForExecution(program, foundation);
-    // returns an array of effects that need to take place in the UI.
-    const rulesEffects = rulesEngine.executeRules({ programRulesVariables, programRules, constants }, currentEventData, allEventsData, dataElementsInProgram, null, null, null, orgUnit, optionSets, processTypes.EVENT);
+    const data = prepareEventData(program, foundation);
+    if (data) {
+        const { optionSets, dataElementsInProgram, programRulesVariables, programRules, constants } = data;
+        // returns an array of effects that need to take place in the UI.
+        const rulesEffects = rulesEngine.executeRules(
+            { programRulesVariables, programRules, constants },
+            currentEventData,
+            allEventsData,
+            dataElementsInProgram,
+            null,
+            null,
+            null,
+            orgUnit,
+            optionSets,
+            processTypes.EVENT,
+        );
 
-    return getRulesActions(rulesEffects, foundation, formId);
+        return getRulesActions(rulesEffects, foundation, formId);
+    }
+    return null;
 }
 
 export function getRulesActionsForTEI(

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
@@ -13,12 +13,13 @@ import type {
     EventData,
     Enrollment,
     TEIValues,
+    InputEvent,
 } from '../../capture-core-utils/RulesEngine/rulesEngine.types';
 
 const rulesEngine = new RulesEngine();
 
 function getRulesActions(
-    rulesEffects: ?Array<?OutputEffect>,
+    rulesEffects: Array<OutputEffect>,
     foundation: ?RenderFoundation,
     formId: string,
 ) {
@@ -31,7 +32,7 @@ export function getRulesActionsForEvent(
     foundation: ?RenderFoundation,
     formId: string,
     orgUnit: Object,
-    currentEventData: ?EventData | {} = {},
+    currentEventData: ?InputEvent = {},
     allEventsData: ?Array<EventData>,
 ) {
     const rulesEffects = runRulesForSingleEvent(
@@ -42,7 +43,6 @@ export function getRulesActionsForEvent(
         currentEventData,
         allEventsData,
     );
-
     if (rulesEffects) {
         return getRulesActions(rulesEffects, foundation, formId);
     }
@@ -66,5 +66,8 @@ export function getRulesActionsForTEI(
         enrollmentData,
         teiValues,
     );
-    return getRulesActions(rulesEffects, foundation, formId);
+    if (rulesEffects) {
+        return getRulesActions(rulesEffects, foundation, formId);
+    }
+    return null;
 }

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
@@ -6,7 +6,6 @@ import { RulesEngine } from 'capture-core-utils/RulesEngine';
 import { RenderFoundation, Program, TrackerProgram } from '../metaData';
 import inputValueConverter from './converters/inputValueConverter';
 import outputRulesEffectsValueConverter from './converters/rulesEffectsValueConverter';
-import momentConverter from './converters/momentConverter';
 import runRulesForSingleEvent from './runRulesForSingleEvent';
 import runRulesForTEI from './runRulesForTEI';
 import postProcessRulesEffects from './postProcessRulesEffects';
@@ -14,7 +13,7 @@ import { updateRulesEffects } from './rulesEngine.actions';
 
 import type { OutputEffect, EventData, Enrollment, TEIValues } from 'capture-core-utils/RulesEngine/rulesEngine.types';
 
-const rulesEngine = new RulesEngine(inputValueConverter, momentConverter, outputRulesEffectsValueConverter);
+const rulesEngine = new RulesEngine(inputValueConverter, outputRulesEffectsValueConverter);
 
 function getRulesActions(
     rulesEffects: ?Array<OutputEffect>,

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
@@ -3,11 +3,11 @@
  * @module rulesEngineActionsCreator
  */
 import { RenderFoundation, Program, TrackerProgram } from '../metaData';
-import runRulesForSingleEvent from './runRulesForSingleEvent';
+import { prepareForExecution } from './runRulesForSingleEvent';
 import runRulesForTEI from './runRulesForTEI';
 import postProcessRulesEffects from './postProcessRulesEffects';
 import { updateRulesEffects } from './rulesEngine.actions';
-import { RulesEngine } from '../../capture-core-utils/RulesEngine';
+import { RulesEngine, processTypes } from '../../capture-core-utils/RulesEngine';
 import type { OutputEffect, EventData, Enrollment, TEIValues } from '../../capture-core-utils/RulesEngine/rulesEngine.types';
 
 const rulesEngine = new RulesEngine();
@@ -29,14 +29,10 @@ export function getRulesActionsForEvent(
     currentEventData: ?EventData  | {} = {},
     allEventsData: ?Array<EventData>,
 ) {
-    const rulesEffects = runRulesForSingleEvent(
-        rulesEngine,
-        program,
-        foundation,
-        orgUnit,
-        currentEventData,
-        allEventsData,
-    );
+    const { optionSets, dataElementsInProgram, programRulesVariables, programRules, constants } = prepareForExecution(program, foundation);
+    // returns an array of effects that need to take place in the UI.
+    const rulesEffects = rulesEngine.executeRules({ programRulesVariables, programRules, constants }, currentEventData, allEventsData, dataElementsInProgram, null, null, null, orgUnit, optionSets, processTypes.EVENT);
+
     return getRulesActions(rulesEffects, foundation, formId);
 }
 

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
@@ -2,12 +2,12 @@
 /**
  * @module rulesEngineActionsCreator
  */
+import { RulesEngine, processTypes } from '../../capture-core-utils/RulesEngine';
 import { RenderFoundation, Program, TrackerProgram } from '../metaData';
 import { prepareEventData } from './runRulesForSingleEvent';
 import runRulesForTEI from './runRulesForTEI';
 import postProcessRulesEffects from './postProcessRulesEffects';
 import { updateRulesEffects } from './rulesEngine.actions';
-import { RulesEngine, processTypes } from '../../capture-core-utils/RulesEngine';
 import type {
     OutputEffect,
     EventData,

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
@@ -2,9 +2,9 @@
 /**
  * @module rulesEngineActionsCreator
  */
-import { RulesEngine, processTypes } from '../../capture-core-utils/RulesEngine';
+import { RulesEngine } from '../../capture-core-utils/RulesEngine';
 import { RenderFoundation, Program, TrackerProgram } from '../metaData';
-import { prepareEventData } from './runRulesForSingleEvent';
+import runRulesForSingleEvent from './runRulesForSingleEvent';
 import runRulesForTEI from './runRulesForTEI';
 import postProcessRulesEffects from './postProcessRulesEffects';
 import { updateRulesEffects } from './rulesEngine.actions';
@@ -34,23 +34,16 @@ export function getRulesActionsForEvent(
     currentEventData: ?EventData | {} = {},
     allEventsData: ?Array<EventData>,
 ) {
-    const data = prepareEventData(program, foundation);
-    if (data) {
-        const { optionSets, dataElementsInProgram, programRulesVariables, programRules, constants } = data;
-        // returns an array of effects that need to take place in the UI.
-        const rulesEffects = rulesEngine.executeRules(
-            { programRulesVariables, programRules, constants },
-            currentEventData,
-            allEventsData,
-            dataElementsInProgram,
-            null,
-            null,
-            null,
-            orgUnit,
-            optionSets,
-            processTypes.EVENT,
-        );
+    const rulesEffects = runRulesForSingleEvent(
+        rulesEngine,
+        program,
+        foundation,
+        orgUnit,
+        currentEventData,
+        allEventsData,
+    );
 
+    if (rulesEffects) {
         return getRulesActions(rulesEffects, foundation, formId);
     }
     return null;

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
@@ -18,7 +18,7 @@ import type {
 const rulesEngine = new RulesEngine();
 
 function getRulesActions(
-    rulesEffects: ?Array<OutputEffect>,
+    rulesEffects: ?Array<?OutputEffect>,
     foundation: ?RenderFoundation,
     formId: string,
 ) {

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/rulesEngineActionsCreator.js
@@ -46,7 +46,7 @@ export function getRulesActionsForEvent(
     if (rulesEffects) {
         return getRulesActions(rulesEffects, foundation, formId);
     }
-    return null;
+    return [];
 }
 
 export function getRulesActionsForTEI(
@@ -69,5 +69,5 @@ export function getRulesActionsForTEI(
     if (rulesEffects) {
         return getRulesActions(rulesEffects, foundation, formId);
     }
-    return null;
+    return [];
 }

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/runRulesForSingleEvent.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/runRulesForSingleEvent.js
@@ -93,6 +93,7 @@ export default function runRulesForSingleEvent(
     if (!programRules || programRules.length === 0) {
         return null;
     }
+
     const dataElementsInProgram = getDataElements(program);
 
     const optionSets = optionSetsStore.get();

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/runRulesForSingleEvent.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/runRulesForSingleEvent.js
@@ -57,26 +57,19 @@ function getDataElements(program: Program) {
 }
 
 
-export function prepareForExecution(program: ?Program, foundation: ?RenderFoundation) {
-    const error = {
-        optionSets: null,
-        dataElementsInProgram: null,
-        programRulesVariables: null,
-        programRules: null,
-        constants: null,
-    };
+export function prepareEventData(program: ?Program, foundation: ?RenderFoundation) {
     if (!program || !foundation) {
         log.error(errorCreator(errorMessages.PROGRAM_OR_FOUNDATION_MISSING)(
             { program, foundation, method: 'getRulesActionsForEvent' }),
         );
-        return error;
+        return null;
     }
 
     const { programRuleVariables } = program;
     const programRules = [...program.programRules, ...foundation.programRules];
 
     if (!programRules || programRules.length === 0) {
-        return error;
+        return null;
     }
 
     const constants = constantsStore.get();

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/runRulesForSingleEvent.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/runRulesForSingleEvent.js
@@ -93,7 +93,6 @@ export default function runRulesForSingleEvent(
     if (!programRules || programRules.length === 0) {
         return null;
     }
-
     const dataElementsInProgram = getDataElements(program);
 
     const optionSets = optionSetsStore.get();

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/runRulesForSingleEvent.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/runRulesForSingleEvent.js
@@ -98,7 +98,7 @@ export default function runRulesForSingleEvent(
     program: ?Program,
     foundation: ?RenderFoundation,
     orgUnit: OrgUnit,
-    currentEvent: ?InputEvent = {},
+    currentEvent: ?InputEvent,
     allEventsData: ?EventsData) {
     const data = prepare(program, foundation);
 

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/runRulesForSingleEvent.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/runRulesForSingleEvent.js
@@ -1,22 +1,11 @@
 // @flow
 import log from 'loglevel';
 import { RulesEngine, processTypes } from 'capture-core-utils/RulesEngine';
-import type
-{
-    DataElement as DataElementForRulesEngine,
-    EventData,
-} from 'capture-core-utils/RulesEngine/rulesEngine.types';
-
 import { errorCreator } from 'capture-core-utils';
-import {
-    Program,
-    TrackerProgram,
-    EventProgram,
-    RenderFoundation,
-    DataElement,
-} from '../metaData';
+import { Program, TrackerProgram, EventProgram, RenderFoundation, DataElement } from '../metaData';
 import constantsStore from '../metaDataMemoryStores/constants/constants.store';
 import optionSetsStore from '../metaDataMemoryStores/optionSets/optionSets.store';
+import type { DataElement as DataElementForRulesEngine, EventData } from '../../capture-core-utils/RulesEngine/rulesEngine.types';
 
 const errorMessages = {
     PROGRAM_NOT_FOUND: 'Program not found in loadAndExecuteRulesForEvent',

--- a/src/core_modules/capture-core/rulesEngineActionsCreator/runRulesForSingleEvent.js
+++ b/src/core_modules/capture-core/rulesEngineActionsCreator/runRulesForSingleEvent.js
@@ -58,9 +58,17 @@ function getDataElements(program: Program) {
 
 
 export function prepareForExecution(program: ?Program, foundation: ?RenderFoundation) {
-    const error = { optionSets: null, dataElementsInProgram: null, programRulesVariables: null, programRules: null, constants: null };
+    const error = {
+        optionSets: null,
+        dataElementsInProgram: null,
+        programRulesVariables: null,
+        programRules: null,
+        constants: null,
+    };
     if (!program || !foundation) {
-        log.error(errorCreator(errorMessages.PROGRAM_OR_FOUNDATION_MISSING)({ program, foundation, method: 'getRulesActionsForEvent' }));
+        log.error(errorCreator(errorMessages.PROGRAM_OR_FOUNDATION_MISSING)(
+            { program, foundation, method: 'getRulesActionsForEvent' }),
+        );
         return error;
     }
 


### PR DESCRIPTION
hey Joakim good morning! 

Opening this PR which continues what we have started with the RulesEngine. There will be few PRs following probably 3 of the same size which will finalise the refactoring. 
There are few touch points I would like to stress so that reviewing this gets easier.

I am focusing here only in simplifying the signature of the RulesEngine class. That means I mostly move around functions that dont have to exist as parameters on the RulesEngine class. One of those is for instance `dateUtils`. Instead of passing this as an argument to the functions I now import it to the files that is used. After these changes we can call `RulesEngine` class without giving it any parameters which is simplifies the code for the developer who wants to use it.

Another change is that now `executionService` is returning the effects instead of returning some effects that will go through a processor to give us the final effects. This way I aim to hide this implementation detail from the user who is calling the  `executeRules.getEffects` function.

NOTE: We have talked about having the same changes for TEI and separating the functions and having one for TEI and one  for the SingleEvents and this is still the case but will come after this PR since this is the order of the changes I have made in git and I also wanna add tests to the TEI before changing it around :)  

Hope the description helps and makes sense ☮️  