### PR TITLE
21 fix: bug on search with range values

### DIFF
--- a/cypress/integration/NewEvent.feature
+++ b/cypress/integration/NewEvent.feature
@@ -22,3 +22,12 @@ And you navigate to find a person relationship
 And you search for an existing unique id and link to the person
 And you submit the event form with the associated relationship to the already existing person
 Then the event and relationship should be sent to the server successfully
+
+Scenario: User searches with range values while trying to link a new event to an existing person
+Given you open the the new event page in Ngelehun and malaria case context
+When you navigate to find a person relationship
+And you select search scope TB program
+And you expand the attributes search area
+And you fill in the zip code range numbers
+And you click search
+Then you can see the first page of the results

--- a/cypress/integration/NewEvent/index.js
+++ b/cypress/integration/NewEvent/index.js
@@ -167,3 +167,45 @@ Then('the event and relationship should be sent to the server successfully', () 
             });
     });
 });
+
+When('you select search scope TB program', () => {
+    cy.get('[data-test="dhis2-capture-virtualized-select"]')
+        .click()
+        .contains('TB prog')
+        .click();
+});
+
+And('you expand the attributes search area', () => {
+    cy.get('[data-test="dhis2-capture-collapsible-button"]')
+        .eq(4)
+        .click();
+});
+
+And('you fill in the zip code range numbers', () => {
+    cy.get('[data-test="dhis2-capture-d2-form-area"]')
+        .find('[data-test="capture-ui-input"]')
+        .eq(5)
+        .type('7130')
+        .blur();
+
+    cy.get('[data-test="dhis2-capture-d2-form-area"]')
+        .find('[data-test="capture-ui-input"]')
+        .eq(6)
+        .type('7135')
+        .blur();
+});
+
+And('you click search', () => {
+    cy.get('[data-test="dhis2-capture-d2-form-area"]')
+        .find('button')
+        .click();
+});
+
+Then('you can see the first page of the results', () => {
+    cy.get('[data-test="dhis2-capture-card-list-item"]')
+        .should('have.length.greaterThan', 0);
+    cy.get('[data-test="dhis2-capture-pagination"]')
+        .contains('Page 1')
+        .should('exist');
+});
+

--- a/cypress/integration/SearchPage.feature
+++ b/cypress/integration/SearchPage.feature
@@ -158,3 +158,26 @@ Feature: User interacts with Search page
     When you click search
     Then you can see the first page of the results
     And the next page button is disabled
+
+  Scenario: Searching using only date range values as attributes
+    Given you are in the search page with the Adult Woman being preselected from the url
+    When you fill in the date of birth
+    And you click search
+    Then you can see the first page of the results
+    
+  Scenario: Searching using zip code range values as attributes
+    Given you are in the search page with the TB program being preselected from the url
+    When you expand the attributes search area
+    And you fill in the zip code range numbers
+    And you click search
+    Then you can see the first page of the results
+
+  Scenario: Searching using zip code range and name values as attributes
+    Given you are in the search page with the TB program being preselected from the url
+    When you expand the attributes search area
+    And you fill in the zip code range numbers
+    And you fill in the first name
+    And you click search
+    Then you can see the first page of the results
+
+

--- a/cypress/integration/SearchPage/index.js
+++ b/cypress/integration/SearchPage/index.js
@@ -234,7 +234,7 @@ Then('you can see the first page of the results', () => {
         .should('exist');
     cy.get('[data-test="dhis2-capture-card-list-item"]')
         .should('have.length.greaterThan', 0);
-    cy.get('[data-test="dhis2-capture-search-results-pagination"]')
+    cy.get('[data-test="dhis2-capture-pagination"]')
         .contains('Page 1')
         .should('exist');
 });
@@ -264,7 +264,7 @@ Then('you can see the second page of the results', () => {
         .should('exist');
     cy.get('[data-test="dhis2-capture-card-list-item"]')
         .should('have.length.greaterThan', 0);
-    cy.get('[data-test="dhis2-capture-search-results-pagination"]')
+    cy.get('[data-test="dhis2-capture-pagination"]')
         .contains('Page 2')
         .should('exist');
 });
@@ -283,4 +283,46 @@ When('you remove the Child Programme selection', () => {
 Then('you still can see the Malaria case diagnosis being selected', () => {
     cy.get('[data-test="dhis2-capture-search-page-content"]')
         .contains('Malaria case diagnosis');
+});
+
+Given('you are in the search page with the Adult Woman being preselected from the url', () => {
+    cy.visit('/#/search/programId=uy2gU8kT1jF&orgUnitId=DiszpKrYNg8');
+});
+
+When('you fill in the date of birth', () => {
+    cy.get('[data-test="dhis2-capture-form-attributes"]')
+        .find('[data-test="capture-ui-input"]')
+        .eq(2)
+        .type('1999-09-01')
+        .blur();
+    cy.get('[data-test="dhis2-capture-form-attributes"]')
+        .find('[data-test="capture-ui-input"]')
+        .eq(3)
+        .type('2020-01-01')
+        .blur();
+});
+
+Given('you are in the search page with the TB program being preselected from the url', () => {
+    cy.visit('/#/search/programId=ur1Edk5Oe2n&orgUnitId=DiszpKrYNg8');
+});
+
+When('you fill in the zip code range numbers', () => {
+    cy.get('[data-test="dhis2-capture-form-attributes"]')
+        .find('[data-test="capture-ui-input"]')
+        .eq(5)
+        .type('7130')
+        .blur();
+    cy.get('[data-test="dhis2-capture-form-attributes"]')
+        .find('[data-test="capture-ui-input"]')
+        .eq(6)
+        .type('7135')
+        .blur();
+});
+
+When('you fill in the first name', () => {
+    cy.get('[data-test="dhis2-capture-form-attributes"]')
+        .find('[data-test="capture-ui-input"]')
+        .eq(0)
+        .type('Lid')
+        .blur();
 });

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-23T10:38:31.011Z\n"
-"PO-Revision-Date: 2020-09-23T10:38:31.011Z\n"
+"POT-Creation-Date: 2020-09-22T10:30:44.432Z\n"
+"PO-Revision-Date: 2020-09-22T10:30:44.432Z\n"
 
 msgid "Choose one or more dates..."
 msgstr ""
@@ -27,6 +27,12 @@ msgid ""
 "Currently, the Capture App only supports running one version concurrently "
 "(in the same domain). Please refresh this page if you would like to use "
 "this version again, but be aware that this will close other versions."
+msgstr ""
+
+msgid "Organisation unit"
+msgstr ""
+
+msgid "Date of enrollment"
 msgstr ""
 
 msgid "Last updated"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-10-06T17:22:52.646Z\n"
-"PO-Revision-Date: 2020-10-06T17:22:52.646Z\n"
+"POT-Creation-Date: 2020-09-23T10:38:31.011Z\n"
+"PO-Revision-Date: 2020-09-23T10:38:31.011Z\n"
 
 msgid "Choose one or more dates..."
 msgstr ""
@@ -677,9 +677,6 @@ msgstr ""
 msgid "No {{trackedEntityTypeName}} found."
 msgstr ""
 
-msgid "{{teiCount}} results found for"
-msgstr ""
-
 msgid "New search"
 msgstr ""
 
@@ -744,9 +741,6 @@ msgstr ""
 msgid "Re-enroll"
 msgstr ""
 
-msgid "Result(s) found for term(s)"
-msgstr ""
-
 msgid "You dont have access to edit this event"
 msgstr ""
 
@@ -774,6 +768,9 @@ msgid "You dont have access to create any relationships"
 msgstr ""
 
 msgid "Add relationship"
+msgstr ""
+
+msgid "Results found"
 msgstr ""
 
 msgid "Selected program"

--- a/src/core_modules/capture-core/components/CardList/CardList.component.js
+++ b/src/core_modules/capture-core/components/CardList/CardList.component.js
@@ -9,11 +9,10 @@ import type { CardDataElementsInformation, SearchResultItem } from '../Pages/Sea
 type OwnProps = $ReadOnly<{|
     dataElements: CardDataElementsInformation,
     items: Array<SearchResultItem>,
+    currentProgramId: ?string,
     currentSearchScopeName?: string,
-    getCustomItemTopElements?: ?(itemProps: Object) => Element<any>,
-    getCustomItemBottomElements?: ?(itemProps: Object) => Element<any>,
-    currentProgramId?: string,
     noItemsText?: string,
+    getCustomItemBottomElements?: (itemProps: Object) => Element<any>,
 |}>
 
 const getStyles = (theme: Theme) => ({
@@ -27,13 +26,12 @@ const CardListIndex = ({
     classes,
     items,
     getCustomItemBottomElements,
-    getCustomItemTopElements,
     dataElements,
     noItemsText,
     currentProgramId,
     currentSearchScopeName,
 }: OwnProps & CssClasses) => {
-    const { imageDataElement } = makeElementsContainerSelector()(dataElements);
+    const { profileImageDataElement, dataElementsExceptProfileImage } = makeElementsContainerSelector()(dataElements);
     return (
         <>
             {
@@ -49,10 +47,9 @@ const CardListIndex = ({
                             item={item}
                             currentSearchScopeName={currentSearchScopeName}
                             currentProgramId={currentProgramId}
-                            getCustomTopElements={getCustomItemTopElements}
                             getCustomBottomElements={getCustomItemBottomElements}
-                            imageDataElement={imageDataElement}
-                            dataElements={dataElements}
+                            profileImageDataElement={profileImageDataElement}
+                            dataElements={dataElementsExceptProfileImage}
                         />
                     ))
             }

--- a/src/core_modules/capture-core/components/CardList/CardList.selectors.js
+++ b/src/core_modules/capture-core/components/CardList/CardList.selectors.js
@@ -10,15 +10,15 @@ export const makeElementsContainerSelector = () => createSelector(
     elementsSelector,
     (elements) => {
         // $FlowFixMe[prop-missing] automated comment
-        const imageDataElement = elements.find(a => a.type === elementTypes.IMAGE);
-        if (imageDataElement) {
-            const newElements = [...elements];
-            newElements.splice(newElements.indexOf(imageDataElement), 1);
+        const profileImageDataElement = elements.find(a => a.type === elementTypes.IMAGE);
+        const newElements = [...elements];
+        if (profileImageDataElement) {
+            newElements.splice(newElements.indexOf(profileImageDataElement), 1);
         }
 
         return {
-            dataElements: elements,
-            imageDataElement,
+            dataElementsExceptProfileImage: newElements,
+            profileImageDataElement,
         };
     });
 

--- a/src/core_modules/capture-core/components/CardList/ListEntry.component.js
+++ b/src/core_modules/capture-core/components/CardList/ListEntry.component.js
@@ -1,11 +1,14 @@
 // @flow
-import React from 'react';
+import React, { type ComponentType } from 'react';
 import { withStyles } from '@material-ui/core';
 import { colors } from '@dhis2/ui-core';
+import { convertValue } from '../../converters/clientToView';
+import { dataElementTypes } from '../../metaData';
 
 type Props = {|
   name: string,
-  value: string
+  value: string,
+  type?: $Values<typeof dataElementTypes>
 |}
 
 const getStyles = (theme: Theme) => ({
@@ -24,13 +27,20 @@ const getStyles = (theme: Theme) => ({
     },
 });
 
-export const ListEntry =
-   withStyles(getStyles)(({ name, value, classes }: Props & CssClasses) => (
-       <div className={classes.entry}>
-           <span className={classes.elementName}>
-               {name}:&nbsp;
-           </span>
-           <span className={classes.elementValue}>
-               {value}
-           </span>
-       </div>));
+const ListEntryPlain = ({
+    name,
+    value,
+    classes,
+    // $FlowFixMe[prop-missing] automated comment
+    type = dataElementTypes.TEXT,
+}: Props & CssClasses) => (
+    <div className={classes.entry}>
+        <span className={classes.elementName}>
+            {name}:&nbsp;
+        </span>
+        <span className={classes.elementValue}>
+            {convertValue(value, type)}
+        </span>
+    </div>);
+
+export const ListEntry: ComponentType<Props> = withStyles(getStyles)(ListEntryPlain);

--- a/src/core_modules/capture-core/components/FormFields/Options/SelectVirtualizedV2/OptionsSelectVirtualized.component.js
+++ b/src/core_modules/capture-core/components/FormFields/Options/SelectVirtualizedV2/OptionsSelectVirtualized.component.js
@@ -228,6 +228,7 @@ class OptionsSelectVirtualized extends React.Component<Props, State> {
         const menuContainerStyle = { ...OptionsSelectVirtualized.defaultMenuContainerStyle, ...menuStyle };
         return (
             <div
+                data-test="dhis2-capture-virtualized-select"
                 ref={(containerInstance) => { this.materialUIContainerInstance = containerInstance; }}
             >
                 <div

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/UniqueTEADuplicate/ExistingTEIContents.component.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/UniqueTEADuplicate/ExistingTEIContents.component.js
@@ -13,6 +13,7 @@ type Props = {
     dataElements: CardDataElementsInformation,
     onLink: (values: Object) => void,
     onCancel: Function,
+    programId: ?string,
 };
 
 class ExistingTEIContents extends React.Component<Props> {
@@ -20,7 +21,7 @@ class ExistingTEIContents extends React.Component<Props> {
         this.props.onLink(this.props.attributeValues);
     }
     render() {
-        const { attributeValues, dataElements, onCancel } = this.props;
+        const { attributeValues, dataElements, onCancel, programId } = this.props;
 
         const items = [
             {
@@ -36,6 +37,7 @@ class ExistingTEIContents extends React.Component<Props> {
                         {i18n.t('Registered person')}
                     </DialogTitle>
                     <CardList
+                        currentProgramId={programId}
                         items={items}
                         dataElements={dataElements}
                     />

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/UniqueTEADuplicate/ExistingTEIContents.container.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/UniqueTEADuplicate/ExistingTEIContents.container.js
@@ -10,6 +10,7 @@ const makeMapStateToProps = () => {
         const dataElements = dataElementsSelector(props);
         const attributeValues = clientValuesSelector(props, dataElements);
         return {
+            programId: state.newRelationshipRegisterTei.programId,
             dataElements,
             attributeValues,
         };

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/UniqueTEADuplicate/ExistingTEILoader.component.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/UniqueTEADuplicate/ExistingTEILoader.component.js
@@ -87,6 +87,7 @@ class ExistingTEILoader extends React.Component<Props, State> {
                     `trackedEntityInstances/${id}`,
                     {
                         program: programId,
+                        fields: '*',
                     },
                 ),
         );

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/GeneralOutput/WarningsSection/SearchGroupDuplicate/ReviewDialog.component.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/GeneralOutput/WarningsSection/SearchGroupDuplicate/ReviewDialog.component.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { withStyles } from '@material-ui/core';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
-import ReviewDialogContents from './ReviewDialogContents.container';
+import { ReviewDialogContents } from './ReviewDialogContents.container';
 
 type Props = {
     open: boolean,

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/GeneralOutput/WarningsSection/SearchGroupDuplicate/ReviewDialogContents.component.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/GeneralOutput/WarningsSection/SearchGroupDuplicate/ReviewDialogContents.component.js
@@ -22,6 +22,7 @@ const getStyles = (theme: Theme) => ({
 });
 
 type Props = {
+    currentProgramId: ?string,
     dataElements: Array<DataElement>,
     teis: Array<{id: string, values: Object}>,
     onLink: Function,
@@ -29,7 +30,7 @@ type Props = {
     isUpdating: boolean,
 };
 
-class ReviewDialogContents extends React.Component<Props> {
+class ReviewDialogContentsPlain extends React.Component<Props> {
     getLinkButton = (itemProps: Object) => {
         const { onLink, classes } = this.props;
         const { id, values } = itemProps.item;
@@ -47,7 +48,7 @@ class ReviewDialogContents extends React.Component<Props> {
     }
 
     render() {
-        const { dataElements, teis, isUpdating, classes } = this.props;
+        const { dataElements, teis, isUpdating, classes, currentProgramId } = this.props;
 
         return (
             <React.Fragment>
@@ -57,6 +58,7 @@ class ReviewDialogContents extends React.Component<Props> {
                     </DialogTitle>
                     <CardListWithLoadingIndicator
                         noItemsText={i18n.t('No results found')}
+                        currentProgramId={currentProgramId}
                         isUpdating={isUpdating}
                         items={teis}
                         dataElements={dataElements}
@@ -69,4 +71,4 @@ class ReviewDialogContents extends React.Component<Props> {
     }
 }
 
-export default withStyles(getStyles)(ReviewDialogContents);
+export const ReviewDialogContentsComponent = withStyles(getStyles)(ReviewDialogContentsPlain);

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/GeneralOutput/WarningsSection/SearchGroupDuplicate/ReviewDialogContents.container.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/GeneralOutput/WarningsSection/SearchGroupDuplicate/ReviewDialogContents.container.js
@@ -1,7 +1,7 @@
 // @flow
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import ReviewDialogContents from './ReviewDialogContents.component';
+import { ReviewDialogContentsComponent } from './ReviewDialogContents.component';
 import withLoadingIndicator from '../../../../../../../HOC/withLoadingIndicator';
 import withErrorMessageHandler from '../../../../../../../HOC/withErrorMessageHandler';
 import { makeDataElementsSelector } from './reviewDialogContents.selectors';
@@ -9,6 +9,7 @@ import { makeDataElementsSelector } from './reviewDialogContents.selectors';
 const makeMapStateToProps = () => {
     const dataElementsSelector = makeDataElementsSelector();
     const mapStateToProps = (state: ReduxState, props: Object) => ({
+        currentProgramId: state.newRelationshipRegisterTei.programId,
         ready: !state.newRelationshipRegisterTeiDuplicatesReview.isLoading,
         isUpdating: state.newRelationshipRegisterTeiDuplicatesReview.isUpdating,
         error: state.newRelationshipRegisterTeiDuplicatesReview.loadError ?
@@ -24,10 +25,10 @@ const mapDispatchToProps = () => ({
 });
 
 // $FlowFixMe
-export default connect(makeMapStateToProps, mapDispatchToProps)(
+export const ReviewDialogContents = connect(makeMapStateToProps, mapDispatchToProps)(
     withLoadingIndicator(() => ({ padding: 5, width: 640, height: 500 }))(
         withErrorMessageHandler()(
-            ReviewDialogContents,
+            ReviewDialogContentsComponent,
         ),
     ),
 );

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/GeneralOutput/WarningsSection/SearchGroupDuplicate/searchGroupDuplicate.epics.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/GeneralOutput/WarningsSection/SearchGroupDuplicate/searchGroupDuplicate.epics.js
@@ -72,6 +72,7 @@ export const loadSearchGroupDuplicatesForReviewEpic = (action$: InputObservable,
                 pageSize: 5,
                 page: requestPage,
                 filter: filters,
+                fields: '*',
                 ...contextParam,
             };
             const attributes = contextParam.program ?

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/TeiRelationship/SearchResults/TeiRelationshipSearchResults.component.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/TeiRelationship/SearchResults/TeiRelationshipSearchResults.component.js
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import i18n from '@dhis2/d2-i18n';
-import { pipe } from 'capture-core-utils';
 import { withStyles } from '@material-ui/core';
 import { Pagination } from 'capture-ui';
 import withNavigation from '../../../../Pagination/withDefaultNavigation';
@@ -10,15 +9,8 @@ import Button from '../../../../Buttons/Button.component';
 import makeAttributesSelector from './teiRelationshipSearchResults.selectors';
 import { CardList } from '../../../../CardList';
 import { LoadingMask } from '../../../../LoadingMasks';
-import {
-    convertFormToClient,
-    convertClientToList,
-} from '../../../../../converters';
-
-const formToListConverterFn = pipe(
-    convertFormToClient,
-    convertClientToList,
-);
+import type { CurrentSearchTerms } from '../../../Search/SearchForm/SearchForm.types';
+import { SearchResultsHeader } from '../../../../SearchResultsHeader';
 
 const SearchResultsPager = withNavigation()(Pagination);
 
@@ -115,42 +107,23 @@ class TeiRelationshipSearchResults extends React.Component<Props> {
         );
     }
 
-    getSearchValues = () => {
-        const { searchValues, searchGroup, teis, classes } = this.props;
+    getSearchValues = (): CurrentSearchTerms => {
+        const { searchValues, searchGroup } = this.props;
         const searchForm = searchGroup.searchForm;
-        const attributeValues = Object.keys(searchValues)
+        return Object.keys(searchValues)
             .filter(key => searchValues[key] !== null)
             .map((key) => {
                 const element = searchForm.getElement(key);
                 const value = searchValues[key];
-                const listValue = element.convertValue(value, formToListConverterFn);
-                return (
-                    <span key={key}>
-                        {element.formName}: {listValue}
-                    </span>
-                );
-            }).reduce((accValues, value) => {
-                if (accValues.length > 0) return [...accValues, ', ', value];
-                return [' ', value];
-            }, []);
-
-        const text = i18n.t('{{teiCount}} results found for', {
-            teiCount: teis.length,
-        });
-
-        return (
-            <div className={classes.topSectionValuesContainer}>
-                {text}
-                {attributeValues}
-            </div>
-        );
+                return { name: element.formName, value, id: element.id, type: element.type };
+            });
     }
 
     renderTopSection = () => {
         const { onNewSearch, onEditSearch, classes } = this.props;
         return (
             <div className={classes.topSection}>
-                {this.getSearchValues()}
+                <SearchResultsHeader currentSearchTerms={this.getSearchValues()} />
                 <div>
                     <Button className={classes.actionButton} onClick={onNewSearch}>
                         {i18n.t('New search')}

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/TeiRelationship/SearchResults/TeiRelationshipSearchResults.component.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/TeiRelationship/SearchResults/TeiRelationshipSearchResults.component.js
@@ -23,6 +23,7 @@ type Props = {
     onChangePage: (page: number) => void,
     onAddRelationship: (id: string, values: Object) => void,
     trackedEntityTypeName: string,
+    selectedProgramId: ?string,
     classes: {
         itemActionsContainer: string,
         addRelationshipButton: string,
@@ -92,11 +93,13 @@ class TeiRelationshipSearchResults extends React.Component<Props> {
 
     renderResults = () => {
         const attributes = this.getAttributes(this.props);
-        const { teis, trackedEntityTypeName } = this.props;
+        const { teis, trackedEntityTypeName, selectedProgramId } = this.props;
+
         return (
             <React.Fragment>
                 {this.renderTopSection()}
                 <CardList
+                    currentProgramId={selectedProgramId}
                     items={teis}
                     dataElements={attributes}
                     noItemsText={i18n.t('No {{trackedEntityTypeName}} found.', { trackedEntityTypeName })}

--- a/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.container.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.container.js
@@ -1,6 +1,7 @@
 // @flow
 import { connect } from 'react-redux';
 import type { ComponentType } from 'react';
+import { isObject, isString } from 'd2-utilizr/src';
 import { SearchFormComponent } from './SearchForm.component';
 import type { CurrentSearchTerms, DispatchersFromRedux, OwnProps, Props, PropsFromRedux } from './SearchForm.types';
 import {
@@ -13,7 +14,24 @@ import {
 import { actionCreator } from '../../../../actions/actions.utils';
 import { addFormData, removeFormData } from '../../../D2Form/actions/form.actions';
 
-const isValueContainingCharacter = string => string.replace(/\s/g, '').length;
+const isValueContainingCharacter = (value: any) => {
+    if (!value) {
+        return false;
+    }
+    if (isString(value)) {
+        return Boolean(value.replace(/\s/g, '').length);
+    }
+
+    if (isObject(value)) {
+        const numberOfValuesWithLength = Object.values(value)
+            .filter(v => isString(v))
+            .filter((v: any) => Boolean(v.replace(/\s/g, '').length))
+            .length;
+
+        return Boolean(numberOfValuesWithLength === Object.keys(value).length);
+    }
+    return true;
+};
 
 const collectCurrentSearchTerms = (searchGroupsForSelectedScope, formsValues): CurrentSearchTerms => {
     const { searchForm: attributeSearchForm, formId } = searchGroupsForSelectedScope
@@ -27,16 +45,16 @@ const collectCurrentSearchTerms = (searchGroupsForSelectedScope, formsValues): C
     const searchTerms = formsValues[formId] || {};
     return Object.keys(searchTerms)
         .reduce((accumulated, attributeValueKey) => {
-            const { name, id } = attributeSearchForm.getElement(attributeValueKey);
+            const { name, id, type } = attributeSearchForm.getElement(attributeValueKey);
             const value = searchTerms[attributeValueKey];
             if (isValueContainingCharacter(value)) {
-                return [...accumulated, { name, value, id }];
+                return [...accumulated, { name, value, id, type }];
             }
             return accumulated;
         }, []);
 };
 
-const mapStateToProps = (state: ReduxState): PropsFromRedux => {
+const mapStateToProps = (state: ReduxState, { searchGroupsForSelectedScope }: OwnProps): PropsFromRedux => {
     const {
         formsValues,
         searchPage: {
@@ -48,22 +66,15 @@ const mapStateToProps = (state: ReduxState): PropsFromRedux => {
     return {
         formsValues,
         searchStatus,
-        isSearchViaAttributesValid: (minAttributesRequiredToSearch, formId) => {
-            const formValues = formsValues[formId] || {};
-            const currentNumberOfFilledInputValues =
-              Object.keys(formValues)
-                  .filter((key) => {
-                      const value = formValues[key];
-                      return value && isValueContainingCharacter(value);
-                  })
-                  .length;
+        isSearchViaAttributesValid: (minAttributesRequiredToSearch) => {
+            const currentSearchTerms = collectCurrentSearchTerms(searchGroupsForSelectedScope, formsValues);
 
-            return currentNumberOfFilledInputValues >= minAttributesRequiredToSearch;
+            return Object.values(currentSearchTerms).length >= minAttributesRequiredToSearch;
         },
     };
 };
 
-const mapDispatchToProps = (dispatch: ReduxDispatch, ownProps: OwnProps): DispatchersFromRedux => ({
+const mapDispatchToProps = (dispatch: ReduxDispatch, { searchGroupsForSelectedScope }: OwnProps): DispatchersFromRedux => ({
     searchViaUniqueIdOnScopeTrackedEntityType: ({ trackedEntityTypeId, formId }) => {
         dispatch(searchViaUniqueIdOnScopeTrackedEntityType({ trackedEntityTypeId, formId }));
     },
@@ -79,7 +90,7 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, ownProps: OwnProps): Dispat
     },
     saveCurrentFormData: (searchScopeType, searchScopeId, formId, formsValues) => {
         const currentSearchTerms =
-          collectCurrentSearchTerms(ownProps.searchGroupsForSelectedScope, formsValues);
+          collectCurrentSearchTerms(searchGroupsForSelectedScope, formsValues);
 
         dispatch(actionCreator(searchPageActionTypes.CURRENT_SEARCH_INFO_SAVE)(
             { searchScopeType,
@@ -90,7 +101,7 @@ const mapDispatchToProps = (dispatch: ReduxDispatch, ownProps: OwnProps): Dispat
     },
     addFormIdToReduxStore: (formId) => { dispatch(addFormData(formId)); },
     removeFormDataFromReduxStore: () => {
-        ownProps.searchGroupsForSelectedScope
+        searchGroupsForSelectedScope
             .forEach(({ formId }) => {
                 dispatch(removeFormData(formId));
             });

--- a/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.epics.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.epics.js
@@ -2,6 +2,7 @@
 import { ofType } from 'redux-observable';
 import { catchError, flatMap, map, startWith } from 'rxjs/operators';
 import { of, from, empty } from 'rxjs';
+import { isObject, isString } from 'd2-utilizr/src';
 import {
     searchPageActionTypes,
     showEmptyResultsViewOnSearchPage,
@@ -37,12 +38,19 @@ const searchViaUniqueIdStream = (queryArgs, attributes, scopeSearchParam) =>
         catchError(() => of(showErrorViewOnSearchPage())),
     );
 
-const getFiltersForAttributesSearchQuery = formValues =>
-    Object.keys(formValues)
+const getFiltersForAttributesSearchQuery = (formValues) => {
+    const stringFilters = Object.keys(formValues)
+        .filter(fieldId => isString(formValues[fieldId]))
         .filter(fieldId => formValues[fieldId].replace(/\s/g, '').length)
         .map(fieldId => `${fieldId}:like:${formValues[fieldId]}`);
 
+    const rangeFilers = Object.keys(formValues)
+        .filter(fieldId => isObject(formValues[fieldId]))
+        .filter(fieldId => ('from' in formValues[fieldId] && 'to' in formValues[fieldId]))
+        .map(fieldId => `${fieldId}:ge:${formValues[fieldId].from}:le:${formValues[fieldId].to}`);
 
+    return [...stringFilters, ...rangeFilers];
+};
 const searchViaAttributesStream = (queryArgs, attributes, triggeredFrom) =>
     from(getTrackedEntityInstances(queryArgs, attributes)).pipe(
         map(({ trackedEntityInstanceContainers: searchResults, pagingData }) => {

--- a/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.epics.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.epics.js
@@ -144,7 +144,6 @@ export const searchViaAttributesOnScopeTrackedEntityTypeEpic = (action$: InputOb
                 page,
                 pageSize: 5,
                 ouMode: 'ACCESSIBLE',
-                fields: '*',
             };
 
             const attributes = getTrackedEntityTypeThrowIfNotFound(trackedEntityTypeId).attributes;

--- a/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.types.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.types.js
@@ -1,10 +1,12 @@
 // @flow
 import type { SearchGroups } from '../SearchPage.types';
+import { typeof dataElementTypes } from '../../../../metaData';
 
 export type CurrentSearchTerms = Array<{|
   +name: string,
-  +value: string,
+  +value: any,
   +id: string,
+  +type: $Values<dataElementTypes>
 |}>
 
 export type FormsValues = {

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
@@ -119,7 +119,7 @@ const Index = ({
 
                     {
                         searchStatus === searchPageStatus.SHOW_RESULTS &&
-                        <SearchResults searchGroupsForSelectedScope={searchGroupsForSelectedScope} />
+                        <SearchResults />
                     }
 
                     {

--- a/src/core_modules/capture-core/components/Pages/Search/SearchResults/SearchResults.component.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchResults/SearchResults.component.js
@@ -7,7 +7,7 @@ import { Button } from '@dhis2/ui-core';
 import { CardList } from '../../../CardList';
 import withNavigation from '../../../Pagination/withDefaultNavigation';
 import { searchScopes } from '../SearchPage.constants';
-import type { CardDataElementsInformation, Props } from './SearchResults.types';
+import type { Props } from './SearchResults.types';
 import { navigateToTrackedEntityDashboard } from '../sharedUtils';
 import { availableCardListButtonState } from '../../../CardList/CardList.constants';
 import { SearchResultsHeader } from '../../../SearchResultsHeader';
@@ -80,7 +80,7 @@ export const SearchResultsIndex = ({
     searchViaAttributesOnScopeTrackedEntityType,
     classes,
     searchResults,
-    searchGroupsForSelectedScope,
+    dataElements,
     currentPage,
     currentSearchScopeType,
     currentSearchScopeId,
@@ -102,17 +102,7 @@ export const SearchResultsIndex = ({
         }
     };
 
-    const collectFormDataElements = (searchGroups): CardDataElementsInformation =>
-        searchGroups
-            .filter(searchGroup => !searchGroup.unique)
-            .flatMap(({ searchForm: { sections } }) => {
-                const elementsMap = [...sections.values()]
-                    .map(section => section.elements)[0];
-                return [...elementsMap.values()]
-                    .map(({ id, name }) => ({ id, name }));
-            });
-
-    const currentProgramId = (currentSearchScopeType === searchScopes.PROGRAM) ? currentSearchScopeId : undefined;
+    const currentProgramId = (currentSearchScopeType === searchScopes.PROGRAM) ? currentSearchScopeId : null;
     return (<>
         <SearchResultsHeader currentSearchTerms={currentSearchTerms} currentSearchScopeName={currentSearchScopeName} />
         <div data-test="dhis2-capture-search-results-list">
@@ -121,7 +111,7 @@ export const SearchResultsIndex = ({
                 currentSearchScopeName={currentSearchScopeName}
                 currentProgramId={currentProgramId}
                 items={searchResults}
-                dataElements={collectFormDataElements(searchGroupsForSelectedScope)}
+                dataElements={dataElements}
                 getCustomItemBottomElements={({ item, navigationButtonsState, programName }) => (
                     <CardListButtons
                         programName={programName}

--- a/src/core_modules/capture-core/components/Pages/Search/SearchResults/SearchResults.component.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchResults/SearchResults.component.js
@@ -10,6 +10,7 @@ import { searchScopes } from '../SearchPage.constants';
 import type { CardDataElementsInformation, Props } from './SearchResults.types';
 import { navigateToTrackedEntityDashboard } from '../sharedUtils';
 import { availableCardListButtonState } from '../../../CardList/CardList.constants';
+import { SearchResultsHeader } from '../../../SearchResultsHeader';
 
 const SearchPagination = withNavigation()(Pagination);
 
@@ -19,14 +20,6 @@ export const getStyles = (theme: Theme) => ({
         justifyContent: 'flex-end',
         marginLeft: theme.typography.pxToRem(8),
         width: theme.typography.pxToRem(600),
-    },
-    topSection: {
-        display: 'flex',
-        flexDirection: 'row',
-        marginTop: theme.typography.pxToRem(20),
-        marginLeft: theme.typography.pxToRem(10),
-        marginRight: theme.typography.pxToRem(10),
-        marginBottom: theme.typography.pxToRem(10),
     },
 });
 
@@ -82,7 +75,6 @@ const CardListButtons = withStyles(buttonStyles)(
         );
     });
 
-
 export const SearchResultsIndex = ({
     searchViaAttributesOnScopeProgram,
     searchViaAttributesOnScopeTrackedEntityType,
@@ -122,15 +114,7 @@ export const SearchResultsIndex = ({
 
     const currentProgramId = (currentSearchScopeType === searchScopes.PROGRAM) ? currentSearchScopeId : undefined;
     return (<>
-        <div data-test="dhis2-capture-search-results-top" className={classes.topSection} >
-            &nbsp;{i18n.t('Result(s) found for term(s)')} {currentSearchScopeName && `${i18n.t('in')} ${currentSearchScopeName}`}.
-            &nbsp;{currentSearchTerms.map(({ name, value, id }, index, rest) => (
-                <div key={id}>
-                    <i>{name}</i>: <b>{value}</b>
-                    {index !== rest.length - 1 && <span>,</span>}
-                    &nbsp;
-                </div>))}
-        </div>
+        <SearchResultsHeader currentSearchTerms={currentSearchTerms} currentSearchScopeName={currentSearchScopeName} />
         <div data-test="dhis2-capture-search-results-list">
             <CardList
                 noItemsText={i18n.t('No results found')}
@@ -150,7 +134,7 @@ export const SearchResultsIndex = ({
                 )}
             />
         </div>
-        <div data-test="dhis2-capture-search-results-pagination" className={classes.pagination}>
+        <div className={classes.pagination}>
             <SearchPagination
                 nextPageButtonDisabled={nextPageButtonDisabled}
                 onChangePage={newPage => handlePageChange(newPage)}

--- a/src/core_modules/capture-core/components/Pages/Search/SearchResults/SearchResults.types.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchResults/SearchResults.types.js
@@ -1,13 +1,11 @@
 // @flow
-import type { SearchGroups } from '../SearchPage.types';
 import type { CurrentSearchTerms } from '../SearchForm/SearchForm.types';
 import { typeof searchScopes } from '../SearchPage.constants';
+import { typeof dataElementTypes } from '../../../../metaData';
 
-export type OwnProps = {|
-  +searchGroupsForSelectedScope: SearchGroups,
-|}
+export type CardDataElementsInformation = Array<{| id: string, name: string, type: $Values<dataElementTypes> |}>
 
-export type CardDataElementsInformation = Array<{| id: string, name: string |}>
+export type CardProfileImageElementInformation = $ReadOnly<{| id: string, name: string, type: "IMAGE" |}>
 
 type Tei = $ReadOnly<{
   created: string,
@@ -49,6 +47,7 @@ export type PropsFromRedux ={|
   +searchResults: Array<SearchResultItem>,
   +currentSearchTerms: CurrentSearchTerms,
   +nextPageButtonDisabled: boolean,
+  +dataElements: CardDataElementsInformation
 |}
 
 export type DispatchersFromRedux = {|
@@ -57,7 +56,6 @@ export type DispatchersFromRedux = {|
 |}
 
 export type Props = {|
-  ...OwnProps,
   ...DispatchersFromRedux,
   ...PropsFromRedux,
 |}

--- a/src/core_modules/capture-core/components/SearchResultsHeader/SearchResultsHeader.component.js
+++ b/src/core_modules/capture-core/components/SearchResultsHeader/SearchResultsHeader.component.js
@@ -1,0 +1,40 @@
+// @flow
+import React from 'react';
+import { withStyles } from '@material-ui/core';
+import i18n from '@dhis2/d2-i18n';
+import type { CurrentSearchTerms } from '../Pages/Search/SearchForm/SearchForm.types';
+import { convertValue } from '../../converters/clientToList';
+
+const styles = (theme: Theme) => ({
+    topSection: {
+        marginTop: theme.typography.pxToRem(20),
+        marginLeft: theme.typography.pxToRem(10),
+        marginRight: theme.typography.pxToRem(10),
+        marginBottom: theme.typography.pxToRem(10),
+    },
+});
+
+type SearchResultsHeaderType = $ReadOnly<{|
+  currentSearchTerms: CurrentSearchTerms,
+  currentSearchScopeName?: string,
+  ...CssClasses
+|}>
+
+const SearchResultsHeaderPlain =
+  ({ currentSearchTerms, currentSearchScopeName, classes }: SearchResultsHeaderType) =>
+      (<div data-test="dhis2-capture-search-results-top" className={classes.topSection} >
+          {i18n.t('Results found')} {currentSearchScopeName && `${i18n.t('in')} ${currentSearchScopeName}`}
+          <div>
+              {
+                  currentSearchTerms.map(({ name, value, id, type }, index, rest) => (
+                      <span key={id}>
+                          <i>{name}</i>: {convertValue(value, type)}
+                          {index !== rest.length - 1 && <span>,&nbsp;</span>}
+                      </span>
+                  ))
+              }
+          </div>
+      </div>
+      );
+
+export const SearchResultsHeader = withStyles(styles)(SearchResultsHeaderPlain);

--- a/src/core_modules/capture-core/components/SearchResultsHeader/index.js
+++ b/src/core_modules/capture-core/components/SearchResultsHeader/index.js
@@ -1,0 +1,1 @@
+export { SearchResultsHeader } from './SearchResultsHeader.component';

--- a/src/core_modules/capture-core/components/Section/SectionHeaderSimple.component.js
+++ b/src/core_modules/capture-core/components/Section/SectionHeaderSimple.component.js
@@ -85,6 +85,7 @@ class SectionHeaderSimple extends Component<Props> {
                             if (onChangeCollapseState) {
                                 return (
                                     <IconButton
+                                        data-test="dhis2-capture-collapsible-button"
                                         disabled={!this.props.isCollapseButtonEnabled}
                                         title={this.props.isCollapsed ? 'Åpne' : 'Lukk'}
                                         onClick={this.handleChangeCollapse}

--- a/src/core_modules/capture-core/components/TeiSearch/TeiSearch.component.js
+++ b/src/core_modules/capture-core/components/TeiSearch/TeiSearch.component.js
@@ -124,6 +124,7 @@ class TeiSearch extends React.Component<Props, State> {
         const collapsed = this.props.openSearchGroupSection !== searchGroupId;
         return (
             <Section
+                data-test="dhis2-capture-search-by-attributes-forms"
                 key={formId}
                 isCollapsed={collapsed}
                 className={this.props.classes.formContainerSection}

--- a/src/core_modules/capture-core/components/TeiSearch/TeiSearch.container.js
+++ b/src/core_modules/capture-core/components/TeiSearch/TeiSearch.container.js
@@ -29,7 +29,6 @@ const makeMapStateToProps = () => {
         };
     };
 
-
     // $FlowFixMe[not-an-object] automated comment
     return mapStateToProps;
 };

--- a/src/core_modules/capture-core/components/TeiSearch/TeiSearchForm/TeiSearchForm.component.js
+++ b/src/core_modules/capture-core/components/TeiSearch/TeiSearchForm/TeiSearchForm.component.js
@@ -150,7 +150,10 @@ class SearchForm extends React.Component<Props> {
         }
         const searchButtonText = searchGroup.unique ? this.getUniqueSearchButtonText(searchForm) : i18n.t('Search by attributes');
         return (
-            <div className={classes.container}>
+            <div
+                data-test="dhis2-capture-d2-form-area"
+                className={classes.container}
+            >
                 <D2Form
                     formRef={(formInstance) => { this.formInstance = formInstance; }}
                     formFoundation={searchGroup.searchForm}

--- a/src/core_modules/capture-core/components/TeiSearch/TeiSearchResults/TeiSearchResults.container.js
+++ b/src/core_modules/capture-core/components/TeiSearch/TeiSearchResults/TeiSearchResults.container.js
@@ -1,5 +1,4 @@
 // @flow
-
 import { connect } from 'react-redux';
 import TeiSearchResults from './TeiSearchResults.component';
 
@@ -20,9 +19,7 @@ const mapStateToProps = (state: ReduxState, props: Object) => {
     };
 };
 
-const mapDispatchToProps = () => ({
-});
+const mapDispatchToProps = () => ({});
 
-// $FlowSuppress
 // $FlowFixMe[missing-annot] automated comment
 export default connect(mapStateToProps, mapDispatchToProps)(TeiSearchResults);

--- a/src/core_modules/capture-core/components/TeiSearch/epics/teiSearch.epics.js
+++ b/src/core_modules/capture-core/components/TeiSearch/epics/teiSearch.epics.js
@@ -69,6 +69,7 @@ const searchTei = (state: ReduxState, searchId: string, formId: string, searchGr
 
     const queryArgs = {
         filter: filters,
+        fields: '*',
         ...getOuQueryArgs(selectedOrgUnit, selectedOrgUnitScope),
         // $FlowFixMe[exponential-spread] automated comment
         ...getContextQueryArgs(selectedProgramId, selectedTrackedEntityTypeId),

--- a/src/core_modules/capture-core/converters/clientToList.js
+++ b/src/core_modules/capture-core/converters/clientToList.js
@@ -50,6 +50,13 @@ function convertRangeForDisplay(parser: any, clientValue: any) {
         </span>
     );
 }
+function convertNumberRangeForDisplay(clientValue) {
+    return (
+        <span>
+            {clientValue.from} {'->'} {clientValue.to}
+        </span>
+    );
+}
 
 const valueConvertersForType = {
     // $FlowFixMe[prop-missing] automated comment
@@ -66,6 +73,8 @@ const valueConvertersForType = {
     [elementTypes.DATE]: convertDateForListDisplay,
     // $FlowFixMe[prop-missing] automated comment
     [elementTypes.DATE_RANGE]: value => convertRangeForDisplay(convertDateForListDisplay, value),
+    // $FlowFixMe[prop-missing] automated comment
+    [elementTypes.NUMBER_RANGE]: convertNumberRangeForDisplay,
     // $FlowFixMe[prop-missing] automated comment
     [elementTypes.DATETIME]: convertDateTimeForListDisplay,
     // $FlowFixMe[prop-missing] automated comment

--- a/src/core_modules/capture-core/reducers/descriptions/searchPage.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/searchPage.reducerDescription.js
@@ -40,7 +40,7 @@ export const searchPageDesc = createReducerDescription({
 }, 'searchPage', {
     searchStatus: searchPageStatus.INITIAL,
     searchResults: [],
-    currentSearchInfo: [],
+    currentSearchInfo: {},
     searchResultsPaginationInfo: {
         nextPageButtonDisabled: false,
         currentPage: 0,

--- a/src/core_modules/capture-core/trackedEntityInstances/trackedEntityInstanceRequests.js
+++ b/src/core_modules/capture-core/trackedEntityInstances/trackedEntityInstanceRequests.js
@@ -60,6 +60,7 @@ export async function getTrackedEntityInstances(queryParams: Object, attributes:
         rowsPerPage: queryParams.pageSize,
         currentPage: queryParams.page,
     };
+
     return {
         trackedEntityInstanceContainers,
         pagingData,

--- a/src/core_modules/capture-ui/DataTable/Pagination.component.js
+++ b/src/core_modules/capture-ui/DataTable/Pagination.component.js
@@ -42,6 +42,7 @@ class Pagination extends React.Component<Props> {
         const rowsCountElement = Pagination.getRowsCountElement(rowsCountSelectorLabel, rowsCountSelector);
         return (
             <div
+                data-test="dhis2-capture-pagination"
                 className={defaultClasses.pagination}
             >
                 {rowsCountElement}


### PR DESCRIPTION
While implementing some features I found out about a bug. 


### What is this bug about?
The bug basically is that when you fetch the `trackedEntityInstances` with some range values you need to add specific filters that include `ge:${value}:le${value}` in the request. 
Also you need to display correctly the form value when this is not a string but an object `{from:"string", to:"string}`. 

Fixed this also in the TEI search realm since displaying the object part of the bug was present there.

Lastly wrote some tests to make sure this wont break again in some near future. The tests cover the SearchPage and the NewEvent page search with range values