### PR TITLE
[DHIS2-8695] TEI working lists #7 - move common actions to WorkingListsCommon

### DIFF
--- a/src/core_modules/capture-core/components/Pages/MainPage/EventWorkingLists/epics/eventList.epics.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/EventWorkingLists/epics/eventList.epics.js
@@ -9,6 +9,7 @@ import {
     deleteEventError,
     deleteEventSuccess,
 } from '../eventWorkingLists.actions';
+import { workingListsCommonActionTypes } from '../../WorkingListsCommon';
 import { initEventWorkingListAsync } from './initEventWorkingList';
 import { updateEventWorkingListAsync } from './updateEventWorkingList';
 import { getApi } from '../../../../../d2';
@@ -16,7 +17,7 @@ import { getApi } from '../../../../../d2';
 export const initEventListEpic = (action$: InputObservable) =>
     action$.pipe(
         ofType(
-            actionTypes.LIST_VIEW_INIT,
+            workingListsCommonActionTypes.LIST_VIEW_INIT,
         ),
         concatMap((action) => {
             const { selectedTemplate, columnsMetaForDataFetching, categoryCombinationMeta, listId } = action.payload;
@@ -39,7 +40,7 @@ export const initEventListEpic = (action$: InputObservable) =>
 
                 takeUntil(
                     action$.pipe(
-                        ofType(actionTypes.LIST_VIEW_INIT_CANCEL),
+                        ofType(workingListsCommonActionTypes.LIST_VIEW_INIT_CANCEL),
                         filter(cancelAction => cancelAction.payload.listId === listId),
                     ),
                 ),
@@ -49,7 +50,7 @@ export const initEventListEpic = (action$: InputObservable) =>
 export const updateEventListEpic = (action$: InputObservable) =>
     action$.pipe(
         ofType(
-            actionTypes.LIST_UPDATE,
+            workingListsCommonActionTypes.LIST_UPDATE,
         ),
         concatMap((action) => {
             const { queryArgs, columnsMetaForDataFetching, categoryCombinationMeta, listId } = action.payload;
@@ -57,13 +58,13 @@ export const updateEventListEpic = (action$: InputObservable) =>
             return from(updatePromise).pipe(
                 takeUntil(
                     action$.pipe(
-                        ofType(actionTypes.LIST_UPDATE_CANCEL),
+                        ofType(workingListsCommonActionTypes.LIST_UPDATE_CANCEL),
                         filter(cancelAction => cancelAction.payload.listId === listId),
                     ),
                 ),
                 takeUntil(
                     action$.pipe(
-                        ofType(actionTypes.LIST_VIEW_INIT_CANCEL),
+                        ofType(workingListsCommonActionTypes.LIST_VIEW_INIT_CANCEL),
                         filter(cancelAction => cancelAction.payload.listId === listId),
                     ),
                 ));
@@ -87,7 +88,7 @@ export const requestDeleteEventEpic = (action$: InputObservable) =>
             return from(deletePromise).pipe(
                 takeUntil(
                     action$.pipe(
-                        ofType(actionTypes.CONTEXT_UNLOADING),
+                        ofType(workingListsCommonActionTypes.CONTEXT_UNLOADING),
                         filter(cancelAction => cancelAction.payload.listId === listId),
                     ),
                 ));

--- a/src/core_modules/capture-core/components/Pages/MainPage/EventWorkingLists/epics/initEventWorkingList.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/EventWorkingLists/epics/initEventWorkingList.js
@@ -7,7 +7,7 @@ import { getEventWorkingListDataAsync } from './eventsRetriever';
 import {
     initListViewSuccess,
     initListViewError,
-} from '../eventWorkingLists.actions';
+} from '../../WorkingListsCommon';
 import { buildQueryArgs } from '../helpers/eventsQueryArgsBuilder';
 import type { ApiEventQueryCriteria, CommonQueryData, ClientConfig, ColumnsMetaForDataFetching } from '../types';
 

--- a/src/core_modules/capture-core/components/Pages/MainPage/EventWorkingLists/epics/templates.epics.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/EventWorkingLists/epics/templates.epics.js
@@ -7,7 +7,7 @@ import { ofType } from 'redux-observable';
 import { concatMap, filter, takeUntil } from 'rxjs/operators';
 import { from } from 'rxjs';
 import {
-    actionTypes,
+    workingListsCommonActionTypes,
     batchActionTypes,
     fetchTemplatesSuccess,
     fetchTemplatesError,
@@ -18,13 +18,13 @@ import {
     addTemplateError,
     deleteTemplateSuccess,
     deleteTemplateError,
-} from '../eventWorkingLists.actions';
+} from '../../WorkingListsCommon';
 import { getTemplatesAsync } from './templatesFetcher';
 import { getApi } from '../../../../../d2';
 
 export const retrieveTemplatesEpic = (action$: InputObservable, store: ReduxStore) =>
     action$.pipe(
-        ofType(actionTypes.TEMPLATES_FETCH),
+        ofType(workingListsCommonActionTypes.TEMPLATES_FETCH),
         concatMap((action) => {
             const listId = action.payload.listId;
             const programId = store.value.currentSelections.programId;
@@ -43,7 +43,7 @@ export const retrieveTemplatesEpic = (action$: InputObservable, store: ReduxStor
             return from(promise).pipe(
                 takeUntil(
                     action$.pipe(
-                        ofType(actionTypes.TEMPLATES_FETCH_CANCEL),
+                        ofType(workingListsCommonActionTypes.TEMPLATES_FETCH_CANCEL),
                         filter(cancelAction => cancelAction.payload.listId === listId),
                     ),
                 ),
@@ -52,7 +52,7 @@ export const retrieveTemplatesEpic = (action$: InputObservable, store: ReduxStor
 
 export const updateTemplateEpic = (action$: InputObservable, store: ReduxStore) =>
     action$.pipe(
-        ofType(actionTypes.TEMPLATE_UPDATE),
+        ofType(workingListsCommonActionTypes.TEMPLATE_UPDATE),
         concatMap((action) => {
             const {
                 template,
@@ -117,13 +117,13 @@ export const updateTemplateEpic = (action$: InputObservable, store: ReduxStore) 
             return from(requestPromise).pipe(
                 takeUntil(
                     action$.pipe(
-                        ofType(actionTypes.TEMPLATE_UPDATE),
+                        ofType(workingListsCommonActionTypes.TEMPLATE_UPDATE),
                         filter(cancelAction => cancelAction.payload.template.id === template.id),
                     ),
                 ),
                 takeUntil(
                     action$.pipe(
-                        ofType(actionTypes.CONTEXT_UNLOADING),
+                        ofType(workingListsCommonActionTypes.CONTEXT_UNLOADING),
                         filter(cancelAction => cancelAction.payload.listId === listId),
                     ),
                 ),
@@ -132,7 +132,7 @@ export const updateTemplateEpic = (action$: InputObservable, store: ReduxStore) 
 
 export const addTemplateEpic = (action$: InputObservable, store: ReduxStore) =>
     action$.pipe(ofType(
-        actionTypes.TEMPLATE_ADD,
+        workingListsCommonActionTypes.TEMPLATE_ADD,
     ),
     concatMap((action) => {
         const {
@@ -192,7 +192,7 @@ export const addTemplateEpic = (action$: InputObservable, store: ReduxStore) =>
         return from(requestPromise).pipe(
             takeUntil(
                 action$.pipe(
-                    ofType(actionTypes.CONTEXT_UNLOADING),
+                    ofType(workingListsCommonActionTypes.CONTEXT_UNLOADING),
                     filter(cancelAction => cancelAction.payload.listId === listId),
                 ),
             ),
@@ -201,7 +201,7 @@ export const addTemplateEpic = (action$: InputObservable, store: ReduxStore) =>
 
 export const deleteTemplateEpic = (action$: InputObservable) =>
     action$.pipe(
-        ofType(actionTypes.TEMPLATE_DELETE),
+        ofType(workingListsCommonActionTypes.TEMPLATE_DELETE),
         concatMap((action) => {
             const {
                 template,
@@ -224,13 +224,13 @@ export const deleteTemplateEpic = (action$: InputObservable) =>
             return from(requestPromise).pipe(
                 takeUntil(
                     action$.pipe(
-                        ofType(actionTypes.TEMPLATE_DELETE),
+                        ofType(workingListsCommonActionTypes.TEMPLATE_DELETE),
                         filter(cancelAction => cancelAction.payload.template.id === template.id),
                     ),
                 ),
                 takeUntil(
                     action$.pipe(
-                        ofType(actionTypes.CONTEXT_UNLOADING),
+                        ofType(workingListsCommonActionTypes.CONTEXT_UNLOADING),
                         filter(cancelAction => cancelAction.payload.listId === listId),
                     ),
                 ),

--- a/src/core_modules/capture-core/components/Pages/MainPage/EventWorkingLists/epics/updateEventWorkingList.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/EventWorkingLists/epics/updateEventWorkingList.js
@@ -5,7 +5,7 @@ import { getEventWorkingListDataAsync } from './eventsRetriever';
 import {
     updateListSuccess,
     updateListError,
-} from '../eventWorkingLists.actions';
+} from '../../WorkingListsCommon';
 import { buildQueryArgs } from '../helpers/eventsQueryArgsBuilder';
 import type { ColumnsMetaForDataFetching } from '../types';
 

--- a/src/core_modules/capture-core/components/Pages/MainPage/EventWorkingLists/eventWorkingLists.actions.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/EventWorkingLists/eventWorkingLists.actions.js
@@ -2,125 +2,18 @@
 import { actionCreator } from '../../../../actions/actions.utils';
 
 export const actionTypes = {
-    DATA_PRE_CLEAN: 'EventWorkingListsDataPreClean',
-    TEMPLATES_FETCH: 'EventWorkingListsTemplatesFetch',
-    TEMPLATES_FETCH_SUCCESS: 'EventWorkingListsTemplatesFetchSuccess',
-    TEMPLATES_FETCH_ERROR: 'EventWorkingListsTemplatesFetchError',
-    TEMPLATES_FETCH_CANCEL: 'EventWorkingListsTemplatesFetchCancel',
-    TEMPLATE_SELECT: 'EventWorkingListsTemplateSelect',
-    TEMPLATE_ADD: 'EventWorkingListsTemplateAdd',
-    TEMPLATE_ADD_SUCCESS: 'EventWorkingListsTemplateAddSuccess',
-    TEMPLATE_ADD_ERROR: 'EventWorkingListsTemplateAddError',
-    TEMPLATE_ADD_SKIP_INIT_CLEAN: 'EventWorkingListsTemplateAddSkipInitClean',
-    TEMPLATE_DELETE: 'EventWorkingListsTemplateDelete',
-    TEMPLATE_DELETE_SUCCESS: 'EventWorkingListsTemplateDeleteSuccess',
-    TEMPLATE_DELETE_ERROR: 'EventWorkingListsTemplateDeleteError',
-    TEMPLATE_UPDATE: 'EventWorkingListsTemplateUpdate',
-    TEMPLATE_UPDATE_SUCCESS: 'EventWorkingListsTemplateUpdateSuccess',
-    TEMPLATE_UPDATE_ERROR: 'EventWorkingListsTemplateUpdateError',
-    LIST_VIEW_INIT: 'WorkingListsListViewInit',
-    LIST_VIEW_INIT_SUCCESS: 'WorkingListsListViewInitSuccess',
-    LIST_VIEW_INIT_ERROR: 'WorkingListsListViewInitError',
-    LIST_VIEW_INIT_CANCEL: 'WorkingListsListViewInitCancel',
-    LIST_UPDATE: 'WorkingListsListUpdate',
-    LIST_UPDATE_SUCCESS: 'WorkingListsListUpdateSuccess',
-    LIST_UPDATE_ERROR: 'WorkingListsListUpdateError',
-    LIST_UPDATE_CANCEL: 'WorkingListsListUpdateCancel',
     EVENT_DELETE: 'EventWorkingListsEventListEventDelete',
     EVENT_DELETE_SUCCESS: 'EventWorkingListsEventListEventDeleteSuccess',
     EVENT_DELETE_ERROR: 'EventWorkingListsEventListEventDeleteError',
-    CONTEXT_UNLOADING: 'EventWorkingListsContextUnloading',
     VIEW_EVENT_PAGE_OPEN: 'ViewEventPageOpen',
     EVENT_REQUEST_DELETE: 'EventWorkingListsEventDelete',
 };
-
-export const batchActionTypes = {
-    TEMPLATES_FETCH_SUCCESS_BATCH: 'EventWorkingListTemplatesFetchSuccessBatch', // shouldn't be used eventually
-};
-
-export const preCleanData =
-    (cleanTemplates: boolean, listId: string) =>
-        actionCreator(actionTypes.DATA_PRE_CLEAN)({ cleanTemplates, listId });
-
-export const fetchTemplates =
-    (programId: string, listId: string) => actionCreator(actionTypes.TEMPLATES_FETCH)({ programId, listId });
-
-export const fetchTemplatesSuccess = (templates: Array<any>, programId: string, listId: string) =>
-    actionCreator(actionTypes.TEMPLATES_FETCH_SUCCESS)({ templates, programId, listId });
-
-export const fetchTemplatesError = (error: string, listId: string) =>
-    actionCreator(actionTypes.TEMPLATES_FETCH_ERROR)({ error, listId });
-
-export const fetchTemplatesCancel = (listId: string) =>
-    actionCreator(actionTypes.TEMPLATES_FETCH_CANCEL)({ listId });
-
-export const selectTemplate = (templateId: string, listId: string) =>
-    actionCreator(actionTypes.TEMPLATE_SELECT)({ templateId, listId });
-
-export const updateTemplate = (template: Object, eventQueryCriteria: Object, data: Object) =>
-    actionCreator(actionTypes.TEMPLATE_UPDATE)({ template, eventQueryCriteria, ...data });
-
-export const updateTemplateSuccess = (templateId: string, eventQueryCriteria: Object, data: Object) =>
-    actionCreator(actionTypes.TEMPLATE_UPDATE_SUCCESS)({ templateId, eventQueryCriteria, ...data });
-
-export const updateTemplateError = (templateId: string, eventQueryCriteria: Object, data: Object) =>
-    actionCreator(actionTypes.TEMPLATE_UPDATE_ERROR)({ templateId, eventQueryCriteria, ...data });
-
-export const addTemplate = (name: string, eventQueryCriteria: Object, data: Object) =>
-    actionCreator(actionTypes.TEMPLATE_ADD)({ name, eventQueryCriteria, ...data });
-
-export const addTemplateSuccess = (templateId: string, clientId: Object, data: Object) =>
-    actionCreator(actionTypes.TEMPLATE_ADD_SUCCESS)({ templateId, clientId, ...data });
-
-export const addTemplateError = (clientId: Object, data: Object) =>
-    actionCreator(actionTypes.TEMPLATE_ADD_ERROR)({ clientId, ...data });
-
-export const cleanSkipInitAddingTemplate = (template: Object, listId: string) =>
-    actionCreator(actionTypes.TEMPLATE_ADD_SKIP_INIT_CLEAN)({ template, listId });
-
-export const deleteTemplate = (template: Object, programId: string, listId: string) =>
-    actionCreator(actionTypes.TEMPLATE_DELETE)({ template, programId, listId });
-
-export const deleteTemplateSuccess = (template: Object, listId: string) =>
-    actionCreator(actionTypes.TEMPLATE_DELETE_SUCCESS)({ template, listId });
-
-export const deleteTemplateError = (template: Object, listId: string) =>
-    actionCreator(actionTypes.TEMPLATE_DELETE_ERROR)({ template, listId });
-
-export const initListView =
-    (selectedTemplate: Object, context: Object, meta: Object) =>
-        actionCreator(actionTypes.LIST_VIEW_INIT)({ ...meta, selectedTemplate, context });
-
-export const initListViewSuccess =
-    (listId: string, data: Object) => actionCreator(actionTypes.LIST_VIEW_INIT_SUCCESS)({ ...data, listId });
-
-export const initListViewError =
-    (listId: string, errorMessage: string) =>
-        actionCreator(actionTypes.LIST_VIEW_INIT_ERROR)({ listId, errorMessage });
-
-export const initListViewCancel =
-    (listId: string) => actionCreator(actionTypes.LIST_VIEW_INIT_CANCEL)({ listId });
-
-export const updateList =
-    (queryArgs: Object, meta: Object) => actionCreator(actionTypes.LIST_UPDATE)({ queryArgs, ...meta });
-
-export const updateListSuccess =
-    (listId: string, data: Object) => actionCreator(actionTypes.LIST_UPDATE_SUCCESS)({ ...data, listId });
-
-export const updateListError =
-    (listId: string, errorMessage: string) =>
-        actionCreator(actionTypes.LIST_UPDATE_ERROR)({ listId, errorMessage });
-
-export const updateListCancel =
-    (listId: string) => actionCreator(actionTypes.LIST_UPDATE_CANCEL)({ listId });
 
 export const deleteEventSuccess =
     (eventId: string, listId: string) => actionCreator(actionTypes.EVENT_DELETE_SUCCESS)({ eventId, listId });
 
 export const deleteEventError =
     () => actionCreator(actionTypes.EVENT_DELETE_ERROR)();
-
-export const unloadingContext = (listId: string) => actionCreator(actionTypes.CONTEXT_UNLOADING)({ listId });
 
 export const openViewEventPage =
     (eventId: string) => actionCreator(actionTypes.VIEW_EVENT_PAGE_OPEN)(eventId);

--- a/src/core_modules/capture-core/components/Pages/MainPage/WorkingListsCommon/actions/workingListsCommon.actions.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/WorkingListsCommon/actions/workingListsCommon.actions.js
@@ -2,22 +2,123 @@
 import { actionCreator } from '../../../../../actions/actions.utils';
 
 export const workingListsCommonActionTypes = {
+    TEMPLATES_FETCH: 'WorkingListsTemplatesFetch',
+    TEMPLATES_FETCH_SUCCESS: 'WorkingListsTemplatesFetchSuccess',
+    TEMPLATES_FETCH_ERROR: 'WorkingListsTemplatesFetchError',
+    TEMPLATES_FETCH_CANCEL: 'WorkingListsTemplatesFetchCancel',
+    TEMPLATE_SELECT: 'WorkingListsTemplateSelect',
+    TEMPLATE_ADD: 'WorkingListsTemplateAdd',
+    TEMPLATE_ADD_SUCCESS: 'WorkingListsTemplateAddSuccess',
+    TEMPLATE_ADD_ERROR: 'WorkingListsTemplateAddError',
+    TEMPLATE_ADD_SKIP_INIT_CLEAN: 'WorkingListsTemplateAddSkipInitClean',
+    TEMPLATE_DELETE: 'WorkingListsTemplateDelete',
+    TEMPLATE_DELETE_SUCCESS: 'WorkingListsTemplateDeleteSuccess',
+    TEMPLATE_DELETE_ERROR: 'WorkingListsTemplateDeleteError',
+    TEMPLATE_UPDATE: 'WorkingListsTemplateUpdate',
+    TEMPLATE_UPDATE_SUCCESS: 'WorkingListsTemplateUpdateSuccess',
+    TEMPLATE_UPDATE_ERROR: 'WorkingListsTemplateUpdateError',
+    LIST_VIEW_INIT: 'WorkingListsListViewInit',
+    LIST_VIEW_INIT_SUCCESS: 'WorkingListsListViewInitSuccess',
+    LIST_VIEW_INIT_ERROR: 'WorkingListsListViewInitError',
+    LIST_VIEW_INIT_CANCEL: 'WorkingListsListViewInitCancel',
+    LIST_UPDATE: 'WorkingListsListUpdate',
+    LIST_UPDATE_SUCCESS: 'WorkingListsListUpdateSuccess',
+    LIST_UPDATE_ERROR: 'WorkingListsListUpdateError',
+    LIST_UPDATE_CANCEL: 'WorkingListsListUpdateCancel',
+    CONTEXT_UNLOADING: 'WorkingListsContextUnloading',
+
     LIST_SORT: 'WorkingListsListSort',
     LIST_COLUMN_ORDER_SET: 'WorkingListsListColumnOrderSet',
     FILTER_SET: 'WorkingListsFilterSet',
     FILTER_CLEAR: 'WorkingListsFilterClear',
-    REST_MENU_ITEM_SELECTED: 'RestMenuItemSelected',
-    STICKY_FILTERS_AFTER_COLUMN_SORTING_SET: 'StickyFiltersAfterColumnSortingSet',
-    PAGE_CHANGE: 'PageChange',
-    ROWS_PER_PAGE_CHANGE: 'RowsPerPageChange',
+    REST_MENU_ITEM_SELECTED: 'WorkingListsRestMenuItemSelected',
+    STICKY_FILTERS_AFTER_COLUMN_SORTING_SET: 'WorkingListsStickyFiltersAfterColumnSortingSet',
+    PAGE_CHANGE: 'WorkingListsPageChange',
+    ROWS_PER_PAGE_CHANGE: 'WorkingListsRowsPerPageChange',
 };
+
+export const batchActionTypes = {
+    TEMPLATES_FETCH_SUCCESS_BATCH: 'EventWorkingListTemplatesFetchSuccessBatch', // TODO: shouldn't be used eventually
+};
+
+export const fetchTemplates =
+    (programId: string, listId: string) =>
+        actionCreator(workingListsCommonActionTypes.TEMPLATES_FETCH)({ programId, listId });
+
+export const fetchTemplatesSuccess = (templates: Array<any>, programId: string, listId: string) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATES_FETCH_SUCCESS)({ templates, programId, listId });
+
+export const fetchTemplatesError = (error: string, listId: string) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATES_FETCH_ERROR)({ error, listId });
+
+export const fetchTemplatesCancel = (listId: string) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATES_FETCH_CANCEL)({ listId });
+
+export const selectTemplate = (templateId: string, listId: string) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATE_SELECT)({ templateId, listId });
+
+export const updateTemplate = (template: Object, eventQueryCriteria: Object, data: Object) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATE_UPDATE)({ template, eventQueryCriteria, ...data });
+
+export const updateTemplateSuccess = (templateId: string, eventQueryCriteria: Object, data: Object) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATE_UPDATE_SUCCESS)({ templateId, eventQueryCriteria, ...data });
+
+export const updateTemplateError = (templateId: string, eventQueryCriteria: Object, data: Object) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATE_UPDATE_ERROR)({ templateId, eventQueryCriteria, ...data });
+
+export const addTemplate = (name: string, eventQueryCriteria: Object, data: Object) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATE_ADD)({ name, eventQueryCriteria, ...data });
+
+export const addTemplateSuccess = (templateId: string, clientId: Object, data: Object) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATE_ADD_SUCCESS)({ templateId, clientId, ...data });
+
+export const addTemplateError = (clientId: Object, data: Object) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATE_ADD_ERROR)({ clientId, ...data });
+
+export const cleanSkipInitAddingTemplate = (template: Object, listId: string) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATE_ADD_SKIP_INIT_CLEAN)({ template, listId });
+
+export const deleteTemplate = (template: Object, programId: string, listId: string) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATE_DELETE)({ template, programId, listId });
+
+export const deleteTemplateSuccess = (template: Object, listId: string) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATE_DELETE_SUCCESS)({ template, listId });
+
+export const deleteTemplateError = (template: Object, listId: string) =>
+    actionCreator(workingListsCommonActionTypes.TEMPLATE_DELETE_ERROR)({ template, listId });
+
+export const initListView = (selectedTemplate: Object, context: Object, meta: Object) =>
+    actionCreator(workingListsCommonActionTypes.LIST_VIEW_INIT)({ ...meta, selectedTemplate, context });
+
+export const initListViewSuccess = (listId: string, data: Object) =>
+    actionCreator(workingListsCommonActionTypes.LIST_VIEW_INIT_SUCCESS)({ ...data, listId });
+
+export const initListViewError = (listId: string, errorMessage: string) =>
+    actionCreator(workingListsCommonActionTypes.LIST_VIEW_INIT_ERROR)({ listId, errorMessage });
+
+export const initListViewCancel =
+    (listId: string) => actionCreator(workingListsCommonActionTypes.LIST_VIEW_INIT_CANCEL)({ listId });
+
+export const updateList = (queryArgs: Object, meta: Object) =>
+    actionCreator(workingListsCommonActionTypes.LIST_UPDATE)({ queryArgs, ...meta });
+
+export const updateListSuccess = (listId: string, data: Object) =>
+    actionCreator(workingListsCommonActionTypes.LIST_UPDATE_SUCCESS)({ ...data, listId });
+
+export const updateListError = (listId: string, errorMessage: string) =>
+    actionCreator(workingListsCommonActionTypes.LIST_UPDATE_ERROR)({ listId, errorMessage });
+
+export const updateListCancel = (listId: string) =>
+    actionCreator(workingListsCommonActionTypes.LIST_UPDATE_CANCEL)({ listId });
+
+export const unloadingContext = (listId: string) =>
+    actionCreator(workingListsCommonActionTypes.CONTEXT_UNLOADING)({ listId });
 
 export const sortList = (id: string, direction: string, listId: string) =>
     actionCreator(workingListsCommonActionTypes.LIST_SORT)({ id, direction, listId });
 
-export const setListColumnOrder =
-    (columns: Array<Object>, listId: string) =>
-        actionCreator(workingListsCommonActionTypes.LIST_COLUMN_ORDER_SET)({ columns, listId }, { skipLogging: ['columns'] });
+export const setListColumnOrder = (columns: Array<Object>, listId: string) =>
+    actionCreator(workingListsCommonActionTypes.LIST_COLUMN_ORDER_SET)({ columns, listId }, { skipLogging: ['columns'] });
 
 export const setFilter = (filter: Object, itemId: string, listId: string) =>
     actionCreator(workingListsCommonActionTypes.FILTER_SET)({ filter, itemId, listId });
@@ -31,10 +132,8 @@ export const restMenuItemSelected = (id: string, listId: string) =>
 export const setStickyFiltersAfterColumnSorting = (includeFilters: Object, listId: string) =>
     actionCreator(workingListsCommonActionTypes.STICKY_FILTERS_AFTER_COLUMN_SORTING_SET)({ includeFilters, listId });
 
-export const changePage =
-    (pageNumber: number, listId: string) =>
-        actionCreator(workingListsCommonActionTypes.PAGE_CHANGE)({ pageNumber, listId });
+export const changePage = (pageNumber: number, listId: string) =>
+    actionCreator(workingListsCommonActionTypes.PAGE_CHANGE)({ pageNumber, listId });
 
-export const changeRowsPerPage =
-    (rowsPerPage: number, listId: string) =>
-        actionCreator(workingListsCommonActionTypes.ROWS_PER_PAGE_CHANGE)({ rowsPerPage, listId });
+export const changeRowsPerPage = (rowsPerPage: number, listId: string) =>
+    actionCreator(workingListsCommonActionTypes.ROWS_PER_PAGE_CHANGE)({ rowsPerPage, listId });

--- a/src/core_modules/capture-core/components/Pages/MainPage/WorkingListsCommon/hooks/useWorkingListsCommonStateManagement.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/WorkingListsCommon/hooks/useWorkingListsCommonStateManagement.js
@@ -4,16 +4,6 @@ import { useMemo, useCallback } from 'react';
 // $FlowFixMe
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import {
-    sortList,
-    setListColumnOrder,
-    setFilter,
-    clearFilter,
-    restMenuItemSelected,
-    changePage,
-    changeRowsPerPage,
-} from '../actions';
-
-import {
     selectTemplate,
     addTemplate,
     updateTemplate,
@@ -26,7 +16,14 @@ import {
     updateListCancel,
     cleanSkipInitAddingTemplate,
     unloadingContext,
-} from '../../EventWorkingLists/eventWorkingLists.actions'; // TODO: Move these actions
+    sortList,
+    setListColumnOrder,
+    setFilter,
+    clearFilter,
+    restMenuItemSelected,
+    changePage,
+    changeRowsPerPage,
+} from '../actions';
 import type { Program } from '../../../../../metaData';
 
 const useTemplates = (listId: string, workingListDispatch: Function) => {

--- a/src/core_modules/capture-core/reducers/descriptions/events.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/events.reducerDescription.js
@@ -5,7 +5,7 @@ import { actionTypes as dataEntryActionTypes } from '../../components/DataEntry/
 import { actionTypes as enrollmentActionTypes } from '../../actions/__TEMP__/enrollment.actions';
 import { actionTypes as editEventActionTypes } from '../../components/Pages/EditEvent/editEvent.actions';
 import { actionTypes as viewEventActionTypes } from '../../components/Pages/ViewEvent/ViewEventComponent/viewEvent.actions';
-import { eventWorkingListsActionTypes } from '../../components/Pages/MainPage/EventWorkingLists';
+import { workingListsCommonActionTypes } from '../../components/Pages/MainPage/WorkingListsCommon';
 
 const getFromWorkingListRetrieval = (eventContainers, containerProperty) => {
     if (!eventContainers || eventContainers.length === 0) {
@@ -21,13 +21,13 @@ const getFromWorkingListRetrieval = (eventContainers, containerProperty) => {
 };
 
 export const eventsDesc = createReducerDescription({
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {  // TODO: Move to common state container in later PR
         const eventContainers = action.payload.eventContainers;
         const newEventsById = getFromWorkingListRetrieval(eventContainers, 'event');
         const newState = { ...newEventsById };
         return newState;
     },
-    [eventWorkingListsActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => { // TODO: Move to common state container in later PR
         const eventContainers = action.payload.eventContainers;
         const newEventsById = getFromWorkingListRetrieval(eventContainers, 'event');
         const newState = { ...newEventsById };
@@ -95,13 +95,13 @@ export const eventsDesc = createReducerDescription({
 }, 'events', {});
 
 export const eventsValuesDesc = createReducerDescription({
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => { // TODO: Move to common state container in later PR
         const eventContainers = action.payload.eventContainers;
         const newEventsValuesById = getFromWorkingListRetrieval(eventContainers, 'values');
         const newState = { ...newEventsValuesById };
         return newState;
     },
-    [eventWorkingListsActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => { // TODO: Move to common state container in later PR
         const eventContainers = action.payload.eventContainers;
         const newEventsValuesById = getFromWorkingListRetrieval(eventContainers, 'values');
         const newState = { ...newEventsValuesById };

--- a/src/core_modules/capture-core/reducers/descriptions/feedback.reducerDescriptionGetter.js
+++ b/src/core_modules/capture-core/reducers/descriptions/feedback.reducerDescriptionGetter.js
@@ -22,6 +22,7 @@ import {
 import { asyncHandlerActionTypes } from '../../components/D2Form';
 import { registrationSectionActionTypes } from '../../components/Pages/NewRelationship/RegisterTei';
 import { eventWorkingListsActionTypes } from '../../components/Pages/MainPage/EventWorkingLists';
+import { workingListsCommonActionTypes } from '../../components/Pages/MainPage/WorkingListsCommon';
 import type { Updaters } from '../../trackerRedux/trackerReducer';
 
 function addErrorFeedback(state: ReduxState, message: string, action?: ?React.Node) {
@@ -53,7 +54,7 @@ export const getFeedbackDesc = (appUpdaters: Updaters) => createReducerDescripti
         addErrorFeedback(state, action.payload.error, action.payload.action),
     [enrollmentActionTypes.ENROLLMENT_LOAD_FAILED]: (state, action) =>
         addErrorFeedback(state, action.payload),
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT_ERROR]: (state, action) =>
+    [workingListsCommonActionTypes.LIST_VIEW_INIT_ERROR]: (state, action) =>
         addErrorFeedback(state, action.payload.errorMessage),
     [newEventDataEntryActionTypes.SAVE_FAILED_FOR_NEW_EVENT_AFTER_RETURNED_TO_MAIN_PAGE]: (state, action) => {
         const error = action.payload;
@@ -77,7 +78,7 @@ export const getFeedbackDesc = (appUpdaters: Updaters) => createReducerDescripti
         ];
         return newState;
     },
-    [eventWorkingListsActionTypes.LIST_UPDATE_ERROR]: (state, action) => [
+    [workingListsCommonActionTypes.LIST_UPDATE_ERROR]: (state, action) => [
         ...state,
         getErrorFeedback(action.payload.errorMessage),
     ],
@@ -85,15 +86,15 @@ export const getFeedbackDesc = (appUpdaters: Updaters) => createReducerDescripti
         ...state,
         getErrorFeedback(i18n.t('Could not delete event')),
     ],
-    [eventWorkingListsActionTypes.TEMPLATE_UPDATE_ERROR]: state => [
+    [workingListsCommonActionTypes.TEMPLATE_UPDATE_ERROR]: state => [
         ...state,
         getErrorFeedback(i18n.t('Could not save working list')),
     ],
-    [eventWorkingListsActionTypes.TEMPLATE_ADD_ERROR]: state => [
+    [workingListsCommonActionTypes.TEMPLATE_ADD_ERROR]: state => [
         ...state,
         getErrorFeedback(i18n.t('Could not add working list')),
     ],
-    [eventWorkingListsActionTypes.TEMPLATE_DELETE_ERROR]: state => [
+    [workingListsCommonActionTypes.TEMPLATE_DELETE_ERROR]: state => [
         ...state,
         getErrorFeedback(i18n.t('Could not delete working list')),
     ],

--- a/src/core_modules/capture-core/reducers/descriptions/workingLists/meta/meta.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/workingLists/meta/meta.reducerDescription.js
@@ -1,18 +1,17 @@
 // @flow
 import { createReducerDescription } from '../../../../trackerRedux/trackerReducer';
 import { workingListsCommonActionTypes } from '../../../../components/Pages/MainPage/WorkingListsCommon';
-import { eventWorkingListsActionTypes } from '../../../../components/Pages/MainPage/EventWorkingLists';
 import { recentlyAddedEventsActionTypes } from '../../../../components/Pages/NewEvent/RecentlyAddedEventsList';
 
 export const workingListsMetaDesc = createReducerDescription({
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT]: (state, action) => {
         const { listId } = action.payload;
         return {
             ...state,
             [listId]: undefined,
         };
     },
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {
         const newState = { ...state };
         const { listId, config, pagingData } = action.payload;
         const {
@@ -47,7 +46,7 @@ export const workingListsMetaDesc = createReducerDescription({
 
         return newState;
     },
-    [eventWorkingListsActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => {
         const newState = { ...state };
         const { listId, pagingData } = action.payload;
         const next = newState[listId].next;
@@ -63,7 +62,7 @@ export const workingListsMetaDesc = createReducerDescription({
         };
         return newState;
     },
-    [eventWorkingListsActionTypes.LIST_UPDATE_ERROR]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_UPDATE_ERROR]: (state, action) => {
         const newState = { ...state };
         const listId = action.payload.listId;
         newState[listId] = {
@@ -72,7 +71,7 @@ export const workingListsMetaDesc = createReducerDescription({
         };
         return newState;
     },
-    [eventWorkingListsActionTypes.TEMPLATE_UPDATE]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_UPDATE]: (state, action) => {
         const { visibleColumnIds, filters, sortById, sortByDirection, listId } = action.payload;
 
         const nextInitial = {
@@ -90,7 +89,7 @@ export const workingListsMetaDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_UPDATE_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_UPDATE_SUCCESS]: (state, action) => {
         const { isActiveTemplate, listId } = action.payload;
 
         if (!isActiveTemplate) {
@@ -106,7 +105,7 @@ export const workingListsMetaDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_UPDATE_ERROR]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_UPDATE_ERROR]: (state, action) => {
         const { isActiveTemplate, listId } = action.payload;
 
         if (!isActiveTemplate) {
@@ -121,7 +120,7 @@ export const workingListsMetaDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_ADD]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_ADD]: (state, action) => {
         const { visibleColumnIds, filters, sortById, sortByDirection, listId } = action.payload;
 
         const nextInitial = {
@@ -139,7 +138,7 @@ export const workingListsMetaDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_ADD_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_ADD_SUCCESS]: (state, action) => {
         const { isActiveTemplate, listId } = action.payload;
 
         if (!isActiveTemplate) {
@@ -155,7 +154,7 @@ export const workingListsMetaDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_ADD_ERROR]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_ADD_ERROR]: (state, action) => {
         const { isActiveTemplate, listId } = action.payload;
 
         if (!isActiveTemplate) {

--- a/src/core_modules/capture-core/reducers/descriptions/workingLists/workingLists.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/workingLists/workingLists.reducerDescription.js
@@ -6,7 +6,7 @@ import { eventWorkingListsActionTypes } from '../../../components/Pages/MainPage
 import { recentlyAddedEventsActionTypes } from '../../../components/Pages/NewEvent/RecentlyAddedEventsList';
 
 export const workingListsTemplatesDesc = createReducerDescription({
-    [eventWorkingListsActionTypes.TEMPLATES_FETCH]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATES_FETCH]: (state, action) => {
         const { listId } = action.payload;
         return {
             ...state,
@@ -16,7 +16,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATES_FETCH_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATES_FETCH_SUCCESS]: (state, action) => {
         const { templates, listId } = action.payload;
         return {
             ...state,
@@ -27,7 +27,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATES_FETCH_ERROR]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATES_FETCH_ERROR]: (state, action) => {
         const { listId, error } = action.payload;
         return {
             ...state,
@@ -38,7 +38,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_SELECT]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_SELECT]: (state, action) => {
         const { listId, templateId } = action.payload;
         return {
             ...state,
@@ -49,7 +49,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_UPDATE]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_UPDATE]: (state, action) => {
         const { eventQueryCriteria, template, listId } = action.payload;
 
         const otherTemplates = state[listId].templates.filter(t => t.id !== template.id);
@@ -69,7 +69,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_UPDATE_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_UPDATE_SUCCESS]: (state, action) => {
         const { eventQueryCriteria, templateId, listId } = action.payload;
         const templates = state[listId].templates;
         const targetTemplate = templates.find(t => t.id === templateId);
@@ -95,7 +95,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
         }
         return state;
     },
-    [eventWorkingListsActionTypes.TEMPLATE_UPDATE_ERROR]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_UPDATE_ERROR]: (state, action) => {
         const { templateId, listId } = action.payload;
 
         const templates = state[listId].templates;
@@ -121,7 +121,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
         }
         return state;
     },
-    [eventWorkingListsActionTypes.TEMPLATE_ADD]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_ADD]: (state, action) => {
         const { name, eventQueryCriteria, template, clientId, listId } = action.payload;
 
         const newTemplate = {
@@ -156,7 +156,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_ADD_SKIP_INIT_CLEAN]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_ADD_SKIP_INIT_CLEAN]: (state, action) => {
         const { template, listId } = action.payload;
         const templates = state[listId].templates;
         const targetTemplate = templates.find(t => t.id === template.id);
@@ -182,7 +182,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
         }
         return state;
     },
-    [eventWorkingListsActionTypes.TEMPLATE_ADD_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_ADD_SUCCESS]: (state, action) => {
         const { templateId, clientId, listId } = action.payload;
         const templates = state[listId].templates;
         const targetTemplate = templates.find(t => t.id === clientId);
@@ -216,7 +216,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_ADD_ERROR]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_ADD_ERROR]: (state, action) => {
         const { clientId, listId } = action.payload;
         const templates = state[listId].templates.filter(t => t.id !== clientId);
         const currentlySelectedTemplateId = state[listId].selectedTemplateId;
@@ -233,7 +233,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_DELETE]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_DELETE]: (state, action) => {
         const { template, listId } = action.payload;
 
         const otherTemplates = state[listId].templates.filter(t => t.id !== template.id);
@@ -254,7 +254,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_DELETE_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_DELETE_SUCCESS]: (state, action) => {
         const { template, listId } = action.payload;
         const otherTemplates = state[listId].templates.filter(t => t.id !== template.id);
 
@@ -268,7 +268,7 @@ export const workingListsTemplatesDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.TEMPLATE_DELETE_ERROR]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATE_DELETE_ERROR]: (state, action) => {
         const { template, listId } = action.payload;
 
         const otherTemplates = state[listId].templates.filter(t => t.id !== template.id);
@@ -290,14 +290,14 @@ export const workingListsTemplatesDesc = createReducerDescription({
 }, 'workingListsTemplates');
 
 export const workingListsDesc = createReducerDescription({
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT]: (state, action) => {
         const { listId } = action.payload;
         return {
             ...state,
             [listId]: undefined,
         };
     },
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {
         const newState = { ...state };
         const { listId, eventContainers, request } = action.payload;
         newState[listId] = {
@@ -309,7 +309,7 @@ export const workingListsDesc = createReducerDescription({
         };
         return newState;
     },
-    [eventWorkingListsActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => {
         const newState = { ...state };
         const { listId, eventContainers, request } = action.payload;
         newState[listId] = {
@@ -354,13 +354,13 @@ const getReadyState = (oldState, more) => ({
 });
 
 export const workingListsUIDesc = createReducerDescription({
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT]: (state, action) => {
         const newState = { ...state };
         const listId = action.payload.listId;
         newState[listId] = { ...newState[listId], isLoading: true };
         return newState;
     },
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {
         const newState = { ...state };
         const listId = action.payload.listId;
         newState[listId] = getReadyState(newState[listId], {
@@ -369,7 +369,7 @@ export const workingListsUIDesc = createReducerDescription({
         });
         return newState;
     },
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT_ERROR]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT_ERROR]: (state, action) => {
         const newState = { ...state };
         const payload = action.payload;
         newState[payload.listId] = getReadyState({}, {
@@ -377,13 +377,13 @@ export const workingListsUIDesc = createReducerDescription({
         });
         return newState;
     },
-    [eventWorkingListsActionTypes.LIST_UPDATE]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_UPDATE]: (state, action) => {
         const newState = { ...state };
         const listId = action.payload.listId;
         newState[listId] = { ...newState[listId], isUpdating: true };
         return newState;
     },
-    [eventWorkingListsActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => {
         const newState = { ...state };
         const listId = action.payload.listId;
         newState[listId] = getReadyState(newState[listId], {
@@ -391,7 +391,7 @@ export const workingListsUIDesc = createReducerDescription({
         });
         return newState;
     },
-    [eventWorkingListsActionTypes.LIST_UPDATE_ERROR]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_UPDATE_ERROR]: (state, action) => {
         const newState = { ...state };
         const listId = action.payload.listId;
         newState[listId] = getReadyState({}, {
@@ -422,14 +422,14 @@ export const workingListsUIDesc = createReducerDescription({
 }, 'workingListsUI');
 
 export const workingListsColumnsOrderDesc = createReducerDescription({
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT]: (state, action) => {
         const { listId } = action.payload;
         return {
             ...state,
             [listId]: undefined,
         };
     },
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {
         const { listId, config: { customColumnOrder } } = action.payload;
         return {
             ...state,
@@ -460,7 +460,7 @@ export const workingListsContextDesc = createReducerDescription({
     The meaning is slightly changed though, having a context now implies that a request for events was done for this context,
     not that events was successfully retrieved for this context.
     */
-    [eventWorkingListsActionTypes.TEMPLATES_FETCH]: (state, action) => {
+    [workingListsCommonActionTypes.TEMPLATES_FETCH]: (state, action) => {
         const { programId, listId } = action.payload;
         return {
             ...state,
@@ -470,7 +470,7 @@ export const workingListsContextDesc = createReducerDescription({
             },
         };
     },
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT]: (state, action) => {
         const newState = { ...state };
         const { listId, context: { programId, ...restContext } } = action.payload;
         newState[listId] = {
@@ -489,14 +489,14 @@ export const workingListsContextDesc = createReducerDescription({
 }, 'workingListsContext');
 
 export const workingListsStickyFiltersDesc = createReducerDescription({
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT]: (state, action) => {
         const { listId } = action.payload;
         return {
             ...state,
             [listId]: undefined,
         };
     },
-    [eventWorkingListsActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {
+    [workingListsCommonActionTypes.LIST_VIEW_INIT_SUCCESS]: (state, action) => {
         const { listId, config } = action.payload;
         const filters = config.filters;
         const filtersWithValueOnInit = filters ? Object.keys(filters).reduce((acc, key) => ({


### PR DESCRIPTION
[DHIS2-9802 (Subtask of DHIS2-8695)](https://jira.dhis2.org/browse/DHIS2-9802)

Moving **most** actions to "workingListsCommon". The idea is to use same Redux actions for both the single event and tracked entity instance lists to get "free" state management. For most actions this probably makes sense, but there is no problem deviating now if different behaviour is required.