### PR TITLE
fix: allows event programs

### DIFF
--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/programsBuilder.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/programsBuilder.js
@@ -176,10 +176,16 @@ function getBuiltPrograms(
     );
 
     const promisePrograms = cachedPrograms
-        .filter(cachedProgram => (
-            cachedProgram.trackedEntityTypeId &&
-            trackedEntityTypeCollection.get(cachedProgram.trackedEntityTypeId)
-        ))
+        .filter((cachedProgram) => {
+            // allow event programs
+            if (cachedProgram.programType === 'WITHOUT_REGISTRATION') {
+                return true;
+            }
+            // We allow only tracker programs that their tracker id exists in the collection.
+            // This is because a user might have access to read and write to a program BUT
+            // they might not have access to read and write to the tracked entity type the program belongs to.
+            return (cachedProgram.trackedEntityTypeId && trackedEntityTypeCollection.get(cachedProgram.trackedEntityTypeId));
+        })
         .map(cachedProgram => programFactory.build(cachedProgram));
 
     return Promise.all(promisePrograms);


### PR DESCRIPTION
Looks like when we fixed the https://jira.dhis2.org/browse/DHIS2-9785 I filtered out all the Event programs. 

The weird thing is that tests were passing [here](https://github.com/dhis2/capture-app/runs/1458403471) but failed when this was merged on `master`. Some [bug](https://github.com/cypress-io/github-action/issues/168) on the cypress gh action must be the reason

This is fixing the issue and makes the tests to pass _correctly_ this time :)