### PR TITLE
chore: adds retries on cypress

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -7,5 +7,9 @@
   "chromeWebSecurity": false,
   "defaultCommandTimeout": 60000,
   "projectId": "322xnh",
-  "experimentalFetchPolyfill": true
+  "experimentalFetchPolyfill": true,
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
+  }
 }

--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/programsBuilder.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/programsBuilder.js
@@ -176,10 +176,16 @@ function getBuiltPrograms(
     );
 
     const promisePrograms = cachedPrograms
-        .filter(cachedProgram => (
-            cachedProgram.trackedEntityTypeId &&
-            trackedEntityTypeCollection.get(cachedProgram.trackedEntityTypeId)
-        ))
+        .filter((cachedProgram) => {
+            // allow event programs
+            if (cachedProgram.programType === 'WITHOUT_REGISTRATION') {
+                return true;
+            }
+            // We allow only tracker programs that their tracker id exists in the collection.
+            // This is because a user might have access to read and write to a program BUT
+            // they might not have access to read and write to the tracked entity type the program belongs to.
+            return (cachedProgram.trackedEntityTypeId && trackedEntityTypeCollection.get(cachedProgram.trackedEntityTypeId));
+        })
         .map(cachedProgram => programFactory.build(cachedProgram));
 
     return Promise.all(promisePrograms);


### PR DESCRIPTION
This update will allow our tests to retry once when they fail.

We have this test that sometimes fails which we tried to fix but not successfully. We could fix it this way instead 