### PR TITLE
fix: test that failed unexpectedly during CI/CD

### DIFF
--- a/cypress/integration/NewEvent/index.js
+++ b/cypress/integration/NewEvent/index.js
@@ -53,6 +53,15 @@ When('you fill in the registration details', () => {
     cy.get('[data-test="dhis2-capture-relationship-register-tei-program-selector"]')
         .find('input')
         .type('Child{enter}', { force: true });
+    cy.get('[data-test="dhis2-capture-form-field-w75KJ2mc4zz"]')
+        .find('input')
+        .type('Sarah');
+    cy.get('[data-test="dhis2-capture-form-field-zDhUuAYrxNC"]')
+        .find('input')
+        .type('Wheeler');
+    cy.get('[data-test="dhis2-capture-form-field-cejWyOfXge6"]')
+        .find('input')
+        .type('Female{enter}', { force: true });
     cy.get('[data-test="dhis2-capture-dataentry-field-enrollmentDate"]')
         .find('input')
         .type('2020-01-01')
@@ -61,19 +70,12 @@ When('you fill in the registration details', () => {
         .find('input')
         .type('2020-01-01')
         .blur();
-    cy.get('[data-test="dhis2-capture-form-field-w75KJ2mc4zz"]')
-        .find('input')
-        .type('Marcus');
-    cy.get('[data-test="dhis2-capture-form-field-zDhUuAYrxNC"]')
-        .find('input')
-        .type('Barnes');
-    cy.get('[data-test="dhis2-capture-form-field-cejWyOfXge6"]')
-        .find('input')
-        .type('Male{enter}', { force: true });
 });
 
 When('you submit the registration form', () => {
     cy.get('[data-test="dhis2-capture-create-and-link-button"]')
+        .click();
+    cy.get('[data-test="dhis2-capture-create-as-new-person"]')
         .click();
 });
 

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/RegisterTei.component.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/RegisterTei.component.js
@@ -63,7 +63,7 @@ class RegisterTei extends React.Component<Props, State> {
         return (
             <div style={{ marginLeft: 16 }}>
                 <Button
-                    dataTest='dhis2-capture-create-as-new-person'
+                    dataTest="dhis2-capture-create-as-new-person"
                     onClick={this.handleSaveFromDialog}
                     primary
                 >

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/RegisterTei.component.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/RegisterTei.component.js
@@ -63,6 +63,7 @@ class RegisterTei extends React.Component<Props, State> {
         return (
             <div style={{ marginLeft: 16 }}>
                 <Button
+                    dataTest='dhis2-capture-create-as-new-person'
                     onClick={this.handleSaveFromDialog}
                     primary
                 >


### PR DESCRIPTION
@JoakimSM there is this test that sometimes failed and sometimes not. 

This is because it can happen that the request clean up sometimes doesnt take place. The user is then added in the database. Next time the test runs we have a duplicate on the person. In this case the tests passes only if the machine is quick enough to press the create user button before the server responds with possible duplicates. 

To solve this I am registering a user we already know exists in the database. And by changing the order the machine is typing. So now the machine first types the name and last name which is used to detect duplicates and then the dates. This way hopefully there will be always time the detection of the duplicates

I hope this will fix the issue. 