### PR TITLE
fix: TECH-522 redux offline retry handling

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -13,3 +13,4 @@ src/core_modules/capture-core/flow/
 module.name_mapper='^capture-core' ->'<PROJECT_ROOT>/src/core_modules/capture-core'
 module.name_mapper='^capture-ui' ->'<PROJECT_ROOT>/src/core_modules/capture-ui'
 module.name_mapper='^capture-core-utils' ->'<PROJECT_ROOT>/src/core_modules/capture-core-utils'
+esproposal.optional_chaining=enable

--- a/src/core_modules/capture-core/trackerOffline/trackerOffline.js
+++ b/src/core_modules/capture-core/trackerOffline/trackerOffline.js
@@ -1,7 +1,7 @@
 // @flow
 import defaultQueue from '@redux-offline/redux-offline/lib/defaults/queue';
 import { effectMethods } from './trackerOffline.const';
-import type { OfflineEffect } from './trackerOffline.types';
+import type { OfflineEffect, OfflineError } from './trackerOffline.types';
 
 export const getEffectReconciler = (() => {
     const mutateTypeForMethods = {
@@ -56,13 +56,9 @@ export const queueConfig = {
     },
 };
 
-export const shouldDiscard = (error: ?{httpStatusCode?: number}) => {
-    const statusCode = error && error.httpStatusCode;
-    if (!statusCode) {
-        return false;
-    }
-
-    if ([408, 429, 502, 503, 504].includes(statusCode)) {
+export const shouldDiscard = (error?: OfflineError) => {
+    const statusCode = error?.details?.httpStatusCode;
+    if (!statusCode || [408, 429, 502, 503, 504].includes(statusCode)) {
         return false;
     }
 

--- a/src/core_modules/capture-core/trackerOffline/trackerOffline.types.js
+++ b/src/core_modules/capture-core/trackerOffline/trackerOffline.types.js
@@ -6,3 +6,14 @@ export type OfflineEffect = {
     data: any,
     method: $Values<effectMethods>,
 };
+
+export type OfflineError = {|
+    details?: {
+        httpStatus: string,
+        httpStatusCode: number,
+        message?: string,
+        status?: string,
+    },
+    type: string,
+    message: string,
+|};


### PR DESCRIPTION
[TECH-522](https://jira.dhis2.org/browse/TECH-522)

After moving to the app runtime data engine, Redux Offline tries to resend requests that the response dictates should only be sent once. For example of you get a 409 error as a response, the request should not be resent. This was due to the response object returned from the data engine being different than the old one.

Note: I used optional chaining in this PR. Optional chaining should be supported since create-react-app (react-scripts) 3.3.0 [v3.3.0](https://github.com/facebook/create-react-app/releases/tag/v3.3.0) We use 3.4.1 at the moment.