### PR TITLE
fix: API breaking changes to v35 

### DIFF
--- a/src/core_modules/capture-core/components/Pages/MainPage/WorkingLists/epics/eventFiltersInterface/toListConfigConverter/toListConfigConverter.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/WorkingLists/epics/eventFiltersInterface/toListConfigConverter/toListConfigConverter.js
@@ -62,11 +62,11 @@ const getDateFilter = (filter: ApiDataFilterDate): DateFilterData => {
 };
 
 const getUser = (userId: string) => getApi()
-    .get(`users/${userId}`, { fields: 'id,name,userCredentials[username]' })
+    .get(`users/${userId}`, { fields: 'id,name,displayName' })
     .then((user: Object) => ({
         id: user.id,
         name: user.name,
-        username: user.userCredentials.username,
+        username: user.displayName,
     }))
     .catch((error) => {
         log.error(


### PR DESCRIPTION
Hey this is according the breaking changes happened in the v35 https://github.com/dhis2/notes-backend/blob/master/platform/35/changelog/user_property_transformer.md