### PR TITLE
chore: split the jobs of linting and flow checking

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -1,4 +1,4 @@
-name: "dhis2: cypress tests"
+name: "dhis2: tests"
 
 on: [push]
 

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -3,7 +3,7 @@ name: "dhis2: tests"
 on: [push]
 
 jobs:
-  cypress-run:
+  cypress:
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.7.0-chrome84
     strategy:

--- a/.github/workflows/flow-checks.yml
+++ b/.github/workflows/flow-checks.yml
@@ -3,18 +3,18 @@ name: 'dhis2: checks'
 on: push
 
 jobs:
-    flow:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 12.x
+  flow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+            node-version: 12.x
 
-            - name: Install
-              run: yarn install --frozen-lockfile
+      - name: Install
+        run: yarn install --frozen-lockfile
 
-            - name: Flow Checks
-              run: yarn flow:check
-        env:
-            CI: true
+      - name: Flow Checks
+        run: yarn flow:check
+    env:
+      CI: true

--- a/.github/workflows/flow-checks.yml
+++ b/.github/workflows/flow-checks.yml
@@ -1,19 +1,20 @@
-name: 'dhis2: flow-checks'
+name: 'dhis2: checks'
 
 on: push
 
 jobs:
-  runs-on: ubuntu-latest
-  steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-            node-version: 12.x
+    flow:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12.x
 
-      - name: Install
-        run: yarn install --frozen-lockfile
+            - name: Install
+              run: yarn install --frozen-lockfile
 
-      - name: Flow Checks
-        run: yarn flow:check
-  env:
-      CI: true
+            - name: Flow Checks
+              run: yarn flow:check
+        env:
+            CI: true

--- a/.github/workflows/flow-checks.yml
+++ b/.github/workflows/flow-checks.yml
@@ -1,4 +1,4 @@
-name: 'dhis2: checks'
+name: 'dhis2: flow-checks'
 
 on: push
 
@@ -14,9 +14,7 @@ jobs:
             - name: Install
               run: yarn install --frozen-lockfile
 
-            - name: Lint
-              run: |
-                  yarn flow:check
-                  yarn linter:check
+            - name: Flow Checks
+              run: yarn flow:check
         env:
             CI: true

--- a/.github/workflows/flow-checks.yml
+++ b/.github/workflows/flow-checks.yml
@@ -3,18 +3,17 @@ name: 'dhis2: flow-checks'
 on: push
 
 jobs:
-    type-checks:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 12.x
+  runs-on: ubuntu-latest
+  steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+            node-version: 12.x
 
-            - name: Install
-              run: yarn install --frozen-lockfile
+      - name: Install
+        run: yarn install --frozen-lockfile
 
-            - name: Flow Checks
-              run: yarn flow:check
-        env:
-            CI: true
+      - name: Flow Checks
+        run: yarn flow:check
+  env:
+      CI: true

--- a/.github/workflows/linter-checks.yml
+++ b/.github/workflows/linter-checks.yml
@@ -3,18 +3,18 @@ name: 'dhis2: checks'
 on: push
 
 jobs:
-    linter:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 12.x
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+            node-version: 12.x
 
-            - name: Install
-              run: yarn install --frozen-lockfile
+      - name: Install
+        run: yarn install --frozen-lockfile
 
-            - name: Linter Checks
-              run: yarn linter:check
-        env:
-            CI: true
+      - name: Linter Checks
+        run: yarn linter:check
+    env:
+      CI: true

--- a/.github/workflows/linter-checks.yml
+++ b/.github/workflows/linter-checks.yml
@@ -1,9 +1,9 @@
-name: 'dhis2: linter-checks'
+name: 'dhis2: checks'
 
 on: push
 
 jobs:
-    type-checks:
+    linter:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/linter-checks.yml
+++ b/.github/workflows/linter-checks.yml
@@ -1,0 +1,20 @@
+name: 'dhis2: linter-checks'
+
+on: push
+
+jobs:
+    type-checks:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12.x
+
+            - name: Install
+              run: yarn install --frozen-lockfile
+
+            - name: Linter Checks
+              run: yarn linter:check
+        env:
+            CI: true


### PR DESCRIPTION
### Motivation
When the check fails in the form that it is now, I will always have to click and go in the github actions area and then scroll over to see whether the flow or linter failed. 

This is sometimes annoying :) This PR splits those two. Now I will be able to see from the PR view which one fails and save myself some clicks 

