### PR TITLE
fix: correct app name and title specified in d2.config.js

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -1,12 +1,12 @@
 const config = {
-  name: "capture",
-  title: "Capture",
-  type: "app",
-  coreApp: true,
+    name: 'capture',
+    title: 'Capture',
+    type: 'app',
+    coreApp: true,
 
-  entryPoints: {
-    app: "./src/index",
-  },
+    entryPoints: {
+        app: './src/index',
+    },
 };
 
 module.exports = config;

--- a/d2.config.js
+++ b/d2.config.js
@@ -1,9 +1,12 @@
 const config = {
-    type: 'app',
-    coreApp: true,
-    entryPoints: {
-        app: './src/index',
-    },
+  name: "capture",
+  title: "Capture",
+  type: "app",
+  coreApp: true,
+
+  entryPoints: {
+    app: "./src/index",
+  },
 };
 
 module.exports = config;


### PR DESCRIPTION
This fixes two issues in the Capture app configuration:

1. In order to successfully override the bundled Capture app, the name needs to match `capture` exactly 
2. The title displayed in the Headerbar and in the browser tab bar is `capture-app` which is incorrect, this corrects it to `Capture`.