### PR TITLE
fix: cache versioning

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 NODE_PATH=src/D2App/core_modules
 REACT_APP_CACHE_VERSION=$npm_package_cacheVersion
+REACT_APP_SERVER_VERSION=$npm_package_serverVersion
 REACT_APP_VERSION=$npm_package_version
 REACT_APP_DHIS2_API_VERSION=37

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "homepage": ".",
   "version": "1.27.2",
   "cacheVersion": "1",
+  "serverVersion": "37",
   "private": false,
   "dependencies": {
     "@dhis2/app-runtime": "^2.8.0",

--- a/scripts/verifyCacheVersion.js
+++ b/scripts/verifyCacheVersion.js
@@ -5,14 +5,14 @@
  */
 const packageDesc = require('../package');
 
-function verifyMajorCacheVersion(appVersion) {
-    if (!appVersion) {
+function verifyMajorCacheVersion(serverVersionAsString) {
+    if (!serverVersionAsString) {
         console.log('Version not specified');
         process.exit(1);
     }
 
-    const appMajorVersion = Number(appVersion.split('.')[0]);
-    if (Number.isNaN(appMajorVersion) || !Number.isSafeInteger(appMajorVersion) || appMajorVersion <= 30) {
+    const serverVersion = Number(serverVersionAsString);
+    if (Number.isNaN(serverVersion) || !Number.isSafeInteger(serverVersion) || serverVersion <= 30) {
         console.log('Invalid app version');
         process.exit(1);
     }
@@ -31,7 +31,7 @@ function verifyMinorCacheVersion(appCacheVersionAsString) {
     }
 }
 
-const appVersion = packageDesc.version;
+const serverVersion = packageDesc.serverVersion;
 const cacheVersion = packageDesc.cacheVersion;
-verifyMajorCacheVersion(appVersion);
+verifyMajorCacheVersion(serverVersion);
 verifyMinorCacheVersion(cacheVersion);

--- a/src/core_modules/capture-core/flow/typeDeclarations.js
+++ b/src/core_modules/capture-core/flow/typeDeclarations.js
@@ -191,6 +191,7 @@ declare class process {
         NODE_ENV: string,
         NODE_PATH: string,
         REACT_APP_CACHE_VERSION: string,
+        REACT_APP_SERVER_VERSION: string,
         REACT_APP_VERSION: string,
         REACT_APP_DHIS2_API_VERSION: string,
     }

--- a/src/core_modules/capture-core/storageControllers/mainStorageController.js
+++ b/src/core_modules/capture-core/storageControllers/mainStorageController.js
@@ -5,8 +5,7 @@ import { mainStores } from './stores';
 const MAIN_STORAGE_KEY = 'dhis2ca';
 
 function getMajorCacheVersion() {
-    const appVersion = process.env.REACT_APP_VERSION;
-    const appMajorVersion = Number(appVersion.split('.')[0]);
+    const appMajorVersion = Number(process.env.REACT_APP_SERVER_VERSION);
     return (appMajorVersion - 30) * 1000;
 }
 


### PR DESCRIPTION
Adding serverVersion to package.json to fix the cache versioning. We will need to change this up a bit when we start publishing to the app hub (we can go into more detail then perhaps)