### PR TITLE
chore: DHIS2-9827 adds height on loading containers

### DIFF
--- a/src/core_modules/capture-core/components/LoadingMasks/LoadingMaskElementCenter.component.js
+++ b/src/core_modules/capture-core/components/LoadingMasks/LoadingMaskElementCenter.component.js
@@ -8,6 +8,7 @@ const styles = () => ({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
+        height: 'calc(100vh - 48px)',
     },
 });
 

--- a/src/core_modules/capture-core/components/LockedSelector/LockedSelector.container.js
+++ b/src/core_modules/capture-core/components/LockedSelector/LockedSelector.container.js
@@ -89,6 +89,6 @@ const mapDispatchToProps = (
 export const LockedSelector: ComponentType<OwnProps> =
   compose(
       connect<Props, OwnProps & CssClasses, _, _, _, _>(mapStateToProps, mapDispatchToProps),
-      withLoadingIndicator(),
+      withLoadingIndicator(() => ({ height: '100px' })),
   )(LockedSelectorComponent);
 


### PR DESCRIPTION
👋 Hey @JoakimSM. This is the ticket:  https://jira.dhis2.org/browse/DHIS2-9827

### What is this PR about?
Well sometimes we have this 
![image](https://user-images.githubusercontent.com/4181674/97145374-6693d700-1766-11eb-86d1-a280da47039c.png)
This ticket aligns  the loader in the middle of the page or the component in the case of Locked selector
