### PR TITLE
chore: adds the tetype selector on the new page

### DIFF
--- a/src/core_modules/capture-core/components/Pages/New/NewPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.component.js
@@ -13,6 +13,7 @@ import { InefficientSelectionsMessage } from '../../InefficientSelectionsMessage
 import { TrackedEntityTypeSelector } from '../../TrackedEntityTypeSelector';
 import { scopeTypes } from '../../../metaData';
 import { useScopeInfo } from '../../../hooks/useScopeInfo';
+import { useScopeTitleText } from '../../../hooks/useScopeTitleText';
 
 const getStyles = ({ typography }) => ({
     container: {
@@ -39,18 +40,6 @@ const getStyles = ({ typography }) => ({
     },
 });
 
-export const useTitleText = (selectedSearchScopeId: ?string) => {
-    const { trackedEntityName, programName, scopeType } = useScopeInfo(selectedSearchScopeId);
-
-    const text = {
-        [scopeTypes.EVENT_PROGRAM]: `${programName}`,
-        [scopeTypes.TRACKER_PROGRAM]: `${trackedEntityName} in program: ${programName}`,
-        [scopeTypes.TRACKED_ENTITY_TYPE]: `${trackedEntityName}`,
-    };
-
-    return scopeType ? text[scopeType] : '';
-};
-
 const NewPagePlain = ({
     showMessageToSelectOrgUnitOnNewPage,
     showDefaultViewOnNewPage,
@@ -62,7 +51,7 @@ const NewPagePlain = ({
     const { scopeType } = useScopeInfo(currentProgramId);
     const [selectedScopeType, setScopeType] = useState(scopeType);
     const [selectedScopeId, setScopeId] = useState(currentProgramId);
-    const titleText = useTitleText(selectedScopeId);
+    const titleText = useScopeTitleText(selectedScopeId);
 
     useEffect(() => {
         setScopeId(currentProgramId);

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.component.js
@@ -1,18 +1,34 @@
 // @flow
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { compose } from 'redux';
 import type { ComponentType } from 'react';
 import withStyles from '@material-ui/core/styles/withStyles';
 import i18n from '@dhis2/d2-i18n';
+import Paper from '@material-ui/core/Paper/Paper';
 import { LockedSelector } from '../../LockedSelector';
 import type { ContainerProps, Props } from './NewPage.types';
 import { withErrorMessageHandler, withLoadingIndicator } from '../../../HOC';
 import { newPageStatuses } from './NewPage.constants';
 import { InefficientSelectionsMessage } from '../../InefficientSelectionsMessage';
+import { TrackedEntityTypeSelector } from '../../TrackedEntityTypeSelector';
+import { scopeTypes } from '../../../metaData';
+import { useScopeInfo } from '../../../hooks/useScopeInfo';
 
-const getStyles = () => ({
+const getStyles = ({ typography }) => ({
     container: {
         padding: '10px 24px 16px 24px',
+    },
+    paper: {
+        marginBottom: typography.pxToRem(10),
+        padding: typography.pxToRem(10),
+    },
+    maxWidth: {
+        maxWidth: typography.pxToRem(950),
+    },
+    title: {
+        padding: '10px 0 0px 10px',
+        fontWeight: 500,
+        marginBottom: typography.pxToRem(16),
     },
     emptySelectionPaperContent: {
         display: 'flex',
@@ -23,13 +39,37 @@ const getStyles = () => ({
     },
 });
 
+export const useTitleText = (selectedSearchScopeId: ?string) => {
+    const { trackedEntityName, programName, scopeType } = useScopeInfo(selectedSearchScopeId);
+
+    const text = {
+        [scopeTypes.EVENT_PROGRAM]: `${programName}`,
+        [scopeTypes.TRACKER_PROGRAM]: `${trackedEntityName} in program: ${programName}`,
+        [scopeTypes.TRACKED_ENTITY_TYPE]: `${trackedEntityName}`,
+    };
+
+    return scopeType ? text[scopeType] : '';
+};
+
 const NewPagePlain = ({
     showMessageToSelectOrgUnitOnNewPage,
     showDefaultViewOnNewPage,
     classes,
     currentOrgUnitId,
+    currentProgramId,
     newPageStatus,
 }: Props) => {
+    const { scopeType } = useScopeInfo(currentProgramId);
+    const [selectedScopeType, setScopeType] = useState(scopeType);
+    const [selectedScopeId, setScopeId] = useState(currentProgramId);
+    const titleText = useTitleText(selectedScopeId);
+
+    useEffect(() => {
+        setScopeId(currentProgramId);
+        setScopeType(scopeType);
+    }, [scopeType, currentProgramId]);
+
+
     useEffect(() => {
         if (!currentOrgUnitId) {
             showMessageToSelectOrgUnitOnNewPage();
@@ -43,21 +83,44 @@ const NewPagePlain = ({
         currentOrgUnitId,
     ]);
 
+    const handleRegistrationScopeSelection = (id, type) => {
+        setScopeId(id);
+        setScopeType(type);
+    };
+
+
     return (<>
         <LockedSelector />
-        <div data-test="dhis2-capture-search-page-content" className={classes.container} >
-            {
-                newPageStatus === newPageStatuses.DEFAULT &&
-                <div>Default view</div>
-            }
 
-        </div>
-        {
-            newPageStatus === newPageStatuses.WITHOUT_ORG_UNIT_SELECTED &&
+        <div data-test="dhis2-capture-registration-page-content" className={classes.container} >
+            <Paper className={classes.paper}>
+                <div className={classes.maxWidth}>
+                    <div className={classes.title} >
+                        New {titleText}
+                    </div>
+
+                    {
+                        newPageStatus === newPageStatuses.DEFAULT &&
+                        <>
+                            {
+                                (!selectedScopeType || selectedScopeType === scopeTypes.TRACKED_ENTITY_TYPE) &&
+                                <TrackedEntityTypeSelector
+                                    onSelect={handleRegistrationScopeSelection}
+                                    selectedSearchScopeId={selectedScopeId}
+                                />
+                            }
+
+                        </>
+                    }
+                </div>
+            </Paper>
+            {
+                newPageStatus === newPageStatuses.WITHOUT_ORG_UNIT_SELECTED &&
                 <InefficientSelectionsMessage
                     message={i18n.t('Choose a registering unit to start reporting')}
                 />
-        }
+            }
+        </div>
     </>);
 };
 

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.component.js
@@ -82,29 +82,28 @@ const NewPagePlain = ({
         <LockedSelector />
 
         <div data-test="dhis2-capture-registration-page-content" className={classes.container} >
-            <Paper className={classes.paper}>
-                <div className={classes.maxWidth}>
-                    <div className={classes.title} >
-                        New {titleText}
-                    </div>
+            {
+                newPageStatus === newPageStatuses.DEFAULT &&
 
-                    {
-                        newPageStatus === newPageStatuses.DEFAULT &&
-                        <>
-                            {
-                                (!selectedScopeType || selectedScopeType === scopeTypes.TRACKED_ENTITY_TYPE) &&
+                <Paper className={classes.paper}>
+                    <div className={classes.maxWidth}>
+                        <div className={classes.title} >
+                            New {titleText}
+                        </div>
+                        {
+                            (!selectedScopeType || selectedScopeType === scopeTypes.TRACKED_ENTITY_TYPE) &&
                                 <TrackedEntityTypeSelector
                                     onSelect={handleRegistrationScopeSelection}
                                     selectedSearchScopeId={selectedScopeId}
                                 />
-                            }
+                        }
+                    </div>
+                </Paper>
+            }
 
-                        </>
-                    }
-                </div>
-            </Paper>
             {
                 newPageStatus === newPageStatuses.WITHOUT_ORG_UNIT_SELECTED &&
+
                 <InefficientSelectionsMessage
                     message={i18n.t('Choose a registering unit to start reporting')}
                 />

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.component.js
@@ -58,7 +58,6 @@ const NewPagePlain = ({
         setScopeType(scopeType);
     }, [scopeType, currentProgramId]);
 
-
     useEffect(() => {
         if (!currentOrgUnitId) {
             showMessageToSelectOrgUnitOnNewPage();
@@ -77,14 +76,12 @@ const NewPagePlain = ({
         setScopeType(type);
     };
 
-
     return (<>
         <LockedSelector />
 
         <div data-test="dhis2-capture-registration-page-content" className={classes.container} >
             {
                 newPageStatus === newPageStatuses.DEFAULT &&
-
                 <Paper className={classes.paper}>
                     <div className={classes.maxWidth}>
                         <div className={classes.title} >
@@ -103,7 +100,6 @@ const NewPagePlain = ({
 
             {
                 newPageStatus === newPageStatuses.WITHOUT_ORG_UNIT_SELECTED &&
-
                 <InefficientSelectionsMessage
                     message={i18n.t('Choose a registering unit to start reporting')}
                 />

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
@@ -33,7 +33,6 @@ export const NewPage: ComponentType<{||}> = () => {
     const newPageStatus: $Keys<newPageStatuses> =
         useSelector(({ newPage }) => newPage.newPageStatus);
 
-
     return (
         <NewPageComponent
             showMessageToSelectOrgUnitOnNewPage={dispatchShowMessageToSelectOrgUnitOnNewPage}

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.types.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.types.js
@@ -1,5 +1,6 @@
 // @flow
 import { typeof newPageStatuses } from './NewPage.constants';
+import type { TrackedEntityTypesWithCorrelatedPrograms } from '../Search/SearchPage.types';
 
 export type ContainerProps = $ReadOnly<{|
   showMessageToSelectOrgUnitOnNewPage: ()=>void,

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.types.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.types.js
@@ -1,6 +1,5 @@
 // @flow
 import { typeof newPageStatuses } from './NewPage.constants';
-import type { TrackedEntityTypesWithCorrelatedPrograms } from '../Search/SearchPage.types';
 
 export type ContainerProps = $ReadOnly<{|
   showMessageToSelectOrgUnitOnNewPage: ()=>void,

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
@@ -78,7 +78,6 @@ const Index = ({
     navigateToMainPage,
     cleanSearchRelatedInfo,
     classes,
-    trackedEntityTypesWithCorrelatedPrograms,
     availableSearchOptions,
     preselectedProgramId,
     searchStatus,

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
@@ -155,7 +155,6 @@ const Index = ({
                         {
                             (selectedSearchScopeType !== searchScopes.PROGRAM) &&
                             <TrackedEntityTypeSelector
-                                trackedEntityTypesWithCorrelatedPrograms={trackedEntityTypesWithCorrelatedPrograms}
                                 onSelect={handleSearchScopeSelection}
                                 selectedSearchScopeId={selectedSearchScopeId}
                             />

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.container.js
@@ -5,9 +5,8 @@ import type { ComponentType } from 'react';
 import { SearchPageComponent } from './SearchPage.component';
 import type { AvailableSearchOptions } from './SearchPage.types';
 import { cleanSearchRelatedData, navigateToMainPage, showInitialViewOnSearchPage } from './SearchPage.actions';
-
 import { searchScopes } from './SearchPage.constants';
-import { useTrackedEntityTypesWithCorrelatedPrograms } from "../../../hooks/useTrackedEntityTypesWithCorrelatedPrograms";
+import { useTrackedEntityTypesWithCorrelatedPrograms } from '../../../hooks/useTrackedEntityTypesWithCorrelatedPrograms';
 
 const buildSearchOption = (id, name, searchGroups, searchScope, type) => ({
     searchOptionId: id,
@@ -27,8 +26,9 @@ const buildSearchOption = (id, name, searchGroups, searchScope, type) => ({
         })),
 });
 
-const useSearchOptions = (trackedEntityTypesWithCorrelatedPrograms): AvailableSearchOptions =>
-    useMemo(() =>
+const useSearchOptions = (): AvailableSearchOptions => {
+    const trackedEntityTypesWithCorrelatedPrograms = useTrackedEntityTypesWithCorrelatedPrograms();
+    return useMemo(() =>
         Object.values(trackedEntityTypesWithCorrelatedPrograms)
             // $FlowFixMe https://github.com/facebook/flow/issues/2221
             .reduce((acc, { trackedEntityTypeId, trackedEntityTypeName, trackedEntityTypeSearchGroups, programs }) => ({
@@ -44,10 +44,12 @@ const useSearchOptions = (trackedEntityTypesWithCorrelatedPrograms): AvailableSe
             }), {}),
     [trackedEntityTypesWithCorrelatedPrograms],
     );
+};
 
-const usePreselectedProgram = (trackedEntityTypesWithCorrelatedPrograms): ?string => {
+const usePreselectedProgram = (): ?string => {
     const currentSelectionsId =
       useSelector(({ currentSelections }) => currentSelections.programId);
+    const trackedEntityTypesWithCorrelatedPrograms = useTrackedEntityTypesWithCorrelatedPrograms();
 
     return useMemo(() => {
         const { programId } =
@@ -77,9 +79,8 @@ export const SearchPage: ComponentType<{||}> = () => {
         () => { dispatch(cleanSearchRelatedData()); },
         [dispatch]);
 
-    const trackedEntityTypesWithCorrelatedPrograms = useTrackedEntityTypesWithCorrelatedPrograms();
-    const availableSearchOptions = useSearchOptions(trackedEntityTypesWithCorrelatedPrograms);
-    const preselectedProgramId = usePreselectedProgram(trackedEntityTypesWithCorrelatedPrograms);
+    const availableSearchOptions = useSearchOptions();
+    const preselectedProgramId = usePreselectedProgram();
 
     const searchStatus: string =
       useSelector(({ searchPage }) => searchPage.searchStatus);
@@ -105,7 +106,6 @@ export const SearchPage: ComponentType<{||}> = () => {
             navigateToMainPage={dispatchNavigateToMainPage}
             showInitialSearchPage={dispatchShowInitialSearchPage}
             cleanSearchRelatedInfo={dispatchCleanSearchRelatedData}
-            trackedEntityTypesWithCorrelatedPrograms={trackedEntityTypesWithCorrelatedPrograms}
             availableSearchOptions={availableSearchOptions}
             preselectedProgramId={preselectedProgramId}
             trackedEntityTypeId={trackedEntityTypeId}

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.container.js
@@ -7,6 +7,7 @@ import type { AvailableSearchOptions } from './SearchPage.types';
 import { cleanSearchRelatedData, navigateToMainPage, showInitialViewOnSearchPage } from './SearchPage.actions';
 
 import { searchScopes } from './SearchPage.constants';
+import { useTrackedEntityTypesWithCorrelatedPrograms } from "../../../hooks/useTrackedEntityTypesWithCorrelatedPrograms";
 
 const buildSearchOption = (id, name, searchGroups, searchScope, type) => ({
     searchOptionId: id,

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.container.js
@@ -3,10 +3,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import React, { useCallback, useMemo, useEffect } from 'react';
 import type { ComponentType } from 'react';
 import { SearchPageComponent } from './SearchPage.component';
-import type { AvailableSearchOptions, TrackedEntityTypesWithCorrelatedPrograms } from './SearchPage.types';
+import type { AvailableSearchOptions } from './SearchPage.types';
 import { cleanSearchRelatedData, navigateToMainPage, showInitialViewOnSearchPage } from './SearchPage.actions';
-import { programCollection } from '../../../metaDataMemoryStores';
-import { TrackerProgram } from '../../../metaData';
+
 import { searchScopes } from './SearchPage.constants';
 
 const buildSearchOption = (id, name, searchGroups, searchScope, type) => ({
@@ -26,40 +25,6 @@ const buildSearchOption = (id, name, searchGroups, searchScope, type) => ({
             minAttributesRequiredToSearch,
         })),
 });
-
-const useTrackedEntityTypesWithCorrelatedPrograms = (): TrackedEntityTypesWithCorrelatedPrograms =>
-    useMemo(() =>
-        [...programCollection.values()]
-            .filter(program => program instanceof TrackerProgram)
-            // $FlowFixMe
-            .reduce((acc, {
-                id: programId,
-                name: programName,
-                trackedEntityType: {
-                    id: trackedEntityTypeId,
-                    name: trackedEntityTypeName,
-                    searchGroups: trackedEntityTypeSearchGroups,
-                },
-                searchGroups,
-            }: TrackerProgram) => {
-                const accumulatedProgramsOfTrackedEntityType =
-            acc[trackedEntityTypeId] ? acc[trackedEntityTypeId].programs : [];
-                return {
-                    ...acc,
-                    [trackedEntityTypeId]: {
-                        trackedEntityTypeId,
-                        trackedEntityTypeName,
-                        trackedEntityTypeSearchGroups,
-                        programs: [
-                            ...accumulatedProgramsOfTrackedEntityType,
-                            { programId, programName, searchGroups },
-                        ],
-
-                    },
-                };
-            }, {}),
-    [],
-    );
 
 const useSearchOptions = (trackedEntityTypesWithCorrelatedPrograms): AvailableSearchOptions =>
     useMemo(() =>

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.types.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.types.js
@@ -19,23 +19,11 @@ export type AvailableSearchOptions = $ReadOnly<{
       +searchGroups: SearchGroups |}
   }>
 
-export type TrackedEntityTypesWithCorrelatedPrograms = $ReadOnly<{
-  [elementId: string]: {|
-    +trackedEntityTypeId: string,
-    +trackedEntityTypeName: string,
-    +programs: Array<{|
-      +programName: string,
-      +programId: string,
-    |}>
-  |}
-}>
-
 export type ContainerProps = $ReadOnly<{|
   cleanSearchRelatedInfo: ()=>void,
   navigateToMainPage: ()=>void,
   showInitialSearchPage: ()=>void,
   trackedEntityTypeId: string,
-  trackedEntityTypesWithCorrelatedPrograms: TrackedEntityTypesWithCorrelatedPrograms,
   availableSearchOptions: AvailableSearchOptions,
   preselectedProgramId: SelectedSearchScopeId,
   searchStatus: string,

--- a/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
+++ b/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
@@ -95,16 +95,17 @@ export const Index =
           </div>
           {
               !selectedSearchScopeId &&
-              <Grid container direction="row" alignItems="center" className={classes.gridContainerInformativeText}>
-                  <Grid item>
-                      <InfoOutlinedIconWithStyles />
+                  <Grid container direction="row" alignItems="center" className={classes.gridContainerInformativeText}>
+                      <Grid item>
+                          <InfoOutlinedIconWithStyles />
+                      </Grid>
+                      <Grid item className={classes.gridItemInformativeText}>
+                          {i18n.t('You can also choose a program from the top bar and search in that program')}
+                      </Grid>
                   </Grid>
-                  <Grid item className={classes.gridItemInformativeText}>
-                      {i18n.t('You can also choose a program from the top bar and search in that program')}
-                  </Grid>
-              </Grid>
           }
-      </>);
+      </>
+      );
   };
 
 export const TrackedEntityTypeSelector: ComponentType<OwnProps> = withStyles(styles)(Index);

--- a/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
+++ b/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
@@ -1,7 +1,5 @@
 // @flow
 import React, { useMemo, type ComponentType } from 'react';
-import { useHistory } from 'react-router';
-import { useSelector } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
 import withStyles from '@material-ui/core/styles/withStyles';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
@@ -14,7 +12,6 @@ import {
 import type { OwnProps, Props } from './TrackedEntityTypeSelector.types';
 import { scopeTypes } from '../../metaData';
 import { useTrackedEntityTypesWithCorrelatedPrograms } from '../../hooks/useTrackedEntityTypesWithCorrelatedPrograms';
-import { urlThreeArguments } from '../../utils/url';
 
 const styles = ({ typography }) => ({
     searchDomainSelectorSection: {
@@ -64,13 +61,10 @@ const InfoOutlinedIconWithStyles = withStyles({
 
 export const Index =
   ({ classes, onSelect, selectedSearchScopeId }: Props) => {
-      const { push } = useHistory();
-      const orgUnitId: string = useSelector(({ currentSelections }) => currentSelections.orgUnitId);
       const trackedEntityTypesWithCorrelatedPrograms = useTrackedEntityTypesWithCorrelatedPrograms();
 
       const handleSelectionChange = ({ selected }) => {
           onSelect(selected, scopeTypes.TRACKED_ENTITY_TYPE);
-          push(urlThreeArguments({ orgUnitId, trackedEntityTypeId: selected }));
       };
 
       return (<>

--- a/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
+++ b/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
@@ -1,6 +1,7 @@
 // @flow
-import React, { useMemo } from 'react';
-import type { ComponentType } from 'react';
+import React, { useMemo, type ComponentType } from 'react';
+import { useHistory } from 'react-router';
+import { useSelector } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
 import withStyles from '@material-ui/core/styles/withStyles';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
@@ -13,9 +14,7 @@ import {
 import type { OwnProps, Props } from './TrackedEntityTypeSelector.types';
 import { scopeTypes } from '../../metaData';
 import { useTrackedEntityTypesWithCorrelatedPrograms } from '../../hooks/useTrackedEntityTypesWithCorrelatedPrograms';
-import { useHistory } from 'react-router';
 import { urlThreeArguments } from '../../utils/url';
-import { useSelector } from 'react-redux';
 
 const styles = ({ typography }) => ({
     searchDomainSelectorSection: {
@@ -69,10 +68,11 @@ export const Index =
       const orgUnitId: string = useSelector(({ currentSelections }) => currentSelections.orgUnitId);
       const trackedEntityTypesWithCorrelatedPrograms = useTrackedEntityTypesWithCorrelatedPrograms();
 
-      const handleSelect = ({ selected }) => {
+      const handleSelectionChange = ({ selected }) => {
           onSelect(selected, scopeTypes.TRACKED_ENTITY_TYPE);
           push(urlThreeArguments({ orgUnitId, trackedEntityTypeId: selected }));
       };
+
       return (<>
           <div className={classes.header}>
               { i18n.t('Search for')}
@@ -81,7 +81,7 @@ export const Index =
           <div className={classes.searchRow}>
               <div className={classes.searchRowSelectElement}>
                   <SingleSelect
-                      onChange={handleSelect}
+                      onChange={handleSelectionChange}
                       selected={selectedSearchScopeId}
                       empty={<div className={classes.customEmpty}>Custom empty component</div>}
                   >

--- a/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
+++ b/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
@@ -87,7 +87,7 @@ export const Index =
                   >
                       {
                           useMemo(() => Object.values(trackedEntityTypesWithCorrelatedPrograms)
-                          // $FlowFixMe https://github.com/facebook/flow/issues/2221
+                              // $FlowFixMe https://github.com/facebook/flow/issues/2221
                               .map(({ trackedEntityTypeName, trackedEntityTypeId }) =>
                                   (<SingleSelectOption
                                       key={trackedEntityTypeId}

--- a/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
+++ b/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
@@ -12,6 +12,7 @@ import {
 } from '@dhis2/ui';
 import type { OwnProps, Props } from './TrackedEntityTypeSelector.types';
 import { scopeTypes } from '../../metaData';
+import { useTrackedEntityTypesWithCorrelatedPrograms } from '../../hooks/useTrackedEntityTypesWithCorrelatedPrograms';
 
 const styles = ({ typography }) => ({
     searchDomainSelectorSection: {
@@ -60,8 +61,10 @@ const InfoOutlinedIconWithStyles = withStyles({
 })(InfoOutlinedIcon);
 
 export const Index =
-  ({ trackedEntityTypesWithCorrelatedPrograms, classes, onSelect, selectedSearchScopeId }: Props) =>
-      (<>
+  ({ classes, onSelect, selectedSearchScopeId }: Props) => {
+      const trackedEntityTypesWithCorrelatedPrograms = useTrackedEntityTypesWithCorrelatedPrograms();
+
+      return (<>
           <div className={classes.header}>
               { i18n.t('Search for')}
           </div>
@@ -75,7 +78,7 @@ export const Index =
                   >
                       {
                           useMemo(() => Object.values(trackedEntityTypesWithCorrelatedPrograms)
-                              // $FlowFixMe https://github.com/facebook/flow/issues/2221
+                          // $FlowFixMe https://github.com/facebook/flow/issues/2221
                               .map(({ trackedEntityTypeName, trackedEntityTypeId }) =>
                                   (<SingleSelectOption
                                       key={trackedEntityTypeId}
@@ -89,16 +92,16 @@ export const Index =
           </div>
           {
               !selectedSearchScopeId &&
-                  <Grid container direction="row" alignItems="center" className={classes.gridContainerInformativeText}>
-                      <Grid item>
-                          <InfoOutlinedIconWithStyles />
-                      </Grid>
-                      <Grid item className={classes.gridItemInformativeText}>
-                          {i18n.t('You can also choose a program from the top bar and search in that program')}
-                      </Grid>
+              <Grid container direction="row" alignItems="center" className={classes.gridContainerInformativeText}>
+                  <Grid item>
+                      <InfoOutlinedIconWithStyles />
                   </Grid>
+                  <Grid item className={classes.gridItemInformativeText}>
+                      {i18n.t('You can also choose a program from the top bar and search in that program')}
+                  </Grid>
+              </Grid>
           }
-      </>
-      );
+      </>);
+  };
 
 export const TrackedEntityTypeSelector: ComponentType<OwnProps> = withStyles(styles)(Index);

--- a/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
+++ b/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
@@ -59,7 +59,7 @@ const InfoOutlinedIconWithStyles = withStyles({
     },
 })(InfoOutlinedIcon);
 
-export const Index =
+export const TrackedEntityTypeSelectorPlain =
   ({ classes, onSelect, selectedSearchScopeId }: Props) => {
       const trackedEntityTypesWithCorrelatedPrograms = useTrackedEntityTypesWithCorrelatedPrograms();
 
@@ -108,4 +108,4 @@ export const Index =
       );
   };
 
-export const TrackedEntityTypeSelector: ComponentType<OwnProps> = withStyles(styles)(Index);
+export const TrackedEntityTypeSelector: ComponentType<OwnProps> = withStyles(styles)(TrackedEntityTypeSelectorPlain);

--- a/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
+++ b/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
@@ -13,6 +13,9 @@ import {
 import type { OwnProps, Props } from './TrackedEntityTypeSelector.types';
 import { scopeTypes } from '../../metaData';
 import { useTrackedEntityTypesWithCorrelatedPrograms } from '../../hooks/useTrackedEntityTypesWithCorrelatedPrograms';
+import { useHistory } from 'react-router';
+import { urlThreeArguments } from '../../utils/url';
+import { useSelector } from 'react-redux';
 
 const styles = ({ typography }) => ({
     searchDomainSelectorSection: {
@@ -62,8 +65,14 @@ const InfoOutlinedIconWithStyles = withStyles({
 
 export const Index =
   ({ classes, onSelect, selectedSearchScopeId }: Props) => {
+      const { push } = useHistory();
+      const orgUnitId: string = useSelector(({ currentSelections }) => currentSelections.orgUnitId);
       const trackedEntityTypesWithCorrelatedPrograms = useTrackedEntityTypesWithCorrelatedPrograms();
 
+      const handleSelect = ({ selected }) => {
+          onSelect(selected, scopeTypes.TRACKED_ENTITY_TYPE);
+          push(urlThreeArguments({ orgUnitId, trackedEntityTypeId: selected }));
+      };
       return (<>
           <div className={classes.header}>
               { i18n.t('Search for')}
@@ -72,7 +81,7 @@ export const Index =
           <div className={classes.searchRow}>
               <div className={classes.searchRowSelectElement}>
                   <SingleSelect
-                      onChange={({ selected }) => { onSelect(selected, scopeTypes.TRACKED_ENTITY_TYPE); }}
+                      onChange={handleSelect}
                       selected={selectedSearchScopeId}
                       empty={<div className={classes.customEmpty}>Custom empty component</div>}
                   >

--- a/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.types.js
+++ b/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.types.js
@@ -1,9 +1,8 @@
 // @flow
-import type { SelectedSearchScopeId, TrackedEntityTypesWithCorrelatedPrograms } from '../Pages/Search/SearchPage.types';
+import type { SelectedSearchScopeId } from '../Pages/Search/SearchPage.types';
 import { typeof scopeTypes } from '../../metaData';
 
 export type OwnProps = $ReadOnly<{|
-  trackedEntityTypesWithCorrelatedPrograms: TrackedEntityTypesWithCorrelatedPrograms,
   onSelect: (searchScopeId: string, searchScopeType: $Keys<scopeTypes>) => void,
   selectedSearchScopeId: SelectedSearchScopeId
 |}>

--- a/src/core_modules/capture-core/hooks/useTrackedEntityTypesWithCorrelatedPrograms.js
+++ b/src/core_modules/capture-core/hooks/useTrackedEntityTypesWithCorrelatedPrograms.js
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { programCollection } from '../metaDataMemoryStores';
 import { TrackerProgram } from '../metaData/Program';
 
-type TrackedEntityTypesWithCorrelatedPrograms = $ReadOnly<{
+type TrackedEntityTypesWithCorrelatedPrograms = $Exact<$ReadOnly<{
     [elementId: string]: {|
         +trackedEntityTypeId: string,
         +trackedEntityTypeName: string,
@@ -13,12 +13,12 @@ type TrackedEntityTypesWithCorrelatedPrograms = $ReadOnly<{
         |}>
     |}
 }>
-
+>
 export const useTrackedEntityTypesWithCorrelatedPrograms = (): TrackedEntityTypesWithCorrelatedPrograms =>
     useMemo(() =>
         [...programCollection.values()]
             .filter(program => program instanceof TrackerProgram)
-        // $FlowFixMe
+            // $FlowFixMe
             .reduce((acc, {
                 id: programId,
                 name: programName,

--- a/src/core_modules/capture-core/hooks/useTrackedEntityTypesWithCorrelatedPrograms.js
+++ b/src/core_modules/capture-core/hooks/useTrackedEntityTypesWithCorrelatedPrograms.js
@@ -1,0 +1,39 @@
+// @flow
+import { useMemo } from 'react';
+import type { TrackedEntityTypesWithCorrelatedPrograms } from '../components/Pages/Search/SearchPage.types';
+import { programCollection } from '../metaDataMemoryStores';
+import { TrackerProgram } from '../metaData/Program';
+
+export const useTrackedEntityTypesWithCorrelatedPrograms = (): TrackedEntityTypesWithCorrelatedPrograms =>
+    useMemo(() =>
+        [...programCollection.values()]
+            .filter(program => program instanceof TrackerProgram)
+        // $FlowFixMe
+            .reduce((acc, {
+                id: programId,
+                name: programName,
+                trackedEntityType: {
+                    id: trackedEntityTypeId,
+                    name: trackedEntityTypeName,
+                    searchGroups: trackedEntityTypeSearchGroups,
+                },
+                searchGroups,
+            }: TrackerProgram) => {
+                const accumulatedProgramsOfTrackedEntityType =
+          acc[trackedEntityTypeId] ? acc[trackedEntityTypeId].programs : [];
+                return {
+                    ...acc,
+                    [trackedEntityTypeId]: {
+                        trackedEntityTypeId,
+                        trackedEntityTypeName,
+                        trackedEntityTypeSearchGroups,
+                        programs: [
+                            ...accumulatedProgramsOfTrackedEntityType,
+                            { programId, programName, searchGroups },
+                        ],
+
+                    },
+                };
+            }, {}),
+    [],
+    );

--- a/src/core_modules/capture-core/hooks/useTrackedEntityTypesWithCorrelatedPrograms.js
+++ b/src/core_modules/capture-core/hooks/useTrackedEntityTypesWithCorrelatedPrograms.js
@@ -1,8 +1,18 @@
 // @flow
 import { useMemo } from 'react';
-import type { TrackedEntityTypesWithCorrelatedPrograms } from '../components/Pages/Search/SearchPage.types';
 import { programCollection } from '../metaDataMemoryStores';
 import { TrackerProgram } from '../metaData/Program';
+
+type TrackedEntityTypesWithCorrelatedPrograms = $ReadOnly<{
+    [elementId: string]: {|
+        +trackedEntityTypeId: string,
+        +trackedEntityTypeName: string,
+        +programs: Array<{|
+            +programName: string,
+            +programId: string,
+        |}>
+    |}
+}>
 
 export const useTrackedEntityTypesWithCorrelatedPrograms = (): TrackedEntityTypesWithCorrelatedPrograms =>
     useMemo(() =>


### PR DESCRIPTION
Hey Joakim. This is the ticket that adds the TEType Selector on the new page. Ticket can be found here https://jira.dhis2.org/browse/DHIS2-9649 

### What is going on here?
Two things: 
1. added the Selector but selecting a new item from the dropdown wont change the url. The next PR will take care of that as it is captured in a separate ticket.
2. reused the `useTrackedEntityTypesWithCorrelatedPrograms` instead of prop drilling I was doing before


