### PR TITLE
TECH-627 Borderless mode

### DIFF
--- a/src/core_modules/capture-core/components/Widget/WidgetCollapsible.component.js
+++ b/src/core_modules/capture-core/components/Widget/WidgetCollapsible.component.js
@@ -17,6 +17,9 @@ const styles = {
             borderBottomLeftRadius: 0,
             borderBottomRightRadius: 0,
         },
+        '&.borderless': {
+            border: 'none',
+        },
     },
     header: {
         display: 'flex',
@@ -44,6 +47,9 @@ const styles = {
         '&.close': {
             animation: 'slideout 200ms normal forwards ease-in-out',
             transformOrigin: '100% 0%',
+        },
+        '&.borderless': {
+            border: 'none',
         },
     },
     toggleButton: {
@@ -77,7 +83,16 @@ const styles = {
     },
 };
 
-const WidgetCollapsiblePlain = ({ header, open, onOpen, onClose, color = colors.white, children, classes }: WidgetCollapsiblePropsPlain) => {
+const WidgetCollapsiblePlain = ({
+    header,
+    open,
+    onOpen,
+    onClose,
+    color = colors.white,
+    borderless = false,
+    children,
+    classes,
+}: WidgetCollapsiblePropsPlain) => {
     const [childrenVisible, setChildrenVisibility] = useState(open); // controls whether children are rendered to the DOM
     const [animationsReady, setAnimationsReadyStatus] = useState(false);
     const [postEffectOpen, setPostEffectOpenStatus] = useState(open);
@@ -107,10 +122,12 @@ const WidgetCollapsiblePlain = ({ header, open, onOpen, onClose, color = colors.
     }, [open, animationsReady]);
 
     return (
-        <div >
+        <div style={{ backgroundColor: color }}>
             <div
-                style={{ backgroundColor: color }}
-                className={cx(classes.headerContainer, { childrenVisible })}
+                className={cx(classes.headerContainer, {
+                    childrenVisible,
+                    borderless,
+                })}
             >
                 <div className={classes.header}>
                     {header}
@@ -130,10 +147,11 @@ const WidgetCollapsiblePlain = ({ header, open, onOpen, onClose, color = colors.
                 childrenVisible ? (
                     <div
                         data-test="widget-contents"
-                        style={{ backgroundColor: color || colors.white }}
                         className={cx(classes.children, {
                             open: animationsReady && open,
-                            close: animationsReady && !open })}
+                            close: animationsReady && !open,
+                            borderless,
+                        })}
                     >
                         {children}
                     </div>

--- a/src/core_modules/capture-core/components/Widget/WidgetNonCollapsible.component.js
+++ b/src/core_modules/capture-core/components/Widget/WidgetNonCollapsible.component.js
@@ -2,6 +2,7 @@
 import React, { type ComponentType } from 'react';
 import { withStyles } from '@material-ui/core';
 import { colors, spacersNum } from '@dhis2/ui';
+import cx from 'classnames';
 import type { WidgetNonCollapsibleProps, WidgetNonCollapsiblePropsPlain } from './widgetNonCollapsible.types';
 
 const styles = {
@@ -21,9 +22,15 @@ const styles = {
     },
 };
 
-const WidgetNonCollapsiblePlain = ({ header, children, color = colors.white, classes }: WidgetNonCollapsiblePropsPlain) => (
+const WidgetNonCollapsiblePlain = ({
+    header,
+    children,
+    color = colors.white,
+    borderless = false,
+    classes,
+}: WidgetNonCollapsiblePropsPlain) => (
     <div
-        className={classes.container}
+        className={cx(classes.container, { borderless })}
         style={{ backgroundColor: color }}
     >
         <div

--- a/src/core_modules/capture-core/components/Widget/widgetCollapsible.types.js
+++ b/src/core_modules/capture-core/components/Widget/widgetCollapsible.types.js
@@ -8,6 +8,7 @@ export type WidgetCollapsibleProps = {|
     onOpen: () => void,
     onClose: () => void,
     color?: string,
+    borderless?: boolean,
 |};
 
 export type WidgetCollapsiblePropsPlain = {|

--- a/src/core_modules/capture-core/components/Widget/widgetNonCollapsible.types.js
+++ b/src/core_modules/capture-core/components/Widget/widgetNonCollapsible.types.js
@@ -5,6 +5,7 @@ export type WidgetNonCollapsibleProps = {|
     header: Node,
     children: Node,
     color?: string,
+    borderless?: boolean,
 |};
 
 export type WidgetNonCollapsiblePropsPlain = {|


### PR DESCRIPTION
Added functionality for removing the border on the `Widget`-component as mentioned in [TECH-627](https://jira.dhis2.org/browse/TECH-627).
Pass the `Borderless`-prop (boolean). (Default behavior is false => full border)