### PR TITLE
fix: DHIS2-10739 handles tei message

### DIFF
--- a/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.epics.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.epics.js
@@ -59,6 +59,14 @@ const getFiltersForAttributesSearchQuery = (formValues) => {
 
     return [...stringFilters, ...rangeFilers];
 };
+
+const handleErrors = ({ httpStatusCode, message }) => {
+    if (httpStatusCode === 409 && message === 'maxteicountreached') {
+        return of(showTooManyResultsViewOnSearchPage());
+    }
+    return of(showErrorViewOnSearchPage());
+};
+
 const searchViaAttributesStream = (queryArgs, attributes, triggeredFrom) =>
     from(getTrackedEntityInstances(queryArgs, attributes)).pipe(
         map(({ trackedEntityInstanceContainers: searchResults, pagingData }) => {
@@ -79,12 +87,7 @@ const searchViaAttributesStream = (queryArgs, attributes, triggeredFrom) =>
             return showEmptyResultsViewOnSearchPage();
         }),
         startWith(showLoadingViewOnSearchPage()),
-        catchError(({ httpStatusCode, message }) => {
-            if (httpStatusCode === 409 && message === 'maxteicountreached') {
-                return of(showTooManyResultsViewOnSearchPage());
-            }
-            return of(showErrorViewOnSearchPage());
-        }),
+        catchError(handleErrors),
     );
 
 export const searchViaUniqueIdOnScopeProgramEpic: Epic = (action$, store) =>
@@ -259,7 +262,7 @@ export const fallbackSearchEpic: Epic = (action$: InputObservable) =>
                     return of(showEmptyResultsViewOnSearchPage());
                 }),
                 startWith(showLoadingViewOnSearchPage()),
-                catchError(() => of(showErrorViewOnSearchPage())),
+                catchError(handleErrors),
             );
         }),
     );


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10739

Now the app handles the error message for the max TEI count when you are coming from a fallback.

Basically the bug was reporting that when you where doing a fallback search and there was a max number on the TEType then you would not get a warning message but a generic error message