### PR TITLE
feat: DHIS2-9665 update the use of the Domain Selector in the search page

### DIFF
--- a/cypress/integration/LockedSelector.feature
+++ b/cypress/integration/LockedSelector.feature
@@ -126,7 +126,7 @@ Feature: Use the LockedSelector to navigate
   Scenario: Clicking the find button when the preselected program can be a search domain
     Given you are in the main page with no selections made
     And you select both org unit and program Child Programme
-    When you click the find button
+    When you click the find button from the dropdown menu
     Then you are navigated to the search page with the same org unit and program Child Programme
     And there should be visible a title with Child Program
     And there should be Child Programme domain forms visible to search with

--- a/cypress/integration/LockedSelector.feature
+++ b/cypress/integration/LockedSelector.feature
@@ -1,5 +1,4 @@
-Feature: In the main page, use the LockedSelector to navigate
-
+Feature: Use the LockedSelector to navigate
   # Main page
 
   Scenario: Notifying that you need to select org unit and program to get started
@@ -122,13 +121,12 @@ Feature: In the main page, use the LockedSelector to navigate
     Given you are in the main page with no selections made
     And you select both org unit and program Malaria case registration
     When you click the find button
-    Then you are navigated to the search page with the same org unit and program Malaria case registration
-    And there should be no search domain preselected
+    Then you stay in the events page since you cant search for events
 
   Scenario: Clicking the find button when the preselected program can be a search domain
     Given you are in the main page with no selections made
     And you select both org unit and program Child Programme
     When you click the find button
     Then you are navigated to the search page with the same org unit and program Child Programme
-    And there should be search domain Child Programme being preselected
+    And there should be visible a title with Child Program
     And there should be Child Programme domain forms visible to search with

--- a/cypress/integration/LockedSelector/index.js
+++ b/cypress/integration/LockedSelector/index.js
@@ -213,6 +213,17 @@ Then('you stay in the events page since you cant search for events', () => {
     cy.url().should('eq', `${Cypress.config().baseUrl}/#/programId=VBqh0ynB2wv&orgUnitId=DiszpKrYNg8`);
 });
 
+When('you click the find button from the dropdown menu', () => {
+    cy.get('[data-test="dhis2-capture-find-button"]')
+        .click();
+    cy.get('[data-test="dhis2-capture-find-menuitem-one"]')
+        .click();
+});
+
+Then('you stay in the events page since you cant search for events', () => {
+    cy.url().should('eq', `${Cypress.config().baseUrl}/#/search/orgUnitId=DiszpKrYNg8`);
+});
+
 Then('you are navigated to the search page with the same org unit and program Child Programme', () => {
     cy.url().should('eq', `${Cypress.config().baseUrl}/#/search/programId=IpHINAT79UW&orgUnitId=DiszpKrYNg8`);
 });

--- a/cypress/integration/LockedSelector/index.js
+++ b/cypress/integration/LockedSelector/index.js
@@ -209,18 +209,17 @@ When('you click the find button', () => {
         .click();
 });
 
-Then('you are navigated to the search page with the same org unit and program Malaria case registration', () => {
-    cy.url().should('eq', `${Cypress.config().baseUrl}/#/search/programId=VBqh0ynB2wv&orgUnitId=DiszpKrYNg8`);
+Then('you stay in the events page since you cant search for events', () => {
+    cy.url().should('eq', `${Cypress.config().baseUrl}/#/programId=VBqh0ynB2wv&orgUnitId=DiszpKrYNg8`);
 });
 
 Then('you are navigated to the search page with the same org unit and program Child Programme', () => {
     cy.url().should('eq', `${Cypress.config().baseUrl}/#/search/programId=IpHINAT79UW&orgUnitId=DiszpKrYNg8`);
 });
 
-And('there should be search domain Child Programme being preselected', () => {
+Then('there should be visible a title with Child Program', () => {
     cy.get('[data-test="dhis2-capture-search-page-content"]')
-        .find('[data-test="dhis2-uicore-select-input"]')
-        .contains('Child Programme')
+        .contains('a Person in program: Child Programme')
         .should('exist');
 });
 
@@ -228,11 +227,4 @@ And('there should be Child Programme domain forms visible to search with', () =>
     cy.get('[data-test="dhis2-capture-search-page-content"]')
         .find('[data-test="capture-ui-input"]')
         .should('have.length', 1);
-});
-
-Then('there should be no search domain preselected', () => {
-    cy.get('[data-test="dhis2-uicore-select-input"]')
-        .should('exist');
-    cy.get('[data-test="dhis2-capture-informative-paper"]')
-        .should('exist');
 });

--- a/cypress/integration/SearchPage.feature
+++ b/cypress/integration/SearchPage.feature
@@ -11,7 +11,7 @@ Feature: User interacts with Search page
 
   Scenario: Search domain is preselected. User lands on the search page with search domain Child Programme preselected
     Given you are in the search page with the Child Programme being preselected from the url
-    Then there should be search domain Child Programme being preselected
+    Then there should be visible a title with Child Program
     And there should be Child Programme domain forms visible to search with
 
   Scenario: Searching using unique identifier returns no results
@@ -116,11 +116,12 @@ Feature: User interacts with Search page
     And the next page button is disabled
 
 
-  Scenario: Changing the program from the LockedSelector wont change the search scope
-    Given you are in the search page with the Child Programme being preselected from the url
-    And you select the search domain Malaria Case diagnosis
+  Scenario: Changing the program from the LockedSelector will change the search scope
+    Given you are on the default search page
+    And you select the search domain Child Programme
     When you remove the Child Programme selection
-    Then you still can see the Malaria case diagnosis being selected
+    And you select the search domain Malaria Case diagnosis
+    Then there should be visible a title with Malaria case diagnosis
 
   # Tracked entity type
   Scenario: Searching using attributes in TEType domain is invalid after clearing all search terms

--- a/cypress/integration/SearchPage.feature
+++ b/cypress/integration/SearchPage.feature
@@ -115,7 +115,6 @@ Feature: User interacts with Search page
     Then you can see the first page of the results
     And the next page button is disabled
 
-
   Scenario: Changing the program from the LockedSelector will change the search scope
     Given you are on the default search page
     And you select the search domain Child Programme

--- a/cypress/integration/SearchPage/index.js
+++ b/cypress/integration/SearchPage/index.js
@@ -30,10 +30,9 @@ Given('you are in the search page with the Child Programme being preselected fro
     cy.visit('/#/search/programId=IpHINAT79UW');
 });
 
-Then('there should be search domain Child Programme being preselected', () => {
+Then('there should be visible a title with Child Program', () => {
     cy.get('[data-test="dhis2-capture-search-page-content"]')
-        .find('[data-test="dhis2-uicore-select-input"]')
-        .contains('Child Programme')
+        .contains('a Person in program: Child Programme')
         .should('exist');
 });
 
@@ -43,8 +42,15 @@ And('there should be Child Programme domain forms visible to search with', () =>
         .should('have.length', 1);
 });
 
+And('you select the search domain Child Programme', () => {
+    cy.get('.Select')
+        .type('Child Program');
+    cy.contains('Child Programme')
+        .click();
+});
+
 And('you select the search domain Malaria Case diagnosis', () => {
-    cy.get('[data-test="dhis2-uicore-select-input"]')
+    cy.get('.Select')
         .type('Malaria case diagn');
     cy.contains('Malaria case diagnosis')
         .click();
@@ -214,7 +220,7 @@ Then('there should be a validation error message', () => {
 });
 
 Given('you are on the search page with preselected program and org unit', () => {
-    cy.visit('/#/search/programId=VBqh0ynB2wv&orgUnitId=DiszpKrYNg8');
+    cy.visit('/#/search/programId=qDkgAbB5Jlk&orgUnitId=DiszpKrYNg8');
 });
 
 When('when you click the back button', () => {
@@ -224,7 +230,7 @@ When('when you click the back button', () => {
 
 Then('you should be taken to the main page with program and org unit preselected', () => {
     cy.url()
-        .should('eq', `${Cypress.config().baseUrl}/#/programId=VBqh0ynB2wv&orgUnitId=DiszpKrYNg8`);
+        .should('eq', `${Cypress.config().baseUrl}/#/programId=qDkgAbB5Jlk&orgUnitId=DiszpKrYNg8`);
 });
 
 Then('you can see the first page of the results', () => {
@@ -280,9 +286,16 @@ When('you remove the Child Programme selection', () => {
         .click();
 });
 
-Then('you still can see the Malaria case diagnosis being selected', () => {
+Then('there should be visible a title with Malaria case diagnosis', () => {
     cy.get('[data-test="dhis2-capture-search-page-content"]')
-        .contains('Malaria case diagnosis');
+        .contains('Find a Malaria Entity in program: Malaria case diagnosis, treatment and investigation')
+        .should('exist');
+});
+
+And('there should be Malaria case diagnosis forms visible to search with', () => {
+    cy.get('[data-test="dhis2-capture-search-page-content"]')
+        .find('[data-test="capture-ui-input"]')
+        .should('have.length', 1);
 });
 
 Given('you are in the search page with the Adult Woman being preselected from the url', () => {

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-10-16T10:04:44.085Z\n"
-"PO-Revision-Date: 2020-10-16T10:04:44.085Z\n"
+"POT-Creation-Date: 2020-10-01T14:44:39.931Z\n"
+"PO-Revision-Date: 2020-10-01T14:44:39.931Z\n"
 
 msgid "Choose one or more dates..."
 msgstr ""
@@ -698,10 +698,10 @@ msgstr ""
 msgid "Register"
 msgstr ""
 
-msgid "Search scope"
+msgid "Search for"
 msgstr ""
 
-msgid "Find results from"
+msgid "You can also choose a program from the top bar and search in that program"
 msgstr ""
 
 msgid "Fill in at least {{minAttributesRequiredToSearch}}  attributes to search"
@@ -714,6 +714,9 @@ msgid "Find by {{name}}"
 msgstr ""
 
 msgid "Search by attributes"
+msgstr ""
+
+msgid "Find a"
 msgstr ""
 
 msgid "Back"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -722,6 +722,9 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
+msgid "Back"
+msgstr ""
+
 msgid ""
 "You can change your search terms and search again to find what you are "
 "looking for."

--- a/src/core_modules/capture-core/components/LockedSelector/LockedSelector.actions.js
+++ b/src/core_modules/capture-core/components/LockedSelector/LockedSelector.actions.js
@@ -38,7 +38,7 @@ export const resetCategoryOptionFromLockedSelector = (categoryId: string) => act
 export const resetAllCategoryOptionsFromLockedSelector = () => actionCreator(lockedSelectorActionTypes.ALL_CATEGORY_OPTIONS_RESET)();
 
 export const openNewEventPageFromLockedSelector = (programId: string, orgUnitId: string) => actionCreator(lockedSelectorActionTypes.NEW_EVENT_PAGE_OPEN)({ programId, orgUnitId });
-export const openSearchPageFromLockedSelector = (programId: string, orgUnitId: string) => actionCreator(lockedSelectorActionTypes.SEARCH_PAGE_OPEN)({ programId, orgUnitId });
+export const openSearchPageFromLockedSelector = () => actionCreator(lockedSelectorActionTypes.SEARCH_PAGE_OPEN)();
 
 
 // these actions are being triggered only when the user updates the url from the url bar.

--- a/src/core_modules/capture-core/components/LockedSelector/LockedSelector.component.js
+++ b/src/core_modules/capture-core/components/LockedSelector/LockedSelector.component.js
@@ -107,7 +107,11 @@ export class LockedSelectorComponent extends Component<Props, State> {
     }
 
     handleOpenSearchPage = () => {
-        this.props.onOpenSearchPage(this.props.selectedProgramId, this.props.selectedOrgUnitId);
+        this.props.onOpenSearchPage();
+    }
+
+    handleOpenSearchPageWithoutProgramId = () => {
+        this.props.onOpenSearchPageWithoutProgramId();
     }
 
 
@@ -124,8 +128,9 @@ export class LockedSelectorComponent extends Component<Props, State> {
                     onResetProgramId={this.handleOpenProgramWarning}
                     onResetCategoryOption={this.handleOpenCatComboWarning}
                     onStartAgain={this.handleOpenStartAgainWarning}
-                    onClickNew={this.handleClickNew}
-                    onClickFind={this.handleOpenSearchPage}
+                    onNewClick={this.handleClickNew}
+                    onFindClickWithoutProgramId={this.handleOpenSearchPageWithoutProgramId}
+                    onFindClick={this.handleOpenSearchPage}
                 />
                 <ConfirmDialog
                     onConfirm={this.handleAcceptStartAgain}

--- a/src/core_modules/capture-core/components/LockedSelector/LockedSelector.container.js
+++ b/src/core_modules/capture-core/components/LockedSelector/LockedSelector.container.js
@@ -51,8 +51,16 @@ const mapDispatchToProps = (
     onOpenNewEventPage: (selectedProgramId, selectedOrgUnitId) => {
         dispatch(openNewEventPageFromLockedSelector(selectedProgramId, selectedOrgUnitId));
     },
-    onOpenSearchPage: (selectedProgramId, selectedOrgUnitId) => {
-        dispatch(openSearchPageFromLockedSelector(selectedProgramId, selectedOrgUnitId));
+    onOpenSearchPage: () => {
+        dispatch(openSearchPageFromLockedSelector());
+    },
+    onOpenSearchPageWithoutProgramId: () => {
+        dispatch(batchActions([
+            resetProgramIdFromLockedSelector(),
+            resetAllCategoryOptionsFromLockedSelector(),
+            resetProgramIdBase(),
+            openSearchPageFromLockedSelector(),
+        ], lockedSelectorBatchActionTypes.PROGRAM_ID_RESET_BATCH));
     },
     onStartAgain: () => {
         dispatch(batchActions([

--- a/src/core_modules/capture-core/components/LockedSelector/LockedSelector.types.js
+++ b/src/core_modules/capture-core/components/LockedSelector/LockedSelector.types.js
@@ -13,7 +13,8 @@ export type PropsFromRedux = $ReadOnly<{|
 
 export type DispatchersFromRedux = $ReadOnly<{|
   onOpenNewEventPage: (selectedProgramId: string, selectedOrgUnitId: string) => void,
-  onOpenSearchPage: (selectedProgramId: string, selectedOrgUnitId: string) => void,
+  onOpenSearchPage: () => void,
+  onOpenSearchPageWithoutProgramId: () => void,
   onSetOrgUnit: (id: string, orgUnit: Object) => void,
   onResetOrgUnitId: () => void,
   onSetProgramId: (id: string) => void,

--- a/src/core_modules/capture-core/components/LockedSelector/QuickSelector/ActionButtons.component.js
+++ b/src/core_modules/capture-core/components/LockedSelector/QuickSelector/ActionButtons.component.js
@@ -1,9 +1,9 @@
 // @flow
-import React, { type ComponentType } from 'react';
+import React, { type ComponentType, useMemo } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
-import { Button, colors } from '@dhis2/ui';
-import { TrackerProgram } from '../../../metaData';
+import { Button, colors, DropdownButton, FlyoutMenu, MenuItem } from '@dhis2/ui';
+import { getProgramFromProgramIdThrowIfNotFound, TrackerProgram } from '../../../metaData';
 
 const styles = ({ typography }) => ({
     marginLeft: {
@@ -26,13 +26,43 @@ type Props = $ReadOnly<{|
     onStartAgainClick: () => void,
     onNewClick: () => void,
     onFindClick: () => void,
+    onFindClickWithoutProgramId: () => void,
     showResetButton: boolean,
 |}>;
+
+const programTypes = {
+    TRACKER_PROGRAM: 'TRACKER_PROGRAM',
+    EVENT_PROGRAM: 'EVENT_PROGRAM',
+};
+
+function useProgramInfo(programId) {
+    let programName = '';
+    let trackedEntityName = '';
+
+    const program = useMemo(() => (
+        programId ? getProgramFromProgramIdThrowIfNotFound(programId) : null),
+    [programId]);
+
+    const programType = program instanceof TrackerProgram
+        ? programTypes.TRACKER_PROGRAM
+        : programTypes.EVENT_PROGRAM;
+
+    if (program) {
+        programName = program.name;
+    }
+    if (program instanceof TrackerProgram) {
+        trackedEntityName = program.trackedEntityType.name.toLowerCase();
+    }
+
+    return { trackedEntityName, programType, programName };
+}
+
 
 const Index = ({
     onStartAgainClick,
     onNewClick,
     onFindClick,
+    onFindClickWithoutProgramId,
     selectedProgramId,
     classes,
     showResetButton,
@@ -44,6 +74,7 @@ const Index = ({
           :
           'Event';
 
+    const { trackedEntityName, programType, programName } = useProgramInfo(selectedProgramId);
 
     return (
         <>
@@ -60,15 +91,46 @@ const Index = ({
                         i18n.t('New')
                 }
             </Button>
-            <Button
-                small
-                secondary
-                dataTest="dhis2-capture-find-button"
-                className={classes.marginLeft}
-                onClick={onFindClick}
-            >
-                { i18n.t('Find') }
-            </Button>
+            {
+                programType !== programTypes.TRACKER_PROGRAM ?
+                    <Button
+                        small
+                        secondary
+                        dataTest="dhis2-capture-find-button"
+                        className={classes.marginLeft}
+                        onClick={onFindClickWithoutProgramId}
+                    >
+                        { i18n.t('Find') }
+                    </Button>
+                    :
+                    <DropdownButton
+                        small
+                        secondary
+                        dataTest="dhis2-capture-find-button"
+                        className={classes.marginLeft}
+                        component={
+                            <FlyoutMenu
+                                dense
+                                maxWidth="250px"
+                            >
+                                <MenuItem
+                                    dataTest="dhis2-capture-find-menuitem-one"
+                                    label={`Find a ${trackedEntityName} in ${programName}`}
+                                    onClick={onFindClick}
+                                />
+                                <MenuItem
+                                    dataTest="dhis2-capture-find-menuitem-two"
+                                    label="Find..."
+                                    onClick={onFindClickWithoutProgramId}
+                                />
+                            </FlyoutMenu>
+                        }
+                    >
+                        { i18n.t('Find') }
+                    </DropdownButton>
+            }
+
+
             {
                 showResetButton ?
                     <button

--- a/src/core_modules/capture-core/components/LockedSelector/QuickSelector/QuickSelector.component.js
+++ b/src/core_modules/capture-core/components/LockedSelector/QuickSelector/QuickSelector.component.js
@@ -33,8 +33,9 @@ type Props = {
     onResetCategoryOption: (categoryId: string) => void,
     onResetAllCategoryOptions: () => void,
     onStartAgain: () => void,
-    onClickNew: () => void,
-    onClickFind: () => void,
+    onNewClick: () => void,
+    onFindClick: () => void,
+    onFindClickWithoutProgramId: () => void,
 };
 
 class QuickSelector extends Component<Props> {
@@ -119,8 +120,9 @@ class QuickSelector extends Component<Props> {
                         <ActionButtons
                             selectedProgramId={this.props.selectedProgramId}
                             onStartAgainClick={this.props.onStartAgain}
-                            onFindClick={this.props.onClickFind}
-                            onNewClick={this.props.onClickNew}
+                            onFindClick={this.props.onFindClick}
+                            onFindClickWithoutProgramId={this.props.onFindClickWithoutProgramId}
+                            onNewClick={this.props.onNewClick}
                             showResetButton={!!(this.props.selectedProgramId || this.props.selectedOrgUnitId)}
                         />
                     </Grid>

--- a/src/core_modules/capture-core/components/Pages/Search/SearchDomainSelector/SearchDomainSelector.component.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchDomainSelector/SearchDomainSelector.component.js
@@ -3,86 +3,102 @@ import React, { useMemo } from 'react';
 import type { ComponentType } from 'react';
 import i18n from '@dhis2/d2-i18n';
 import withStyles from '@material-ui/core/styles/withStyles';
+import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
+import Grid from '@material-ui/core/Grid';
 import {
     SingleSelect,
     SingleSelectOption,
+    colors,
 } from '@dhis2/ui';
-import { Section, SectionHeaderSimple } from '../../../Section';
 import type { OwnProps, Props } from './SearchDomainSelector.types';
+import { searchScopes } from '../SearchPage.constants';
 
-const styles = (theme: Theme) => ({
+const styles = ({ typography }) => ({
     searchDomainSelectorSection: {
-        margin: theme.typography.pxToRem(10),
+        margin: typography.pxToRem(10),
+    },
+    header: {
+        paddingLeft: 8,
     },
     searchRow: {
+        maxWidth: typography.pxToRem(400),
         display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-    },
-    searchRowTitle: {
-        flexBasis: 200,
-        marginLeft: 8,
+        flexDirection: 'column',
+        justifyContent: 'start',
+        padding: '8px 0',
     },
     searchRowSelectElement: {
+        marginLeft: 8,
+        marginRight: 8,
+        marginBottom: 8,
         width: '100%',
+    },
+    gridContainerInformativeText: {
+        marginLeft: 8,
+        marginTop: 4,
+        marginBottom: 12,
+    },
+    gridItemInformativeText: {
+        fontSize: 14,
+        marginLeft: 8,
+        color: colors.grey800,
     },
     customEmpty: {
         textAlign: 'center',
         padding: '8px 24px',
     },
-    divider: {
-        padding: '8px',
-    },
 });
+
+const InfoOutlinedIconWithStyles = withStyles({
+    root: {
+        fontSize: 14,
+        color: colors.grey800,
+        transformBox: 'view-box',
+        position: 'relative',
+        top: '2px',
+    },
+})(InfoOutlinedIcon);
 
 export const Index =
   ({ trackedEntityTypesWithCorrelatedPrograms, classes, onSelect, selectedSearchScopeId }: Props) =>
-      (<Section
-          className={classes.searchDomainSelectorSection}
-          header={
-              <SectionHeaderSimple
-                  containerStyle={{ paddingLeft: 8, borderBottom: '1px solid #ECEFF1' }}
-                  title={i18n.t('Search scope')}
-              />
-          }
-      >
-          <div className={classes.searchRow} style={{ padding: '8px 0' }}>
-              <div className={classes.searchRowTitle}>{ i18n.t('Find results from') }</div>
-              <div className={classes.searchRowSelectElement} style={{ marginRight: 8 }}>
+      (<>
+          <div className={classes.header}>
+              { i18n.t('Search for')}
+          </div>
+
+          <div className={classes.searchRow}>
+              <div className={classes.searchRowSelectElement}>
                   <SingleSelect
-                      onChange={(selected) => { onSelect(selected); }}
+                      onChange={({ selected }) => { onSelect(selected, searchScopes.TRACKED_ENTITY_TYPE); }}
                       selected={selectedSearchScopeId}
                       empty={<div className={classes.customEmpty}>Custom empty component</div>}
                   >
                       {
                           useMemo(() => Object.values(trackedEntityTypesWithCorrelatedPrograms)
                               // $FlowFixMe https://github.com/facebook/flow/issues/2221
-                              .map(({ trackedEntityTypeName, trackedEntityTypeId, programs: tePrograms }) =>
-                                  // SingleSelect component wont allow us to wrap the SingleSelectOption
-                                  // in any other element and still make use of the default behaviour.
-                                  // Therefore we are returning the group title and the
-                                  // SingleSelectOption in an array.
-                                  [
-                                      <SingleSelectOption
-                                          value={trackedEntityTypeId}
-                                          label={trackedEntityTypeName}
-                                      />,
-                                      tePrograms.map(({ programName, programId }) =>
-                                          (<SingleSelectOption value={programId} label={programName} />)),
-                                      <div className={classes.divider} key={trackedEntityTypeId}>
-                                          <hr />
-                                      </div>,
-                                  ],
-                              ),
-                          [
-                              classes.divider,
-                              trackedEntityTypesWithCorrelatedPrograms,
-                          ])
+                              .map(({ trackedEntityTypeName, trackedEntityTypeId }) =>
+                                  (<SingleSelectOption
+                                      key={trackedEntityTypeId}
+                                      value={trackedEntityTypeId}
+                                      label={trackedEntityTypeName}
+                                  />),
+                              ), [trackedEntityTypesWithCorrelatedPrograms])
                       }
                   </SingleSelect>
               </div>
           </div>
-      </Section>
+          {
+              !selectedSearchScopeId &&
+                  <Grid container direction="row" alignItems="center" className={classes.gridContainerInformativeText}>
+                      <Grid item>
+                          <InfoOutlinedIconWithStyles />
+                      </Grid>
+                      <Grid item className={classes.gridItemInformativeText}>
+                          {i18n.t('You can also choose a program from the top bar and search in that program')}
+                      </Grid>
+                  </Grid>
+          }
+      </>
       );
 
 export const SearchDomainSelector: ComponentType<OwnProps> = withStyles(styles)(Index);

--- a/src/core_modules/capture-core/components/Pages/Search/SearchDomainSelector/SearchDomainSelector.types.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchDomainSelector/SearchDomainSelector.types.js
@@ -1,9 +1,10 @@
 // @flow
 import type { SelectedSearchScopeId, TrackedEntityTypesWithCorrelatedPrograms } from '../SearchPage.types';
+import { typeof searchScopes } from '../SearchPage.constants';
 
 export type OwnProps = $ReadOnly<{|
   trackedEntityTypesWithCorrelatedPrograms: TrackedEntityTypesWithCorrelatedPrograms,
-  onSelect: ({ selected: string }) => void,
+  onSelect: (searchScopeId: string, searchScopeType: $Keys<searchScopes>) => void,
   selectedSearchScopeId: SelectedSearchScopeId
 |}>
 
@@ -11,4 +12,3 @@ export type Props = {|
   ...CssClasses,
   ...OwnProps,
 |}
-

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
@@ -22,11 +22,17 @@ import { LoadingMask } from '../../LoadingMasks';
 import { SearchResults } from './SearchResults/SearchResults.container';
 import { SearchDomainSelector } from './SearchDomainSelector';
 import { withErrorMessageHandler, withLoadingIndicator } from '../../../HOC';
+import { searchScopes } from './SearchPage.constants';
 import { ResultsPageSizeContext } from '../shared-contexts';
 
 const getStyles = (theme: Theme) => ({
     maxWidth: {
         maxWidth: theme.typography.pxToRem(950),
+    },
+    title: {
+        padding: '10px 0 0px 10px',
+        fontWeight: 500,
+        marginBottom: theme.typography.pxToRem(16),
     },
     container: {
         padding: '10px 24px 24px 24px',
@@ -71,7 +77,16 @@ const Index = ({
     preselectedProgramId,
     searchStatus,
 }: Props) => {
-    const [selectedSearchScopeId, setSelectedSearchScopeId] = useState(() => preselectedProgramId);
+    const [selectedSearchScopeId, setSearchScopeId] = useState(preselectedProgramId);
+    const [selectedSearchScopeType, setSearchScopeType] = useState(preselectedProgramId ? searchScopes.PROGRAM : null);
+
+    useEffect(() => {
+        showInitialSearchPage();
+        setSearchScopeId(preselectedProgramId);
+
+        const type = preselectedProgramId ? searchScopes.PROGRAM : null;
+        setSearchScopeType(type);
+    }, [showInitialSearchPage, preselectedProgramId]);
 
     useEffect(() => {
         if (!preselectedProgramId) {
@@ -88,9 +103,23 @@ const Index = ({
     const searchGroupsForSelectedScope =
       (selectedSearchScopeId ? availableSearchOptions[selectedSearchScopeId].searchGroups : []);
 
-    const handleSearchScopeSelection = ({ selected }) => {
+    const deriveTitleText = () => {
+        const TETypeName = (selectedSearchScopeId ? availableSearchOptions[selectedSearchScopeId].TETypeName : null);
+        const searchOptionName = (selectedSearchScopeId ? availableSearchOptions[selectedSearchScopeId].searchOptionName : null);
+
+        if (TETypeName && searchOptionName) {
+            return `${i18n.t('Find a {{TETypeName}} in program: ', { TETypeName })} ${searchOptionName}`;
+        }
+        if (!TETypeName && searchOptionName) {
+            return `${i18n.t('Find a')} ${searchOptionName}`;
+        }
+        return i18n.t('Find');
+    };
+
+    const handleSearchScopeSelection = (searchScopeId, searchType) => {
         showInitialSearchPage();
-        setSelectedSearchScopeId(selected);
+        setSearchScopeId(searchScopeId);
+        setSearchScopeType(searchType);
     };
 
     return (<>
@@ -108,11 +137,17 @@ const Index = ({
 
                 <Paper className={classes.paper}>
                     <div className={classes.maxWidth}>
-                        <SearchDomainSelector
-                            trackedEntityTypesWithCorrelatedPrograms={trackedEntityTypesWithCorrelatedPrograms}
-                            onSelect={handleSearchScopeSelection}
-                            selectedSearchScopeId={selectedSearchScopeId}
-                        />
+                        <div className={classes.title} >
+                            {deriveTitleText()}
+                        </div>
+                        {
+                            (selectedSearchScopeType !== searchScopes.PROGRAM) &&
+                            <SearchDomainSelector
+                                trackedEntityTypesWithCorrelatedPrograms={trackedEntityTypesWithCorrelatedPrograms}
+                                onSelect={handleSearchScopeSelection}
+                                selectedSearchScopeId={selectedSearchScopeId}
+                            />
+                        }
 
                         <SearchForm
                             selectedSearchScopeId={selectedSearchScopeId}

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.container.js
@@ -1,6 +1,6 @@
 // @flow
 import { useDispatch, useSelector } from 'react-redux';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useEffect } from 'react';
 import type { ComponentType } from 'react';
 import { SearchPageComponent } from './SearchPage.component';
 import type { AvailableSearchOptions, TrackedEntityTypesWithCorrelatedPrograms } from './SearchPage.types';
@@ -9,9 +9,10 @@ import { programCollection } from '../../../metaDataMemoryStores';
 import { TrackerProgram } from '../../../metaData';
 import { searchScopes } from './SearchPage.constants';
 
-const buildSearchOption = (id, name, searchGroups, searchScope) => ({
+const buildSearchOption = (id, name, searchGroups, searchScope, type) => ({
     searchOptionId: id,
     searchOptionName: name,
+    TETypeName: type,
     searchGroups: [...searchGroups.values()]
         .map(({ unique, searchForm, minAttributesRequiredToSearch }, index) => ({
             unique,
@@ -67,21 +68,12 @@ const useSearchOptions = (trackedEntityTypesWithCorrelatedPrograms): AvailableSe
             .reduce((acc, { trackedEntityTypeId, trackedEntityTypeName, trackedEntityTypeSearchGroups, programs }) => ({
                 ...acc,
                 [trackedEntityTypeId]:
-            buildSearchOption(
-                trackedEntityTypeId,
-                trackedEntityTypeName,
-                trackedEntityTypeSearchGroups,
-                searchScopes.TRACKED_ENTITY_TYPE,
-            ),
+                  buildSearchOption(trackedEntityTypeId, trackedEntityTypeName, trackedEntityTypeSearchGroups, searchScopes.TRACKED_ENTITY_TYPE),
+
                 ...programs.reduce((accumulated, { programId, programName, searchGroups }) => ({
                     ...accumulated,
                     [programId]:
-                buildSearchOption(
-                    programId,
-                    programName,
-                    searchGroups,
-                    searchScopes.PROGRAM,
-                ),
+                      buildSearchOption(programId, programName, searchGroups, searchScopes.PROGRAM, trackedEntityTypeName),
                 }), {}),
             }), {}),
     [trackedEntityTypesWithCorrelatedPrograms],
@@ -112,7 +104,9 @@ export const SearchPage: ComponentType<{||}> = () => {
     const dispatchShowInitialSearchPage = useCallback(
         () => { dispatch(showInitialViewOnSearchPage()); },
         [dispatch]);
-    const dispatchNavigateToMainPage = () => { dispatch(navigateToMainPage()); };
+    const dispatchNavigateToMainPage = useCallback(
+        () => { dispatch(navigateToMainPage()); },
+        [dispatch]);
 
     const trackedEntityTypesWithCorrelatedPrograms = useTrackedEntityTypesWithCorrelatedPrograms();
     const availableSearchOptions = useSearchOptions(trackedEntityTypesWithCorrelatedPrograms);
@@ -124,7 +118,16 @@ export const SearchPage: ComponentType<{||}> = () => {
       useSelector(({ activePage }) => activePage.selectionsError && activePage.selectionsError.error);
     const ready: boolean =
       useSelector(({ activePage }) => !activePage.isLoading);
+    const currentProgramId: string =
+      useSelector(({ currentSelections }) => currentSelections.programId);
 
+    useEffect(() => {
+        if (currentProgramId && (currentProgramId !== preselectedProgramId)) {
+            // There is no search for Event type of programs.
+            // In this case we navigate the users back to the main page
+            dispatchNavigateToMainPage();
+        }
+    }, [currentProgramId, preselectedProgramId, dispatchNavigateToMainPage]);
 
     return (
         <SearchPageComponent

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.epics.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.epics.js
@@ -19,7 +19,6 @@ export const openSearchPageLocationChangeEpic = (action$: InputObservable, store
     action$.pipe(
         ofType(lockedSelectorActionTypes.SEARCH_PAGE_OPEN),
         map(() => {
-            const state = store.value;
-            const { programId, orgUnitId } = state.currentSelections;
+            const { orgUnitId, programId } = store.value.currentSelections;
             return push(`/search/${urlArguments(programId, orgUnitId)}`);
         }));

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.types.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.types.js
@@ -15,6 +15,7 @@ export type AvailableSearchOptions = $ReadOnly<{
     [elementId: string]: {|
       +searchOptionId: string,
       +searchOptionName: string,
+      +TETypeName: ?string,
       +searchGroups: SearchGroups |}
   }>
 


### PR DESCRIPTION
👋   Joakim hi. This is the: https://jira.dhis2.org/browse/DHIS2-9665

### What is this PR doing?
After our talk with Joe we decided on showing the domain selector optionally. 

The behaviour now is the following
* the selector is visible only when the user is in the search page but hasnt selected a Tracker program
* when the user is on the search page and they select an Event type of program they are being navigated back to viewing all the events.

