### PR TITLE
fix: url back and forth bug

### DIFF
--- a/src/core_modules/capture-core/reducers/descriptions/currentSelections.reducerDescriptionGetter.js
+++ b/src/core_modules/capture-core/reducers/descriptions/currentSelections.reducerDescriptionGetter.js
@@ -175,7 +175,6 @@ export const getCurrentSelectionsReducerDesc = (appUpdaters: Updaters) => create
     [lockedSelectorActionTypes.FROM_URL_UPDATE]: (state, action) => {
         const { nextProps: selections } = action.payload;
         return {
-            ...state,
             ...selections,
             categories: undefined,
             categoriesMeta: undefined,


### PR DESCRIPTION
There was a bug I found related to the url and is pretty easy to explain. 

Basically when you will have the url like so 
![image](https://user-images.githubusercontent.com/4181674/109525098-17a9d580-7aa9-11eb-95d8-c2bb22966a71.png)

And you press to go back to the previous page by the browser button sometimes the page goes into an infinite loop. This is because the url queries aka `orgUnitId` and `programId` arent in sync with the `currentSelections`.

This PR fixes this bug by updating the store with the newest `currentSelections` and omiting the ones that were there beforehand