### PR TITLE
fix: TECH-622 use 2.37 backend for tests

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 NODE_PATH=src/D2App/core_modules
 REACT_APP_CACHE_VERSION=$npm_package_cacheVersion
 REACT_APP_VERSION=$npm_package_version
-REACT_APP_DHIS2_API_VERSION=36
+REACT_APP_DHIS2_API_VERSION=37

--- a/.env.cypress
+++ b/.env.cypress
@@ -1,4 +1,4 @@
-DHIS2_BASE_URL=https://debug.dhis2.org/ca-test-2.36
+DHIS2_BASE_URL=https://debug.dhis2.org/ca-test-2.37
 DHIS2_USERNAME=system
 DHIS2_PASSWORD=System123
 

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -32,5 +32,5 @@ jobs:
     env:
       CI: true
       CYPRESS_RECORD_KEY: '6b0bce0d-a4e8-417b-bbee-9157cbe9a999'
-      REACT_APP_DHIS2_BASE_URL: 'https://debug.dhis2.org/ca-test-2.36'
+      REACT_APP_DHIS2_BASE_URL: 'https://debug.dhis2.org/ca-test-2.37'
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cypress/integration/WorkingLists/EventWorkingLists/EventWorkingListsUser/index.js
+++ b/cypress/integration/WorkingLists/EventWorkingLists/EventWorkingListsUser/index.js
@@ -293,11 +293,11 @@ When('you select the working list called Events today', () => {
         .click();
 });
 
-When('you change the sharing settings', () => {
+When('you change the sharing settings', () =>
     // Making post requests using the old d2 library doesn't work for cypress tests atm
     // since the sharing dialog is posting using the d2 library, we will need to temporarily send the post request manually
     cy.buildApiUrl('sharing?type=eventFilter&id=CLBKvCKspBk')
-        .then((sharingUrl) => {
+        .then(sharingUrl =>
             cy.request('POST', sharingUrl, {
                 meta: {
                     allowPublicAccess: true,
@@ -337,9 +337,9 @@ When('you change the sharing settings', () => {
 
                 cy.contains('Close')
                     .click();
-            });
-        });
-});
+            }),
+        ),
+);
 
 When('you update the working list', () => {
     cy.get('[data-test="online-list-table"]')


### PR DESCRIPTION
Use 2.37 backend for tests.

There is also a fix in here. Ideally I would have created a separate PR for the fix, but the 2.36 test backend was updated and caused some tests to fail and I didn't want to fix those tests temporarily and then change them again after updating to use the 2.37 backend. The fix is: When updating I encountered a problem where a form could be submitted before the initial field validations were complete (required for compulsory fields). I would have loved to rework this from scratch, but the best solution I found for now is to wait if this happens (I don't think you should be able to experience this if you're not running this using a testing engine)