### PR TITLE
chore: fixes error alerts from lgtm tool 01

### DIFF
--- a/src/core_modules/capture-core-utils/storage/StorageController.js
+++ b/src/core_modules/capture-core-utils/storage/StorageController.js
@@ -37,7 +37,7 @@ export default class StorageController {
             throw new Error(StorageController.errorMessages.INVALID_NAME);
         }
 
-        if (!Adapters || !isArray(Adapters || Adapters.length === 0)) {
+        if (!Adapters || !isArray(Adapters) || Adapters.length === 0) {
             throw new Error(StorageController.errorMessages.NO_ADAPTERS_DEFINED);
         }
 

--- a/src/core_modules/capture-core/components/FiltersForTypes/Boolean/BooleanFilter.component.js
+++ b/src/core_modules/capture-core/components/FiltersForTypes/Boolean/BooleanFilter.component.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react';
 import { withStyles } from '@material-ui/core/styles';
-import elementTypes from '../../../metaData/DataElement/elementTypes';
 import D2TrueFalse from '../../FormFields/Generic/D2TrueFalse.component';
 import { orientations } from '../../FormFields/Options/MultiSelectBoxes/multiSelectBoxes.const';
 import { getBooleanFilterData } from './booleanFilterDataGetter';
@@ -16,7 +15,6 @@ const getStyles = (theme: Theme) => ({
 type Value = ?Array<any>;
 
 type Props = {
-    type: $Values<typeof elementTypes>,
     value: Value,
     onCommitValue: (value: Value) => void,
     classes: {
@@ -32,8 +30,8 @@ class BooleanFilter extends Component<Props> implements UpdatableFilterContent<V
         if (!value) {
             return null;
         }
-        const optionSet = this.booleanFieldInstance && this.booleanFieldInstance.optionSet;
-        return getBooleanFilterData(value, this.props.type, optionSet);
+
+        return getBooleanFilterData(value);
     }
 
     onIsValid() { //eslint-disable-line

--- a/src/core_modules/capture-core/components/FiltersForTypes/Numeric/NumericFilter.component.js
+++ b/src/core_modules/capture-core/components/FiltersForTypes/Numeric/NumericFilter.component.js
@@ -96,7 +96,7 @@ class NumericFilter extends Component<Props> implements UpdatableFilterContent<V
     }
 
     static isFilterValid(minValue?: ?string, maxValue?: ?string, type: $Values<typeof elementTypes>) {
-        if (!NumericFilter.validateField(minValue, type).isValid) {
+        if (!NumericFilter.validateField(minValue, type).isValid) || !NumericFilter.validateField(maxValue, type).isValid {
             return false;
         }
 

--- a/src/core_modules/capture-core/components/FiltersForTypes/Numeric/NumericFilter.component.js
+++ b/src/core_modules/capture-core/components/FiltersForTypes/Numeric/NumericFilter.component.js
@@ -96,8 +96,7 @@ class NumericFilter extends Component<Props> implements UpdatableFilterContent<V
     }
 
     static isFilterValid(minValue?: ?string, maxValue?: ?string, type: $Values<typeof elementTypes>) {
-        if (!(NumericFilter.validateField(minValue, type).isValid &&
-            NumericFilter.validateField(minValue, type).isValid)) {
+        if (!NumericFilter.validateField(minValue, type).isValid) {
             return false;
         }
 

--- a/src/core_modules/capture-core/components/FiltersForTypes/Numeric/NumericFilter.component.js
+++ b/src/core_modules/capture-core/components/FiltersForTypes/Numeric/NumericFilter.component.js
@@ -96,7 +96,7 @@ class NumericFilter extends Component<Props> implements UpdatableFilterContent<V
     }
 
     static isFilterValid(minValue?: ?string, maxValue?: ?string, type: $Values<typeof elementTypes>) {
-        if (!NumericFilter.validateField(minValue, type).isValid) || !NumericFilter.validateField(maxValue, type).isValid {
+        if (!NumericFilter.validateField(minValue, type).isValid || !NumericFilter.validateField(maxValue, type).isValid) {
             return false;
         }
 

--- a/src/core_modules/capture-core/components/FormFields/OrgUnitTree/OrgUnitTree.component.js
+++ b/src/core_modules/capture-core/components/FormFields/OrgUnitTree/OrgUnitTree.component.js
@@ -84,6 +84,7 @@ export default class OrgUnitTree extends React.Component {
 
                   const items = [];
                   /* eslint-disable no-unused-vars */
+                  // todo this would need to be taked care of (report lgtm)
                   for (const [k, v] of units.entries()) {
                       const { value: selectedPath } = this.props;
                       const children = v.children.valuesContainerMap.size > 0 ? [] : null;

--- a/src/core_modules/capture-core/components/FormFields/UserField/Search.component.js
+++ b/src/core_modules/capture-core/components/FormFields/UserField/Search.component.js
@@ -102,6 +102,7 @@ class UserSearch extends React.Component<Props, State> {
         });
     }
 
+    // suggestionsError is never been used (report lgmt)
     setSuggestionsError(message: string) {
         this.setState({
             suggestionsError: message,

--- a/src/core_modules/capture-core/components/Pages/EditEvent/EditEvent.component.js
+++ b/src/core_modules/capture-core/components/Pages/EditEvent/EditEvent.component.js
@@ -47,16 +47,9 @@ type Props = {
     },
 };
 
-type State = {
-    discardWarningOpen: boolean,
-}
 
-class EditEvent extends Component<Props, State> {
+class EditEvent extends Component<Props> {
     cancelButtonInstance: ?CancelButton;
-    constructor(props: Props) {
-        super(props);
-        this.state = { discardWarningOpen: false };
-    }
 
     handleGoBackToAllEvents = () => {
         this.cancelButtonInstance && this.cancelButtonInstance.handleCancel();

--- a/src/core_modules/capture-core/components/Pages/MainPage/EventsList/AddWorkingListConfigDialog/AddWorkingListConfigDialog.container.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/EventsList/AddWorkingListConfigDialog/AddWorkingListConfigDialog.container.js
@@ -7,6 +7,7 @@ const mapStateToProps = () => ({});
 
 const mapDispatchToProps = (dispatch: ReduxDispatch) => ({
     onAddWorkingListConfig: (name: string, description: string) => {
+        // todo addWorkingListConfig is not a function (report lgtm).
         dispatch(addWorkingListConfig(name, description));
     },
 });

--- a/src/core_modules/capture-core/components/Pages/MainPage/WorkingLists/epics/templates.epics.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/WorkingLists/epics/templates.epics.js
@@ -29,7 +29,7 @@ export const retrieveTemplatesEpic = (action$: InputObservable, store: ReduxStor
             const programId = store.getState().currentSelections.programId;
             const promise = getTemplatesAsync(store.getState())
                 .then(container => batchActions([
-                    selectTemplate(container.default.id, listId, container.default),
+                    selectTemplate(container.default.id, listId),
                     fetchTemplatesSuccess(container.workingListConfigs, programId, listId),
                 ], batchActionTypes.TEMPLATES_FETCH_SUCCESS_BATCH))
                 .catch((error) => {

--- a/src/core_modules/capture-core/components/Pages/NewEnrollment/DataEntry/actions/dataEntry.actionBatchs.js
+++ b/src/core_modules/capture-core/components/Pages/NewEnrollment/DataEntry/actions/dataEntry.actionBatchs.js
@@ -23,6 +23,7 @@ export const updateFieldBatch = (
         innerAction,
         ...filterActionsToBeExecuted,
         startRunRulesPostUpdateField(dataEntryId, itemId, uid),
+        // todo this is undefined (lgtm)
         startRunRulesOnUpdateForNewEnrollment(innerAction.payload, filterActions, uid),
     ], batchActionTypes.UPDATE_FIELD_NEW_ENROLLMENT_ACTION_BATCH);
 };
@@ -43,6 +44,7 @@ export const asyncUpdateSuccessBatch = (
         innerAction,
         ...filterActionsToBeExecuted,
         startRunRulesPostUpdateField(dataEntryId, itemId, uid),
+        // todo this is undefined (lgtm)
         startRunRulesOnUpdateForNewEnrollment({ ...innerAction.payload, dataEntryId, itemId }, filterActions, uid),
     ], batchActionTypes.UPDATE_FIELD_NEW_ENROLLMENT_ACTION_BATCH);
 };

--- a/src/core_modules/capture-core/components/Pages/NewEvent/DataEntryWrapper/NewEventDataEntryWrapper.component.js
+++ b/src/core_modules/capture-core/components/Pages/NewEvent/DataEntryWrapper/NewEventDataEntryWrapper.component.js
@@ -47,17 +47,9 @@ type Props = {
     stage: ?ProgramStage,
 }
 
-type State = {
-    discardWarningOpen: boolean,
-}
 
-class NewEventDataEntryWrapper extends React.Component<Props, State> {
+class NewEventDataEntryWrapper extends React.Component<Props> {
     cancelButtonInstance: ?any;
-
-    constructor(props: Props) {
-        super(props);
-        this.state = { discardWarningOpen: false };
-    }
 
     handleGoBackToAllEvents = () => {
         this.cancelButtonInstance && this.cancelButtonInstance.handleCancel();

--- a/src/core_modules/capture-core/components/Pages/NewEvent/SelectionsComplete/SelectionsComplete.component.js
+++ b/src/core_modules/capture-core/components/Pages/NewEvent/SelectionsComplete/SelectionsComplete.component.js
@@ -6,7 +6,7 @@ import NewRelationshipWrapper from '../NewRelationshipWrapper/NewEventNewRelatio
 import SelectionsNoAccess from '../SelectionsNoAccess/dataEntrySelectionsNoAccess.container';
 
 
-const getStyles = (theme: Theme) => ({
+const getStyles = () => ({
     container: {
         padding: '10px 24px 24px 24px',
     },
@@ -23,17 +23,7 @@ type Props = {
     },
 };
 
-type State = {
-    discardWarningOpen: boolean,
-}
-
-class SelectionsComplete extends Component<Props, State> {
-    cancelButtonInstance: ?any;
-
-    constructor(props: Props) {
-        super(props);
-        this.state = { discardWarningOpen: false };
-    }
+class SelectionsComplete extends Component<Props> {
     render() {
         const { classes, showAddRelationship, eventAccess } = this.props;
         if (!eventAccess.write) {

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/dataEntry.epics.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/dataEntry.epics.js
@@ -43,7 +43,7 @@ export const openNewRelationshipRegisterTeiDataEntryEpic = (action$: InputObserv
 
                 const openEnrollmentPromise = openDataEntryForNewEnrollmentBatchAsync(
                     trackerProgram,
-                    trackerProgram && trackerProgram.enrollment.enrollmentForm,
+                    trackerProgram.enrollment.enrollmentForm,
                     orgUnit,
                     DATA_ENTRY_ID,
                     [openDataEntry()],

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/TrackedEntityInstance/tei.selectors.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/TrackedEntityInstance/tei.selectors.js
@@ -18,6 +18,6 @@ export const makeTeiRegistrationMetadataSelector = () => createSelector(
             return null;
         }
 
-        return TEType && TEType.teiRegistration;
+        return TEType.teiRegistration;
     },
 );

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/open.epics.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/open.epics.js
@@ -80,7 +80,7 @@ export const openNewRelationshipRegisterTeiEpic = (action$: InputObservable, sto
             if (trackerProgram) { // enrollment form
                 const openEnrollmentPromise = openDataEntryForNewEnrollmentBatchAsync(
                     trackerProgram,
-                    trackerProgram && trackerProgram.enrollment.enrollmentForm,
+                    trackerProgram.enrollment.enrollmentForm,
                     orgUnit,
                     DATA_ENTRY_ID,
                     [initializeRegisterTei(trackerProgram.id, orgUnit)],

--- a/src/core_modules/capture-core/components/Pages/ViewEvent/ViewEvent.component.js
+++ b/src/core_modules/capture-core/components/Pages/ViewEvent/ViewEvent.component.js
@@ -44,6 +44,7 @@ type Props = {
     onBackToAllEvents: () => void,
     currentDataEntryKey: string,
     programStage: ProgramStage,
+    eventAccess: { read: boolean, write: boolean },
     classes: {
         container: string,
         contentContainer: string,
@@ -53,16 +54,8 @@ type Props = {
     },
 };
 
-type State = {
-    discardWarningOpen: boolean,
-}
 
-class ViewEvent extends Component<Props, State> {
-    constructor(props: Props) {
-        super(props);
-        this.state = { discardWarningOpen: false };
-    }
-
+class ViewEvent extends Component<Props> {
     handleGoBackToAllEvents = () => {
         this.props.onBackToAllEvents();
     }

--- a/src/core_modules/capture-core/components/QuickSelector/Program/CategorySelector.component.js
+++ b/src/core_modules/capture-core/components/QuickSelector/Program/CategorySelector.component.js
@@ -82,6 +82,7 @@ class CategorySelector extends React.Component<Props, State> {
             prevOrgUnitId: null,
         };
         this.onSelectSelector = makeOnSelectSelector();
+        // todo you cannot setState from this component (lgtm report)
         this.loadCagoryOptions(this.props);
     }
 

--- a/src/core_modules/capture-core/rules/engine/services/VariableService/VariableService.js
+++ b/src/core_modules/capture-core/rules/engine/services/VariableService/VariableService.js
@@ -541,14 +541,14 @@ export default class VariableService {
             );
 
             variables.enrollment_count = this.buildVariable(
-                selectedEnrollment ? 1 : 0,
+                1,
                 typeKeys.INTEGER, {
                     variablePrefix: variablePrefixes.CONTEXT_VARIABLE,
                 },
             );
 
             variables.tei_count = this.buildVariable(
-                selectedEnrollment ? 1 : 0,
+                1,
                 typeKeys.INTEGER, {
                     variablePrefix: variablePrefixes.CONTEXT_VARIABLE,
                 },

--- a/src/core_modules/capture-ui/internal/AgeInput/AgeNumberInput.component.js
+++ b/src/core_modules/capture-ui/internal/AgeInput/AgeNumberInput.component.js
@@ -16,13 +16,12 @@ type Props = {
 
 type State = {
     focus?: ?boolean,
-    hasValue?: ?boolean,
 }
 
 class AgeNumberInput extends Component<Props, State> {
     constructor(props) {
         super(props);
-        this.state = {};
+        this.state = { focus: false };
     }
     handleBlur = (event) => {
         this.props.onBlur(event.currentTarget.value);


### PR DESCRIPTION
hey @JoakimSM as we talked about some time ago. 

## What is this PR?
I am opening this PR to fix some lgmt errors. In this series of PRs the goal is to have `eslint` checking our PRs so that if any error occurs that is `eslint` related the github checkers will spot it for us. This will include only errors and not warnings.

I am not intending to change any `eslint` rules, I will simply fix the `errors` that are being reported if any. This step is necessary so that we can then add the `eslint` check in our CI/CD pipeline.  `eslint` then will be checking our codebase for any errors and if there are none then it will give us a success or else will throw an error. The motivation is that we will have a more cohesive style on the code and that devs will not spent time looking into linting errors on PRs and will focus on reviewing the logic of a feature, the readability and so on. 

## What is he bigger picture of the stacked PRs. 

This is gonna be 4 stacked PRs. 

 - The first will fix most of lgtm errors
 - The second will fix most of lgmt warnings
 - The third will fix eslint errors 
 - The fourth will add a script on our pipeline to check for `eslint` errors. Something between the lines `eslint src/*.js`


Please let me know if I could do anything differently. 