### PR TITLE
fix: tests actually rerun

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -33,3 +33,4 @@ jobs:
       CI: true
       CYPRESS_RECORD_KEY: '6b0bce0d-a4e8-417b-bbee-9157cbe9a999'
       REACT_APP_DHIS2_BASE_URL: 'https://debug.dhis2.org/ca-test-2.36'
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@JoakimSM this fixes the issue we had with cypress not re-running the tests. See slack [discussion](https://dhis2.slack.com/archives/G014JTQQ5UN/p1616680292001300) 