### PR TITLE
fix: DHIS2-10711 duplicated calls on search page

### DIFF
--- a/src/core_modules/capture-core/components/DataEntries/index.js
+++ b/src/core_modules/capture-core/components/DataEntries/index.js
@@ -1,7 +1,6 @@
 // @flow
 export {
     openDataEntryForNewEnrollmentBatchAsync,
-    sectionKeys as sectionKeysForEnrollmentDataEntry,
     runRulesOnUpdateFieldBatch,
     openBatchActionTypes as enrollmentOpenBatchActionTypes,
     enrollmentBatchActionTypes,

--- a/src/core_modules/capture-core/components/DataEntryWidgetOutput/DataEntryWidgetOutput.container.js
+++ b/src/core_modules/capture-core/components/DataEntryWidgetOutput/DataEntryWidgetOutput.container.js
@@ -11,8 +11,8 @@ type OwnProps = {|
     selectedScopeId: string,
 |}
 const mapStateToProps = (state: ReduxState, { dataEntryId }) => {
-    const registerTeiContainer = state.newRelationshipRegisterTei;
-    const ready = !registerTeiContainer.loading;
+    const { dataEntries } = state;
+    const ready = !!dataEntries[dataEntryId];
 
     const dataEntryKey = ready ? getDataEntryKey(dataEntryId, state.dataEntries[dataEntryId].itemId) : null;
     return {

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
@@ -58,7 +58,7 @@ export const NewPage: ComponentType<{||}> = () => {
         useSelector(({ activePage }) => activePage.selectionsError && activePage.selectionsError.error);
 
     const ready: boolean =
-        useSelector(({ activePage }) => !activePage.lockedSelectorLoads && !activePage.isDataEntryLoading);
+        useSelector(({ activePage }) => ((activePage.lockedSelectorLoads === false) && (activePage.isDataEntryLoading === false)));
 
     const currentScopeId: string =
         useSelector(({ currentSelections }) => currentSelections.programId || currentSelections.trackedEntityTypeId);

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
@@ -58,7 +58,7 @@ export const NewPage: ComponentType<{||}> = () => {
         useSelector(({ activePage }) => activePage.selectionsError && activePage.selectionsError.error);
 
     const ready: boolean =
-        useSelector(({ activePage }) => (activePage.isDataEntryLoading === false));
+        useSelector(({ activePage }) => (!activePage.isDataEntryLoading));
 
     const currentScopeId: string =
         useSelector(({ currentSelections }) => currentSelections.programId || currentSelections.trackedEntityTypeId);

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
@@ -58,7 +58,7 @@ export const NewPage: ComponentType<{||}> = () => {
         useSelector(({ activePage }) => activePage.selectionsError && activePage.selectionsError.error);
 
     const ready: boolean =
-        useSelector(({ activePage }) => ((activePage.lockedSelectorLoads === false) && (activePage.isDataEntryLoading === false)));
+        useSelector(({ activePage }) => (activePage.isDataEntryLoading === false));
 
     const currentScopeId: string =
         useSelector(({ currentSelections }) => currentSelections.programId || currentSelections.trackedEntityTypeId);

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/useSaveButtonText.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/useSaveButtonText.js
@@ -5,15 +5,17 @@ import { DATA_ENTRY_ID } from '../registerTei.const';
 
 export const useSaveButtonText = trackedEntityTypeName =>
     useSelector(({ dataEntriesSearchGroupsResults, dataEntries }) => {
-        const dataEntryKey = getDataEntryKey(DATA_ENTRY_ID, dataEntries[DATA_ENTRY_ID].itemId);
-
-        const duplicatesFound = Boolean(
-            dataEntriesSearchGroupsResults[dataEntryKey] &&
-      dataEntriesSearchGroupsResults[dataEntryKey].main &&
-      dataEntriesSearchGroupsResults[dataEntryKey].main.count,
-        );
-
         const trackedEntityTypeNameLC = trackedEntityTypeName.toLocaleLowerCase();
+        let duplicatesFound;
+        if (dataEntries[DATA_ENTRY_ID]) {
+            const dataEntryKey = getDataEntryKey(DATA_ENTRY_ID, dataEntries[DATA_ENTRY_ID].itemId);
+
+            duplicatesFound = Boolean(
+                dataEntriesSearchGroupsResults[dataEntryKey] &&
+                      dataEntriesSearchGroupsResults[dataEntryKey].main &&
+                      dataEntriesSearchGroupsResults[dataEntryKey].main.count,
+            );
+        }
         return duplicatesFound ?
             i18n.t('Review Duplicates') :
             i18n.t('Save new {{trackedEntityTypeName}} and link', { trackedEntityTypeName: trackedEntityTypeNameLC });

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/RegisterTei.component.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/RegisterTei.component.js
@@ -10,7 +10,7 @@ import { DataEntryWidgetOutput } from '../../../DataEntryWidgetOutput/DataEntryW
 import { PossibleDuplicatesDialog } from '../../../PossibleDuplicatesDialog';
 import { ResultsPageSizeContext } from '../../shared-contexts';
 import type { Props } from './RegisterTei.types';
-import { withErrorMessageHandler, withLoadingIndicator } from '../../../../HOC';
+import { withErrorMessageHandler } from '../../../../HOC';
 
 const getStyles = () => ({
     container: {
@@ -122,7 +122,6 @@ const RegisterTeiPlain = ({
 
 export const RegisterTeiComponent: ComponentType<$Diff<Props, CssClasses>> =
   compose(
-      withLoadingIndicator(),
       withErrorMessageHandler(),
       withStyles(getStyles),
   )(RegisterTeiPlain);

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/RegisterTei.container.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/RegisterTei.container.js
@@ -21,7 +21,6 @@ const useNewRelationshipScopeId = (): string =>
 
 export const RegisterTei = ({ onLink, onSave, onGetUnsavedAttributeValues }: OwnProps) => {
     const dataEntryId = 'relationship';
-    const ready = useSelector(({ newRelationshipRegisterTei }) => (!newRelationshipRegisterTei.loading));
     const error = useSelector(({ newRelationshipRegisterTei }) => (newRelationshipRegisterTei.error));
     const newRelationshipProgramId = useNewRelationshipScopeId();
     const { trackedEntityName } = useScopeInfo(newRelationshipProgramId);
@@ -36,7 +35,6 @@ export const RegisterTei = ({ onLink, onSave, onGetUnsavedAttributeValues }: Own
             onReviewDuplicates={onReviewDuplicates}
             trackedEntityName={trackedEntityName}
             newRelationshipProgramId={newRelationshipProgramId}
-            ready={ready}
             error={error}
             possibleDuplicatesExist={usePossibleDuplicatesExist(dataEntryId)}
         />);

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/RegisterTei.types.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/RegisterTei.types.js
@@ -3,7 +3,6 @@ type PropsFromRedux = {|
     dataEntryId: string,
     trackedEntityName: ?string,
     newRelationshipProgramId: string,
-    ready: boolean,
     error: string,
     possibleDuplicatesExist: ?boolean,
 |};

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/open.epics.js
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/open.epics.js
@@ -1,7 +1,7 @@
 // @flow
-import { from, of } from 'rxjs';
+import { of } from 'rxjs';
 import { ofType } from 'redux-observable';
-import { filter, switchMap, takeUntil } from 'rxjs/operators';
+import { filter, switchMap } from 'rxjs/operators';
 import log from 'loglevel';
 import i18n from '@dhis2/d2-i18n';
 import { errorCreator } from 'capture-core-utils';
@@ -9,20 +9,14 @@ import {
     actionTypes as newRelationshipActionTypes,
 } from '../newRelationship.actions';
 import {
-    openDataEntryForNewEnrollmentBatchAsync,
-    openDataEntryForNewTeiBatchAsync,
-} from '../../../DataEntries';
-import {
     initializeRegisterTei,
     initializeRegisterTeiFailed,
 } from './registerTei.actions';
 import {
     getTrackerProgramThrowIfNotFound,
-    getTrackedEntityTypeThrowIfNotFound,
     type TrackerProgram,
 } from '../../../../metaData';
 import { findModes } from '../findModes';
-import { DATA_ENTRY_ID } from './registerTei.const';
 
 // get tracker program if the suggested program id is valid for the current context
 function getTrackerProgram(suggestedProgramId: string) {

--- a/src/core_modules/capture-core/reducers/descriptions/activePage.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/activePage.reducerDescription.js
@@ -104,7 +104,7 @@ export const activePageDesc = createReducerDescription({
     }),
 }, 'activePage', {
     selectionsError: null,
-    lockedSelectorLoads: false,
-    isDataEntryLoading: false,
+    lockedSelectorLoads: undefined,
+    isDataEntryLoading: undefined,
     viewEventLoadError: null,
 });

--- a/src/core_modules/capture-core/reducers/descriptions/activePage.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/activePage.reducerDescription.js
@@ -104,7 +104,7 @@ export const activePageDesc = createReducerDescription({
     }),
 }, 'activePage', {
     selectionsError: null,
-    lockedSelectorLoads: undefined,
-    isDataEntryLoading: undefined,
+    lockedSelectorLoads: false,
+    isDataEntryLoading: false,
     viewEventLoadError: null,
 });

--- a/src/core_modules/capture-core/reducers/descriptions/activePage.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/activePage.reducerDescription.js
@@ -80,15 +80,6 @@ export const activePageDesc = createReducerDescription({
         lockedSelectorLoads: false,
     }),
 
-    [newEventDataEntryActionTypes.OPEN_NEW_EVENT_IN_DATA_ENTRY]: state => ({
-        ...state,
-        isDataEntryLoading: false,
-    }),
-    [newEventDataEntryActionTypes.NEW_EVENT_IN_DATAENTRY_OPENING_CANCEL]: state => ({
-        ...state,
-        isDataEntryLoading: false,
-    }),
-
     [enrollmentPageActionTypes.INFORMATION_FETCH]: state => ({
         ...state,
         lockedSelectorLoads: true,

--- a/src/core_modules/capture-core/reducers/descriptions/activePage.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/activePage.reducerDescription.js
@@ -5,7 +5,6 @@ import {
     actionTypes as viewEventActionTypes,
     actionTypes as viewEventPageActionTypes,
 } from '../../components/Pages/ViewEvent/ViewEventComponent/viewEvent.actions';
-import { dataEntryActionTypes as newEventDataEntryActionTypes } from '../../components/DataEntries/SingleEventRegistrationEntry';
 import { actionTypes as viewEventDataEntryActionTypes } from '../../components/Pages/ViewEvent/EventDetailsSection/ViewEventDataEntry/viewEventDataEntry.actions';
 import { eventWorkingListsActionTypes } from '../../components/Pages/MainPage/EventWorkingLists';
 import { enrollmentPageActionTypes } from '../../components/Pages/Enrollment/EnrollmentPage.actions';

--- a/src/core_modules/capture-core/reducers/descriptions/newRelationship.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/newRelationship.reducerDescription.js
@@ -32,22 +32,17 @@ export const newRelationshipDesc = createReducerDescription({
 }, 'newRelationship', {});
 
 export const newRelationshipRegisterTeiDesc = createReducerDescription({
-    [newRelationshipActionTypes.SELECT_FIND_MODE]: () => ({
-        loading: true,
-    }),
     [registerTeiActionTypes.REGISTER_TEI_INITIALIZE]: (state, action) => {
         const { programId, orgUnit } = action.payload;
         return {
             ...state,
             programId,
             orgUnit,
-            loading: false,
         };
     },
     [registerTeiActionTypes.REGISTER_TEI_INITIALIZE_FAILED]: (state, action) => ({
         ...state,
         error: action.payload.errorMessage,
-        loading: false,
     }),
     [registrationSectionActionTypes.PROGRAM_CHANGE]: (state, action) => {
         const { programId } = action.payload;

--- a/src/core_modules/capture-ui/FormBuilder/FormBuilder.component.js
+++ b/src/core_modules/capture-ui/FormBuilder/FormBuilder.component.js
@@ -196,6 +196,7 @@ class FormBuilder extends React.Component<Props> {
                         id,
                         fieldValidatingPromiseContainer.validatingCompleteUid,
                         message,
+                        null,
                     );
 
                     return fieldValidatingPromiseContainer.cancelableValidatingPromise.promise;


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-10711


### What is this PR doing?
How this workes is that the page will be immediately rendered _and_ fetch the relevant data. But then the page would go loading again since we based the readiness of the page on the `lockedSelectorLoads`.

When I was developing this I didnt have a clear separation in my mind, for the locked selector variable called `lockedSelectorLoads`. However, it might make sense that this value is only responsible for the loading state of the locked selector and not of whole pages as I did here.
