### PR TITLE
fix: Cypress post upgrade

### DIFF
--- a/.env.cypress
+++ b/.env.cypress
@@ -1,6 +1,6 @@
-DHIS2_BASE_URL=https://debug.dhis2.org/ca-test-2.37
-DHIS2_USERNAME=system
-DHIS2_PASSWORD=System123
+dhis2BaseUrl=https://debug.dhis2.org/ca-test-2.37
+dhis2Username=system
+dhis2Password=System123
 
-DHIS2_USERNAME_ENGLISH=englishB
-DHIS2_PASSWORD_ENGLISH=!English123B
+dhis2UsernameEnglish=englishB
+dhis2PasswordEnglish=!English123B

--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -25,12 +25,11 @@ jobs:
           parallel: true
           group: e2e-chrome-parallel
           browser: chrome
-          start: 'yarn start'
+          start: 'yarn start:forCypress'
           wait-on: 'http://localhost:3000'
           # wait for 200 secs for the server to respond
           wait-on-timeout: 200
     env:
       CI: true
       CYPRESS_RECORD_KEY: '6b0bce0d-a4e8-417b-bbee-9157cbe9a999'
-      REACT_APP_DHIS2_BASE_URL: 'https://debug.dhis2.org/ca-test-2.37'
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cypress.env.json
+++ b/cypress.env.json
@@ -1,5 +1,0 @@
-{
-    "dhis2Username": "system",
-    "dhis2Password": "System123",
-    "dhis2BaseUrl": "https://debug.dhis2.org/ca-test-2.37"
-}

--- a/cypress/integration/SmokeTests/LoginWithUserEnglish/index.js
+++ b/cypress/integration/SmokeTests/LoginWithUserEnglish/index.js
@@ -1,5 +1,5 @@
 beforeEach(() => {
-    cy.loginThroughForm('DHIS2_USERNAME_ENGLISH', 'DHIS2_PASSWORD_ENGLISH');
+    cy.loginThroughForm('dhis2UsernameEnglish', 'dhis2PasswordEnglish');
 });
 
 Given('you open the capture app', () => {

--- a/cypress/integration/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/index.js
+++ b/cypress/integration/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/index.js
@@ -56,7 +56,7 @@ Then('the list should display teis with a completed enrollment', () => {
 
     cy.get('[data-test="tei-working-lists"]')
         .find('tr')
-        .should('have.length', 6)
+        .should('have.length', 5)
         .each(($teiRow, index) => {
             if (index) {
                 cy.wrap($teiRow)

--- a/cypress/integration/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/index.js
+++ b/cypress/integration/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/index.js
@@ -50,7 +50,6 @@ Then('the list should display teis with a completed enrollment', () => {
     const names = [
         'Filona Ryder',
         'Gertrude Fjordsen',
-        'Frank Fjordsen',
         'Emma Johnson',
         'Alan Thompson',
     ];
@@ -126,6 +125,7 @@ Then('the assignee filter button should show that unassigned filter is in effect
 
 Then('the list should display teis with an active enrollment and unassinged events', () => {
     const names = [
+        'Frank',
         'Maria',
         'Joe',
         'Anthony',
@@ -140,7 +140,6 @@ Then('the list should display teis with an active enrollment and unassinged even
         'Wayne',
         'Johnny',
         'Donna',
-        'Sharon',
     ];
 
     cy.get('[data-test="tei-working-lists"]')

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,5 +1,4 @@
 const {
-    networkShim,
     chromeAllowXSiteCookies,
     cucumberPreprocessor,
 } = require('@dhis2/cypress-plugins');
@@ -8,7 +7,6 @@ const getCypressEnvVariables = require('./getCypressEnvVariables');
 const path = require('path');
 
 module.exports = (on, config) => {
-    networkShim(on);
     chromeAllowXSiteCookies(on);
     cucumberPreprocessor(on, config);
     on('before:browser:launch', (browser, launchOptions) => {

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -1,5 +1,5 @@
 Cypress.Commands.add('buildApiUrl', (...urlParts) =>
-    [Cypress.env('DHIS2_BASE_URL'), 'api', ...urlParts]
+    [Cypress.env('dhis2BaseUrl'), 'api', ...urlParts]
         .map(part => part.replace(/(^\/)|(\/$)/, ''))
         .join('/'),
 );
@@ -13,7 +13,7 @@ Cypress.Commands.add(
             .should('contain', className),
 );
 
-Cypress.Commands.add('loginThroughForm', (username = 'DHIS2_USERNAME', password = 'DHIS2_PASSWORD') => {
+Cypress.Commands.add('loginThroughForm', (username = 'dhis2Username', password = 'dhis2Password') => {
     cy.visit('/').then(() => {
         cy.get('#j_username').type(Cypress.env(username));
         cy.get('#j_password').type(Cypress.env(password));

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,5 +1,3 @@
-import { enableNetworkShim } from '@dhis2/cypress-commands';
-
 // Add additional support functions here
 import './helpers';
 
@@ -12,4 +10,3 @@ beforeEach(() => {
     */
     cy.clearCookies({ domain: null });
 });
-enableNetworkShim();

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "flow:check": "./node_modules/.bin/flow check ./src",
     "flow:addTypes": "flow-typed install",
     "lint": "npm run flow:check && npm run linter:check",
-    "cy:open": "wait-on 'http-get://localhost:3000' && cypress open",
-    "cy:run": "wait-on 'http-get://localhost:3000' && cypress run",
+    "cy:open": "concurrently --kill-others \"yarn start:forCypress\" \"wait-on 'http-get://localhost:3000' && cypress open\"",
+    "cy:run": "concurrently --kill-others \"yarn start:forCypress\" \"wait-on 'http-get://localhost:3000' && cypress run\"",
     "verifyCacheVersion": "node scripts/verifyCacheVersion.js",
     "postinstall": "husky install",
     "i18n:add": "d2-app-scripts i18n extract && git add ./i18n/"

--- a/scripts/startAppForCypress.js
+++ b/scripts/startAppForCypress.js
@@ -33,7 +33,7 @@ const env = Object
     .reduce((acc, key) => {
         if (key.startsWith('REACT')) {
             acc[key] = envFromCypressFiles[key];
-        } else if (key === 'DHIS2_BASE_URL') {
+        } else if (key === 'dhis2BaseUrl') {
             acc.REACT_APP_DHIS2_BASE_URL = envFromCypressFiles[key];
         }
         return acc;

--- a/src/core_modules/capture-core/components/DataEntry/withSaveHandler/withSaveHandler.js
+++ b/src/core_modules/capture-core/components/DataEntry/withSaveHandler/withSaveHandler.js
@@ -292,7 +292,11 @@ const getSaveHandler = (
                 inProgressList: state.dataEntriesInProgressList[key] || [],
                 calculatedFoundation: foundation,
                 fieldsValidated: reduxSectionKeys
-                    .every(reduxSectionKey => state.formsSectionsFieldsUI[reduxSectionKey]),
+                    .every((reduxSectionKey) => {
+                        const reduxSection = state.formsSectionsFieldsUI[reduxSectionKey];
+                        // $FlowFixMe
+                        return reduxSection && Object.values(reduxSection).every(({ valid }) => valid !== undefined);
+                    }),
             };
         };
 


### PR DESCRIPTION
Changes:
- Automatically start the app when running `yarn cy:open` and `yarn cy:run`
- Some time ago we made some custom scripts in our app to deal with some Cypress edge cases. An example would be be if you create a `.env.development` or `.env.development.local` file locally and then run `yarn cy:open`; in this case you would, without the scripts, run against your local instance while the api requests made in your tests will run against your test instance. To fix this we specify our Cypress config in the `.env.cypress` file and the server specified here will always be used. Updated the variable names in this file instead of `cypress.json`.
- Fixed some tests after updating the DB