### PR TITLE
feat: DHIS2-9675 Redesign Find button to match the new concept

### DIFF
--- a/cypress/integration/LockedSelector.feature
+++ b/cypress/integration/LockedSelector.feature
@@ -126,7 +126,7 @@ Feature: Use the LockedSelector to navigate
   Scenario: Clicking the find button when the preselected program can be a search domain
     Given you are in the main page with no selections made
     And you select both org unit and program Child Programme
-    When you click the find button
+    When you click the find button from the dropdown menu
     Then you are navigated to the search page with the same org unit and program Child Programme
     And there should be visible a title with Child Program
     And there should be Child Programme domain forms visible to search with

--- a/cypress/integration/LockedSelector/index.js
+++ b/cypress/integration/LockedSelector/index.js
@@ -213,6 +213,17 @@ Then('you stay in the events page since you cant search for events', () => {
     cy.url().should('eq', `${Cypress.config().baseUrl}/#/programId=VBqh0ynB2wv&orgUnitId=DiszpKrYNg8`);
 });
 
+When('you click the find button from the dropdown menu', () => {
+    cy.get('[data-test="dhis2-capture-find-button"]')
+        .click();
+    cy.get('[data-test="dhis2-capture-find-menuitem-one"]')
+        .click();
+});
+
+Then('you stay in the events page since you cant search for events', () => {
+    cy.url().should('eq', `${Cypress.config().baseUrl}/#/search/orgUnitId=DiszpKrYNg8`);
+});
+
 Then('you are navigated to the search page with the same org unit and program Child Programme', () => {
     cy.url().should('eq', `${Cypress.config().baseUrl}/#/search/programId=IpHINAT79UW&orgUnitId=DiszpKrYNg8`);
 });

--- a/cypress/integration/SearchPage.feature
+++ b/cypress/integration/SearchPage.feature
@@ -115,7 +115,6 @@ Feature: User interacts with Search page
     Then you can see the first page of the results
     And the next page button is disabled
 
-
   Scenario: Changing the program from the LockedSelector will change the search scope
     Given you are on the default search page
     And you select the search domain Child Programme

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -722,6 +722,9 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
+msgid "Back"
+msgstr ""
+
 msgid ""
 "You can change your search terms and search again to find what you are "
 "looking for."

--- a/src/core_modules/capture-core/components/LockedSelector/LockedSelector.actions.js
+++ b/src/core_modules/capture-core/components/LockedSelector/LockedSelector.actions.js
@@ -38,7 +38,7 @@ export const resetCategoryOptionFromLockedSelector = (categoryId: string) => act
 export const resetAllCategoryOptionsFromLockedSelector = () => actionCreator(lockedSelectorActionTypes.ALL_CATEGORY_OPTIONS_RESET)();
 
 export const openNewEventPageFromLockedSelector = (programId: string, orgUnitId: string) => actionCreator(lockedSelectorActionTypes.NEW_EVENT_PAGE_OPEN)({ programId, orgUnitId });
-export const openSearchPageFromLockedSelector = (programId: string, orgUnitId: string) => actionCreator(lockedSelectorActionTypes.SEARCH_PAGE_OPEN)({ programId, orgUnitId });
+export const openSearchPageFromLockedSelector = () => actionCreator(lockedSelectorActionTypes.SEARCH_PAGE_OPEN)();
 
 
 // these actions are being triggered only when the user updates the url from the url bar.

--- a/src/core_modules/capture-core/components/LockedSelector/LockedSelector.component.js
+++ b/src/core_modules/capture-core/components/LockedSelector/LockedSelector.component.js
@@ -107,7 +107,11 @@ export class LockedSelectorComponent extends Component<Props, State> {
     }
 
     handleOpenSearchPage = () => {
-        this.props.onOpenSearchPage(this.props.selectedProgramId, this.props.selectedOrgUnitId);
+        this.props.onOpenSearchPage();
+    }
+
+    handleOpenSearchPageWithoutProgramId = () => {
+        this.props.onOpenSearchPageWithoutProgramId();
     }
 
 
@@ -124,8 +128,9 @@ export class LockedSelectorComponent extends Component<Props, State> {
                     onResetProgramId={this.handleOpenProgramWarning}
                     onResetCategoryOption={this.handleOpenCatComboWarning}
                     onStartAgain={this.handleOpenStartAgainWarning}
-                    onClickNew={this.handleClickNew}
-                    onClickFind={this.handleOpenSearchPage}
+                    onNewClick={this.handleClickNew}
+                    onFindClickWithoutProgramId={this.handleOpenSearchPageWithoutProgramId}
+                    onFindClick={this.handleOpenSearchPage}
                 />
                 <ConfirmDialog
                     onConfirm={this.handleAcceptStartAgain}

--- a/src/core_modules/capture-core/components/LockedSelector/LockedSelector.container.js
+++ b/src/core_modules/capture-core/components/LockedSelector/LockedSelector.container.js
@@ -51,8 +51,16 @@ const mapDispatchToProps = (
     onOpenNewEventPage: (selectedProgramId, selectedOrgUnitId) => {
         dispatch(openNewEventPageFromLockedSelector(selectedProgramId, selectedOrgUnitId));
     },
-    onOpenSearchPage: (selectedProgramId, selectedOrgUnitId) => {
-        dispatch(openSearchPageFromLockedSelector(selectedProgramId, selectedOrgUnitId));
+    onOpenSearchPage: () => {
+        dispatch(openSearchPageFromLockedSelector());
+    },
+    onOpenSearchPageWithoutProgramId: () => {
+        dispatch(batchActions([
+            resetProgramIdFromLockedSelector(),
+            resetAllCategoryOptionsFromLockedSelector(),
+            resetProgramIdBase(),
+            openSearchPageFromLockedSelector(),
+        ], lockedSelectorBatchActionTypes.PROGRAM_ID_RESET_BATCH));
     },
     onStartAgain: () => {
         dispatch(batchActions([

--- a/src/core_modules/capture-core/components/LockedSelector/LockedSelector.types.js
+++ b/src/core_modules/capture-core/components/LockedSelector/LockedSelector.types.js
@@ -13,7 +13,8 @@ export type PropsFromRedux = $ReadOnly<{|
 
 export type DispatchersFromRedux = $ReadOnly<{|
   onOpenNewEventPage: (selectedProgramId: string, selectedOrgUnitId: string) => void,
-  onOpenSearchPage: (selectedProgramId: string, selectedOrgUnitId: string) => void,
+  onOpenSearchPage: () => void,
+  onOpenSearchPageWithoutProgramId: () => void,
   onSetOrgUnit: (id: string, orgUnit: Object) => void,
   onResetOrgUnitId: () => void,
   onSetProgramId: (id: string) => void,

--- a/src/core_modules/capture-core/components/LockedSelector/QuickSelector/ActionButtons.component.js
+++ b/src/core_modules/capture-core/components/LockedSelector/QuickSelector/ActionButtons.component.js
@@ -1,9 +1,9 @@
 // @flow
-import React, { type ComponentType } from 'react';
+import React, { type ComponentType, useMemo } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
-import { Button, colors } from '@dhis2/ui';
-import { TrackerProgram } from '../../../metaData';
+import { Button, colors, DropdownButton, FlyoutMenu, MenuItem } from '@dhis2/ui';
+import { getProgramFromProgramIdThrowIfNotFound, TrackerProgram } from '../../../metaData';
 
 const styles = ({ typography }) => ({
     marginLeft: {
@@ -26,13 +26,43 @@ type Props = $ReadOnly<{|
     onStartAgainClick: () => void,
     onNewClick: () => void,
     onFindClick: () => void,
+    onFindClickWithoutProgramId: () => void,
     showResetButton: boolean,
 |}>;
+
+const programTypes = {
+    TRACKER_PROGRAM: 'TRACKER_PROGRAM',
+    EVENT_PROGRAM: 'EVENT_PROGRAM',
+};
+
+function useProgramInfo(programId) {
+    let programName = '';
+    let trackedEntityName = '';
+
+    const program = useMemo(() => (
+        programId ? getProgramFromProgramIdThrowIfNotFound(programId) : null),
+    [programId]);
+
+    const programType = program instanceof TrackerProgram
+        ? programTypes.TRACKER_PROGRAM
+        : programTypes.EVENT_PROGRAM;
+
+    if (program) {
+        programName = program.name;
+    }
+    if (program instanceof TrackerProgram) {
+        trackedEntityName = program.trackedEntityType.name.toLowerCase();
+    }
+
+    return { trackedEntityName, programType, programName };
+}
+
 
 const Index = ({
     onStartAgainClick,
     onNewClick,
     onFindClick,
+    onFindClickWithoutProgramId,
     selectedProgramId,
     classes,
     showResetButton,
@@ -44,6 +74,7 @@ const Index = ({
           :
           'Event';
 
+    const { trackedEntityName, programType, programName } = useProgramInfo(selectedProgramId);
 
     return (
         <>
@@ -60,15 +91,46 @@ const Index = ({
                         i18n.t('New')
                 }
             </Button>
-            <Button
-                small
-                secondary
-                dataTest="dhis2-capture-find-button"
-                className={classes.marginLeft}
-                onClick={onFindClick}
-            >
-                { i18n.t('Find') }
-            </Button>
+            {
+                programType !== programTypes.TRACKER_PROGRAM ?
+                    <Button
+                        small
+                        secondary
+                        dataTest="dhis2-capture-find-button"
+                        className={classes.marginLeft}
+                        onClick={onFindClickWithoutProgramId}
+                    >
+                        { i18n.t('Find') }
+                    </Button>
+                    :
+                    <DropdownButton
+                        small
+                        secondary
+                        dataTest="dhis2-capture-find-button"
+                        className={classes.marginLeft}
+                        component={
+                            <FlyoutMenu
+                                dense
+                                maxWidth="250px"
+                            >
+                                <MenuItem
+                                    dataTest="dhis2-capture-find-menuitem-one"
+                                    label={`Find a ${trackedEntityName} in ${programName}`}
+                                    onClick={onFindClick}
+                                />
+                                <MenuItem
+                                    dataTest="dhis2-capture-find-menuitem-two"
+                                    label="Find..."
+                                    onClick={onFindClickWithoutProgramId}
+                                />
+                            </FlyoutMenu>
+                        }
+                    >
+                        { i18n.t('Find') }
+                    </DropdownButton>
+            }
+
+
             {
                 showResetButton ?
                     <button

--- a/src/core_modules/capture-core/components/LockedSelector/QuickSelector/QuickSelector.component.js
+++ b/src/core_modules/capture-core/components/LockedSelector/QuickSelector/QuickSelector.component.js
@@ -33,8 +33,9 @@ type Props = {
     onResetCategoryOption: (categoryId: string) => void,
     onResetAllCategoryOptions: () => void,
     onStartAgain: () => void,
-    onClickNew: () => void,
-    onClickFind: () => void,
+    onNewClick: () => void,
+    onFindClick: () => void,
+    onFindClickWithoutProgramId: () => void,
 };
 
 class QuickSelector extends Component<Props> {
@@ -119,8 +120,9 @@ class QuickSelector extends Component<Props> {
                         <ActionButtons
                             selectedProgramId={this.props.selectedProgramId}
                             onStartAgainClick={this.props.onStartAgain}
-                            onFindClick={this.props.onClickFind}
-                            onNewClick={this.props.onClickNew}
+                            onFindClick={this.props.onFindClick}
+                            onFindClickWithoutProgramId={this.props.onFindClickWithoutProgramId}
+                            onNewClick={this.props.onNewClick}
                             showResetButton={!!(this.props.selectedProgramId || this.props.selectedOrgUnitId)}
                         />
                     </Grid>

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.epics.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.epics.js
@@ -19,7 +19,6 @@ export const openSearchPageLocationChangeEpic = (action$: InputObservable, store
     action$.pipe(
         ofType(lockedSelectorActionTypes.SEARCH_PAGE_OPEN),
         map(() => {
-            const state = store.value;
-            const { programId, orgUnitId } = state.currentSelections;
+            const { orgUnitId, programId } = store.value.currentSelections;
             return push(`/search/${urlArguments(programId, orgUnitId)}`);
         }));


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-9675


### What is this PR doing?

Adds the dropdown menu on the Find button of the LockedSelector.

![image](https://user-images.githubusercontent.com/4181674/95170793-e7d1fc80-07ac-11eb-8583-622d20aa9f78.png)


The button basically has two states. 
a) when there is _no_ Tracker program selected you can only see a button. 
b) when there is  a Tracker program selected then there is a dropdown button. The dropdown has two options as we discussed in the concept. 

You can find the concept [here](https://dhis2.github.io/design-specs/capture-context/capture-context-test/?01_blank).