### PR TITLE
fix: re-adds env dev file

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,7 @@
+# Default admin/district authorization for development
+REACT_APP_DHIS2_BASE_URL="http://localhost:8080/dhis"
+REACT_APP_DHIS2_AUTHORIZATION="Basic c3lzdGVtOlN5c3RlbTEyMw=="
+REACT_APP_TRACKER_CAPTURE_APP_PATH="http://localhost:8080/dhis/dhis-web-tracker-capture"
+#admin: YWRtaW46ZGlzdHJpY3Q=
+#system: c3lzdGVtOlN5c3RlbTEyMw==
+#tracker: dHJhY2tlcjpUcmFja2VyMTIz

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn extract-pot && git add -A ."
+      "pre-commit": "yarn extract-pot && git add ./i18n/"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Hey Joakim! This adds back the `env.developement`. Also would change the auto commit on the branch `v33`. This was original the reason why I went into the loop of thinking that I reversed the auto-committed changes that the `.env` file had and instead I deleted it. 😅 

Thanks for caching this, I would never have seen it. 

