### PR TITLE
fix: Program rules for org unit data elements [v37]

### DIFF
--- a/src/core_modules/capture-core/rules/engine/converters/inputValueConverter.js
+++ b/src/core_modules/capture-core/rules/engine/converters/inputValueConverter.js
@@ -93,7 +93,7 @@ class RulesValueConverter implements IConvertInputRulesValue {
     }
 
     convertOrgUnit(value: any): string {
-        return value?.id;
+        return value?.id || '';
     }
 }
 

--- a/src/core_modules/capture-core/rules/engine/converters/inputValueConverter.js
+++ b/src/core_modules/capture-core/rules/engine/converters/inputValueConverter.js
@@ -91,6 +91,10 @@ class RulesValueConverter implements IConvertInputRulesValue {
     convertAge(value: any): string {
         return this.convertDate(value);
     }
+
+    convertOrgUnit(value: any): string {
+        return value.id;
+    }
 }
 
 export default new RulesValueConverter();

--- a/src/core_modules/capture-core/rules/engine/converters/inputValueConverter.js
+++ b/src/core_modules/capture-core/rules/engine/converters/inputValueConverter.js
@@ -93,7 +93,7 @@ class RulesValueConverter implements IConvertInputRulesValue {
     }
 
     convertOrgUnit(value: any): string {
-        return value.id;
+        return value?.id;
     }
 }
 

--- a/src/core_modules/capture-core/rules/engine/converters/rulesEffectsValueConverter.js
+++ b/src/core_modules/capture-core/rules/engine/converters/rulesEffectsValueConverter.js
@@ -83,7 +83,7 @@ class RulesValueConverter implements IConvertOutputRulesEffectsValue {
         };
     }
     convertOrgUnit(value: any): string {
-        return value?.id;
+        return value?.id || '';
     }
 }
 

--- a/src/core_modules/capture-core/rules/engine/converters/rulesEffectsValueConverter.js
+++ b/src/core_modules/capture-core/rules/engine/converters/rulesEffectsValueConverter.js
@@ -83,7 +83,7 @@ class RulesValueConverter implements IConvertOutputRulesEffectsValue {
         };
     }
     convertOrgUnit(value: any): string {
-        return value.id;
+        return value?.id;
     }
 }
 

--- a/src/core_modules/capture-core/rules/engine/converters/rulesEffectsValueConverter.js
+++ b/src/core_modules/capture-core/rules/engine/converters/rulesEffectsValueConverter.js
@@ -82,6 +82,9 @@ class RulesValueConverter implements IConvertOutputRulesEffectsValue {
             days: days.toString(),
         };
     }
+    convertOrgUnit(value: any): string {
+        return value.id;
+    }
 }
 
 export default new RulesValueConverter();

--- a/src/core_modules/capture-core/rules/engine/rulesEngine.types.js
+++ b/src/core_modules/capture-core/rules/engine/rulesEngine.types.js
@@ -221,6 +221,7 @@ export interface IConvertInputRulesValue {
     convertPercentage(value: any): number | string;
     convertUrl(value: any): string;
     convertAge(value: any): number | string;
+    convertOrgUnit(value: any): string;
 }
 
 export interface IConvertOutputRulesEffectsValue {
@@ -242,6 +243,7 @@ export interface IConvertOutputRulesEffectsValue {
     convertPercentage(value: number): any;
     convertUrl(value: string): any;
     convertAge(value: string): any;
+    convertOrgUnit(value: any): string;
 }
 
 export type D2FunctionParameters = {

--- a/src/core_modules/capture-core/rules/engine/typeToInterfaceFnName.const.js
+++ b/src/core_modules/capture-core/rules/engine/typeToInterfaceFnName.const.js
@@ -20,4 +20,5 @@ export default {
     [typeKeys.PERCENTAGE]: 'convertPercentage',
     [typeKeys.URL]: 'convertUrl',
     [typeKeys.AGE]: 'convertAge',
+    [typeKeys.ORGANISATION_UNIT]: 'convertOrgUnit',
 };


### PR DESCRIPTION
Program rules using an organisation unit data element do not currently work because there's no ``converter`` method defined for them. The issue affects both to the program rule expression and the program rule action.

JIRA Issue:

- [DHIS2-11154](https://jira.dhis2.org/browse/DHIS2-11154)

Backport PRs:

- https://github.com/dhis2/capture-app/pull/1692
- https://github.com/dhis2/capture-app/pull/1693
- https://github.com/dhis2/capture-app/pull/1694

Since the related code of ``RuleEngine`` is not typed I intentionally did not type the additions. The intention of the PR is to fix the issue without rewriting the typings, that should be done in future PRs.