### PR TITLE
fix: Program rules for org unit data elements [v35]

### DIFF
--- a/src/core_modules/capture-core/rules/engine/converters/inputValueConverter.js
+++ b/src/core_modules/capture-core/rules/engine/converters/inputValueConverter.js
@@ -93,7 +93,7 @@ class RulesValueConverter implements IConvertInputRulesValue {
     }
 
     convertOrgUnit(value: any): string {
-        return value?.id;
+        return value?.id || '';
     }
 }
 

--- a/src/core_modules/capture-core/rules/engine/converters/inputValueConverter.js
+++ b/src/core_modules/capture-core/rules/engine/converters/inputValueConverter.js
@@ -91,6 +91,10 @@ class RulesValueConverter implements IConvertInputRulesValue {
     convertAge(value: any): string {
         return this.convertDate(value);
     }
+
+    convertOrgUnit(value: any): string {
+        return value.id;
+    }
 }
 
 export default new RulesValueConverter();

--- a/src/core_modules/capture-core/rules/engine/converters/inputValueConverter.js
+++ b/src/core_modules/capture-core/rules/engine/converters/inputValueConverter.js
@@ -93,7 +93,7 @@ class RulesValueConverter implements IConvertInputRulesValue {
     }
 
     convertOrgUnit(value: any): string {
-        return value.id;
+        return value?.id;
     }
 }
 

--- a/src/core_modules/capture-core/rules/engine/converters/rulesEffectsValueConverter.js
+++ b/src/core_modules/capture-core/rules/engine/converters/rulesEffectsValueConverter.js
@@ -83,7 +83,7 @@ class RulesValueConverter implements IConvertOutputRulesEffectsValue {
         };
     }
     convertOrgUnit(value: any): string {
-        return value?.id;
+        return value?.id || '';
     }
 }
 

--- a/src/core_modules/capture-core/rules/engine/converters/rulesEffectsValueConverter.js
+++ b/src/core_modules/capture-core/rules/engine/converters/rulesEffectsValueConverter.js
@@ -83,7 +83,7 @@ class RulesValueConverter implements IConvertOutputRulesEffectsValue {
         };
     }
     convertOrgUnit(value: any): string {
-        return value.id;
+        return value?.id;
     }
 }
 

--- a/src/core_modules/capture-core/rules/engine/converters/rulesEffectsValueConverter.js
+++ b/src/core_modules/capture-core/rules/engine/converters/rulesEffectsValueConverter.js
@@ -82,6 +82,9 @@ class RulesValueConverter implements IConvertOutputRulesEffectsValue {
             days: days.toString(),
         };
     }
+    convertOrgUnit(value: any): string {
+        return value.id;
+    }
 }
 
 export default new RulesValueConverter();

--- a/src/core_modules/capture-core/rules/engine/rulesEngine.types.js
+++ b/src/core_modules/capture-core/rules/engine/rulesEngine.types.js
@@ -223,6 +223,7 @@ export interface IConvertInputRulesValue {
     convertPercentage(value: any): number | string;
     convertUrl(value: any): string;
     convertAge(value: any): number | string;
+    convertOrgUnit(value: any): string;
 }
 
 export interface IConvertOutputRulesEffectsValue {
@@ -244,6 +245,7 @@ export interface IConvertOutputRulesEffectsValue {
     convertPercentage(value: number): any;
     convertUrl(value: string): any;
     convertAge(value: string): any;
+    convertOrgUnit(value: any): string;
 }
 
 export type D2FunctionParameters = {

--- a/src/core_modules/capture-core/rules/engine/typeToInterfaceFnName.const.js
+++ b/src/core_modules/capture-core/rules/engine/typeToInterfaceFnName.const.js
@@ -20,4 +20,5 @@ export default {
     [typeKeys.PERCENTAGE]: 'convertPercentage',
     [typeKeys.URL]: 'convertUrl',
     [typeKeys.AGE]: 'convertAge',
+    [typeKeys.ORGANISATION_UNIT]: 'convertOrgUnit',
 };


### PR DESCRIPTION
Program rules using an organisation unit data element do not currently work because there's no ``converter`` method defined for them. The issue affects both to the program rule expression and the program rule action.