### PR TITLE
fix: DHIS2-10179  block users without tetype write access

### DIFF
--- a/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
@@ -25,9 +25,11 @@ const useUserWriteAccess = (scopeId) => {
     }
     try {
         if (scope instanceof TrackerProgram) {
-            const { access } = scope;
+            const { access, trackedEntityType: { access: tetypeAccess } } = scope;
+            const userHasWriteAccessForTheProgram = access && access.data && access.data.write;
+            const userHasWriteAccessForTheTEType = tetypeAccess && tetypeAccess.data && tetypeAccess.data.write;
 
-            return access && access.data && access.data.write;
+            return userHasWriteAccessForTheProgram && userHasWriteAccessForTheTEType;
         } else if (scope instanceof TrackedEntityType) {
             const { access } = scope;
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-10179 Geetha have found a bug on this ticket. 

### The bug

Basically the user need _both_ tetype write access _and_ program write access to be able to see that registration form for a tracker program. 
Before this fix, we would allow the user to see the registration form, for say Child Programme, while they _do not have_ write access for the type Person. 

We will then throw an error while they try to submit the form. Which basically doesnt make much sense. 

Now the user sees the same message as in the other cases explaining to them that they cannot create for their current selections 

![image](https://user-images.githubusercontent.com/4181674/106147687-1581ed80-6170-11eb-999f-80b918769a5e.png)
