### PR TITLE
fix: DHIS2-10713 when optionSet use EQ to filter

### DIFF
--- a/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.epics.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.epics.js
@@ -47,7 +47,7 @@ const searchViaUniqueIdStream = (queryArgs, attributes, scopeSearchParam, curren
         catchError(() => of(showErrorViewOnSearchPage())),
     );
 
-export const deriveFilterKeyword = (fieldId, attributes: Array<DataElement>): ("eq" | "like") => {
+export const deriveFilterKeyword = (fieldId: string, attributes: Array<DataElement>): ("eq" | "like") => {
     const hasOptionSet = Boolean(attributes.find(({ id, optionSet }) => (id === fieldId) && (optionSet)));
     return hasOptionSet ? 'eq' : 'like';
 };

--- a/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.epics.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.epics.js
@@ -20,6 +20,7 @@ import {
     scopeTypes,
     getTrackedEntityTypeThrowIfNotFound,
     getTrackerProgramThrowIfNotFound,
+    type DataElement,
 } from '../../../../metaData';
 import { navigateToTrackedEntityDashboard } from '../../../../utils/navigateToTrackedEntityDashboard';
 import { PAGINATION } from '../SearchPage.constants';
@@ -46,11 +47,16 @@ const searchViaUniqueIdStream = (queryArgs, attributes, scopeSearchParam, curren
         catchError(() => of(showErrorViewOnSearchPage())),
     );
 
-const getFiltersForAttributesSearchQuery = (formValues) => {
+export const deriveFilterKeyword = (fieldId, attributes: Array<DataElement>): ("eq" | "like") => {
+    const hasOptionSet = Boolean(attributes.find(({ id, optionSet }) => (id === fieldId) && (optionSet)));
+    return hasOptionSet ? 'eq' : 'like';
+};
+
+const getFiltersForAttributesSearchQuery = (formValues, attributes) => {
     const stringFilters = Object.keys(formValues)
         .filter(fieldId => isString(formValues[fieldId]))
         .filter(fieldId => formValues[fieldId].replace(/\s/g, '').length)
-        .map(fieldId => `${fieldId}:like:${formValues[fieldId]}`);
+        .map(fieldId => `${fieldId}:${deriveFilterKeyword(fieldId, attributes)}:${formValues[fieldId]}`);
 
     const rangeFilers = Object.keys(formValues)
         .filter(fieldId => isObject(formValues[fieldId]))
@@ -148,16 +154,16 @@ export const searchViaAttributesOnScopeProgramEpic: Epic = (action$, store) =>
         ofType(searchPageActionTypes.VIA_ATTRIBUTES_ON_SCOPE_PROGRAM_SEARCH),
         flatMap(({ payload: { formId, programId, page, triggeredFrom } }) => {
             const { formsValues } = store.value;
+            const attributes = getTrackerProgramThrowIfNotFound(programId).attributes;
 
             const queryArgs = {
-                filter: getFiltersForAttributesSearchQuery(formsValues[formId]),
+                filter: getFiltersForAttributesSearchQuery(formsValues[formId], attributes),
                 program: programId,
                 page,
                 pageSize: 5,
                 ouMode: 'ACCESSIBLE',
                 fields: '*',
             };
-            const attributes = getTrackerProgramThrowIfNotFound(programId).attributes;
 
             return searchViaAttributesStream(queryArgs, attributes, triggeredFrom);
         }),
@@ -168,16 +174,15 @@ export const searchViaAttributesOnScopeTrackedEntityTypeEpic: Epic = (action$, s
         ofType(searchPageActionTypes.VIA_ATTRIBUTES_ON_SCOPE_TRACKED_ENTITY_TYPE_SEARCH),
         flatMap(({ payload: { formId, trackedEntityTypeId, page, triggeredFrom } }) => {
             const { formsValues } = store.value;
+            const attributes = getTrackedEntityTypeThrowIfNotFound(trackedEntityTypeId).attributes;
 
             const queryArgs = {
-                filter: getFiltersForAttributesSearchQuery(formsValues[formId]),
+                filter: getFiltersForAttributesSearchQuery(formsValues[formId], attributes),
                 trackedEntityType: trackedEntityTypeId,
                 page,
                 pageSize: 5,
                 ouMode: 'ACCESSIBLE',
             };
-
-            const attributes = getTrackedEntityTypeThrowIfNotFound(trackedEntityTypeId).attributes;
 
             return searchViaAttributesStream(queryArgs, attributes, triggeredFrom);
         }),
@@ -242,7 +247,9 @@ export const fallbackSearchEpic: Epic = (action$: InputObservable) =>
     action$.pipe(
         ofType(searchPageActionTypes.FALLBACK_SEARCH),
         flatMap(({ payload: { fallbackFormValues, trackedEntityTypeId, pageSize, page } }) => {
-            const filter = getFiltersForAttributesSearchQuery(fallbackFormValues);
+            const attributes = getTrackedEntityTypeThrowIfNotFound(trackedEntityTypeId).attributes;
+
+            const filter = getFiltersForAttributesSearchQuery(fallbackFormValues, attributes);
             const queryArgs = {
                 filter,
                 trackedEntityType: trackedEntityTypeId,
@@ -251,7 +258,6 @@ export const fallbackSearchEpic: Epic = (action$: InputObservable) =>
                 ouMode: 'ACCESSIBLE',
             };
 
-            const attributes = getTrackedEntityTypeThrowIfNotFound(trackedEntityTypeId).attributes;
 
             return from(getTrackedEntityInstances(queryArgs, attributes)).pipe(
                 map(({ trackedEntityInstanceContainers: searchResults, pagingData }) => {

--- a/src/core_modules/capture-core/components/PossibleDuplicatesDialog/possibleDuplicatesDialog.epics.js
+++ b/src/core_modules/capture-core/components/PossibleDuplicatesDialog/possibleDuplicatesDialog.epics.js
@@ -60,7 +60,7 @@ export const loadSearchGroupDuplicatesForReviewEpic: Epic = (action$, store) =>
                             return null;
                         }
                         const serverValue = element.convertValue(value, pipeD2(convertFormToClient, convertClientToServer));
-                        return `${element.id}:LIKE:${serverValue}`;
+                        return `${element.id}:${element.optionSet ? 'eq' : 'like'}:${serverValue}`;
                     })
                     .filter(f => f);
 


### PR DESCRIPTION
Hey this solves the ticket https://jira.dhis2.org/browse/DHIS2-10713

Basically we want that when we search by that an attribute that has an optionSet (like the gender data element), to use EQ instead of LIKE, because we don’t need partial matching.