### PR TITLE
fix: DHIS2-10142 access problem in the search page

### DIFF
--- a/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
+++ b/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.component.js
@@ -74,7 +74,6 @@ export const TrackedEntityTypeSelectorPlain =
                                         && trackedEntityTypeAccess.data
                                         && trackedEntityTypeAccess.data.read;
                                   }
-                                  return true;
                               })
                               // $FlowFixMe https://github.com/facebook/flow/issues/2221
                               .map(({ trackedEntityTypeName, trackedEntityTypeId }) =>

--- a/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.container.js
+++ b/src/core_modules/capture-core/components/TrackedEntityTypeSelector/TrackedEntityTypeSelector.container.js
@@ -5,7 +5,7 @@ import type { OwnProps } from './TrackedEntityTypeSelector.types';
 import { setTrackedEntityTypeIdOnUrl } from './TrackedEntityTypeSelector.actions';
 import { TrackedEntityTypeSelectorComponent } from './TrackedEntityTypeSelector.component';
 
-export const TrackedEntityTypeSelector = ({ onSelect, accessNeeded }: OwnProps) => {
+export const TrackedEntityTypeSelector = ({ onSelect, accessNeeded = 'read' }: OwnProps) => {
     const dispatch = useDispatch();
 
     const dispatchSetTrackedEntityTypeIdOnUrl = useCallback(


### PR DESCRIPTION
Hey this fixes a bug found by Geetha on the access realted topic.  https://jira.dhis2.org/browse/DHIS2-10142
 
Long story short:
* When the user has only view access of a TEType then they could see the TEType (Person) on the dropdown of the search page. 
* However when they dont have view access but the have _no access_ the should not be able to see the person under the drop down menu in the search page as in the image 
![image](https://user-images.githubusercontent.com/4181674/106138469-16ad1d80-6164-11eb-9864-93257eb9ba42.png)

### How we solving it?

We hardcode the `accessNeeded` prop to be `read` when the user used the <TrackedEntityTypeSelector />` without specifying what access is needed. Looks logical to me because you will _always_ need to have at least read access to be able to view the TEType in the dropdown menu.

Happy to discuss edge cases if you see any :)


