### PR TITLE
refactor: [TECH-580] ScopeSelector in enrollment page - part 1

### DIFF
--- a/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPage.component.js
@@ -3,7 +3,7 @@ import React from 'react';
 import type { ComponentType } from 'react';
 import withStyles from '@material-ui/core/styles/withStyles';
 import { compose } from 'redux';
-import { LockedSelector } from '../../LockedSelector';
+import { ScopeSelector } from '../../ScopeSelector';
 import type { Props } from './EnrollmentPage.types';
 import { enrollmentPageStatuses } from './EnrollmentPage.constants';
 import { LoadingMaskForPage } from '../../LoadingMasks/LoadingMaskForPage.component';
@@ -24,7 +24,7 @@ const getStyles = ({ typography }) => ({
 });
 
 const EnrollmentPagePlain = ({ classes, enrollmentPageStatus }) => (<>
-    <LockedSelector pageToPush="enrollment" />
+    <ScopeSelector pageToPush="enrollment" />
 
     <div data-test="enrollment-page-content" className={classes.container} >
 

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/ActionButtons.component.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/ActionButtons.component.js
@@ -1,0 +1,149 @@
+// @flow
+import React, { type ComponentType } from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import i18n from '@dhis2/d2-i18n';
+import { Button, colors, DropdownButton, FlyoutMenu, MenuItem } from '@dhis2/ui';
+import { scopeTypes } from '../../../metaData';
+import { useScopeInfo } from '../../../hooks/useScopeInfo';
+
+
+const styles = ({ typography }) => ({
+    container: {
+        marginLeft: typography.pxToRem(8),
+        marginBottom: typography.pxToRem(8),
+        marginTop: typography.pxToRem(8),
+    },
+    marginRight: {
+        marginRight: typography.pxToRem(12),
+    },
+    buttonAsLink: {
+        fontSize: typography.pxToRem(13),
+        background: 'none!important',
+        border: 'none',
+        padding: '0!important',
+        color: colors.grey700,
+        textDecoration: 'underline',
+        cursor: 'pointer',
+    },
+});
+
+type Props = $ReadOnly<{|
+    selectedProgramId: string,
+    onStartAgainClick: () => void,
+    onNewClick: () => void,
+    onNewClickWithoutProgramId: () => void,
+    onFindClick: () => void,
+    onFindClickWithoutProgramId: () => void,
+    showResetButton: boolean,
+|}>;
+
+
+const ActionButtonsPlain = ({
+    onStartAgainClick,
+    onNewClick,
+    onNewClickWithoutProgramId,
+    onFindClick,
+    onFindClickWithoutProgramId,
+    selectedProgramId,
+    classes,
+    showResetButton,
+}: Props & CssClasses) => {
+    const { trackedEntityName, scopeType, programName } = useScopeInfo(selectedProgramId);
+
+    return (
+        <div className={classes.container}>
+            {
+                (scopeType !== scopeTypes.TRACKER_PROGRAM && scopeType !== scopeTypes.EVENT_PROGRAM) ?
+                    <Button
+                        small
+                        secondary
+                        dataTest="new-event-button"
+                        className={classes.marginRight}
+                        onClick={onNewClickWithoutProgramId}
+                    >
+                        { i18n.t('New') }
+                    </Button>
+                    :
+                    <DropdownButton
+                        small
+                        secondary
+                        dataTest="new-button"
+                        className={classes.marginRight}
+                        component={
+                            <FlyoutMenu
+                                dense
+                                maxWidth="250px"
+                            >
+                                <MenuItem
+                                    dataTest="new-menuitem-one"
+                                    label={i18n.t('New {{trackedEntityName}} in {{programName}}', { trackedEntityName, programName })}
+                                    onClick={onNewClick}
+                                />
+                                <MenuItem
+                                    dataTest="new-menuitem-two"
+                                    label={`${i18n.t('New')}...`}
+                                    onClick={onNewClickWithoutProgramId}
+                                />
+                            </FlyoutMenu>
+                        }
+                    >
+                        { i18n.t('New') }
+                    </DropdownButton>
+            }
+
+            {
+                scopeType !== scopeTypes.TRACKER_PROGRAM ?
+                    <Button
+                        small
+                        secondary
+                        dataTest="find-button"
+                        className={classes.marginRight}
+                        onClick={onFindClickWithoutProgramId}
+                    >
+                        { i18n.t('Search') }
+                    </Button>
+                    :
+                    <DropdownButton
+                        small
+                        secondary
+                        dataTest="find-button"
+                        className={classes.marginRight}
+                        component={
+                            <FlyoutMenu
+                                dense
+                                maxWidth="250px"
+                            >
+                                <MenuItem
+                                    dataTest="find-menuitem-one"
+                                    label={i18n.t('Search for a {{trackedEntityName}} in {{programName}}', { trackedEntityName, programName })}
+                                    onClick={onFindClick}
+                                />
+                                <MenuItem
+                                    dataTest="find-menuitem-two"
+                                    label={`${i18n.t('Search')}...`}
+                                    onClick={onFindClickWithoutProgramId}
+                                />
+                            </FlyoutMenu>
+                        }
+                    >
+                        { i18n.t('Search') }
+                    </DropdownButton>
+            }
+
+            {
+                showResetButton ?
+                    <button
+                        className={classes.buttonAsLink}
+                        data-test="start-again-button"
+                        onClick={onStartAgainClick}
+                    >
+                        { i18n.t('Clear selections') }
+                    </button>
+                    :
+                    null
+            }
+        </div>
+    );
+};
+
+export const ActionButtons: ComponentType<Props> = withStyles(styles)(ActionButtonsPlain);

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/OrgUnitField.container.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/OrgUnitField.container.js
@@ -1,0 +1,26 @@
+// @flow
+import { connect } from 'react-redux';
+import { OrgUnitField as BasicOrgUnitField } from '../../FormFields/New';
+import { searchOrgUnits, clearOrgUnitsSearch } from './actions/orgUnitList.actions';
+import { get as getOrgUnitRoots } from '../../FormFields/New/Fields/OrgUnitField/orgUnitRoots.store';
+
+const mapStateToProps = (state: ReduxState) => {
+    const regUnitRootsState = getOrgUnitRoots('regUnit') || getOrgUnitRoots('captureRoots');
+
+    return {
+        roots: regUnitRootsState,
+        searchText: state.registeringUnitList.searchText,
+        ready: !state.registeringUnitList.isLoading,
+        treeKey: state.registeringUnitList.key,
+    };
+};
+
+const mapDispatchToProps = (dispatch: ReduxDispatch) => ({
+    onSearch: (searchText: string) => {
+        const action = searchText ? searchOrgUnits(searchText) : clearOrgUnitsSearch();
+        dispatch(action);
+    },
+});
+
+// $FlowFixMe[missing-annot] automated comment
+export const OrgUnitField = connect(mapStateToProps, mapDispatchToProps)(BasicOrgUnitField);

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/OrgUnitSelector.component.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/OrgUnitSelector.component.js
@@ -1,0 +1,185 @@
+// @flow
+import React, { Component } from 'react';
+import i18n from '@dhis2/d2-i18n';
+import { withStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import IconButton from '@material-ui/core/IconButton';
+import ClearIcon from '@material-ui/icons/Clear';
+import { Button } from '../../Buttons';
+import { OrgUnitField } from './OrgUnitField.container';
+
+const styles = (theme: Theme) => ({
+    paper: {
+        padding: 8,
+        backgroundColor: theme.palette.grey.lighter,
+    },
+    title: {
+        margin: 0,
+        fontWeight: 425,
+        fontSize: 15,
+        paddingBottom: 5,
+    },
+    form: {
+        width: '100%',
+    },
+    listItem: {
+        backgroundColor: '#ffffff',
+        borderRadius: 5,
+        marginBottom: 5,
+        padding: 5,
+        border: '1px solid lightGrey',
+    },
+    selectedText: {
+        marginTop: 5,
+        marginBottom: 5,
+        padding: 5,
+        borderLeft: '2px solid #71a4f8',
+    },
+    selectedPaper: {
+        backgroundColor: theme.palette.grey.lighter,
+        padding: 8,
+    },
+    selectedButton: {
+        width: 20,
+        height: 20,
+        padding: 0,
+    },
+    selectedButtonIcon: {
+        width: 20,
+        height: 20,
+    },
+    selectedItemContainer: {
+        display: 'flex',
+        alignItems: 'center',
+        minHeight: 28,
+        marginTop: 8,
+        marginBottom: 4,
+        paddingLeft: 5,
+        borderLeft: `2px solid ${theme.palette.primary.light}`,
+    },
+    selectedItemClear: {
+        flexGrow: 1,
+        display: 'flex',
+        justifyContent: 'flex-end',
+    },
+});
+
+type Props = {
+    handleClickOrgUnit: (orgUnitId: ?string, orgUnitObject: ?Object) => void,
+    onReset: () => void,
+    selectedOrgUnitId: string,
+    showWarning: boolean,
+    selectedOrgUnit: Object,
+    classes: Object,
+};
+
+type State = {
+    open: boolean,
+};
+
+class OrgUnitSelectorPlain extends Component<Props, State> {
+    handleShowWarning: () => void;
+    handleClose: () => void;
+    handleClick: (orgUnit: Object) => void;
+    handleReset: () => void;
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            open: false,
+        };
+
+        this.handleShowWarning = this.handleShowWarning.bind(this);
+        this.handleClose = this.handleClose.bind(this);
+        this.handleClick = this.handleClick.bind(this);
+        this.handleReset = this.handleReset.bind(this);
+    }
+
+    handleShowWarning() {
+        if (this.props.showWarning) {
+            this.setState({ open: true });
+        } else {
+            this.handleReset();
+        }
+    }
+
+    handleClose() {
+        this.setState({ open: false });
+    }
+
+    handleClick(event, selectedOu) {
+        const orgUnitObject = { id: selectedOu.id, name: selectedOu.displayName, code: selectedOu.code };
+        this.props.handleClickOrgUnit(selectedOu.id, orgUnitObject);
+    }
+
+    handleReset() {
+        this.props.handleClickOrgUnit(undefined, null);
+    }
+
+    render() {
+        // If orgUnit is set in Redux state.
+        if (this.props.selectedOrgUnitId) {
+            return (
+                <div>
+                    <Paper square elevation={0} className={this.props.classes.selectedPaper}>
+                        <h4 className={this.props.classes.title}>{ i18n.t('Selected registering unit') }</h4>
+                        <div className={this.props.classes.selectedItemContainer}>
+                            <div>{this.props.selectedOrgUnit.name}</div>
+                            <div className={this.props.classes.selectedItemClear}>
+                                <IconButton data-test="reset-selection-button" className={this.props.classes.selectedButton} onClick={() => this.props.onReset()}>
+                                    <ClearIcon className={this.props.classes.selectedButtonIcon} />
+                                </IconButton>
+                            </div>
+                        </div>
+                    </Paper>
+                    <Dialog
+                        open={this.state.open}
+                        onClose={this.handleClose}
+                    >
+                        <DialogTitle>{i18n.t('Start Again')}</DialogTitle>
+                        <DialogContent>
+                            <DialogContentText>
+                                {i18n.t('Are you sure? All unsaved data will be lost.')}
+                            </DialogContentText>
+                        </DialogContent>
+                        <DialogActions>
+                            <Button
+                                onClick={this.handleClose}
+                                secondary
+                            >
+                                {i18n.t('Cancel')}
+                            </Button>
+                            <Button
+                                onClick={this.handleReset}
+                                primary
+                            >
+                                {i18n.t('Accept')}
+                            </Button>
+                        </DialogActions>
+                    </Dialog>
+                </div>
+            );
+        }
+
+        return (
+            <div data-test="org-unit-selector-container">
+                <Paper square elevation={0} className={this.props.classes.paper}>
+                    <h4 className={this.props.classes.title}>{ i18n.t('Registering Organisation Unit') }</h4>
+                    <div>
+                        <OrgUnitField
+                            data-test="org-unit-field"
+                            onSelectClick={this.handleClick}
+                        />
+                    </div>
+                </Paper>
+            </div>
+        );
+    }
+}
+
+export const OrgUnitSelector = withStyles(styles)(OrgUnitSelectorPlain);

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/Program/CategorySelector.component.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/Program/CategorySelector.component.js
@@ -1,0 +1,170 @@
+// @flow
+import * as React from 'react';
+import i18n from '@dhis2/d2-i18n';
+import log from 'loglevel';
+import { errorCreator, makeCancelablePromise } from 'capture-core-utils';
+import type { Category as CategoryMetadata } from '../../../../metaData';
+import { OptionsSelectVirtualized } from '../../../FormFields/Options/SelectVirtualizedV2/OptionsSelectVirtualized.component';
+import { buildCategoryOptionsAsync } from '../../../../metaDataMemoryStoreBuilders';
+import { withLoadingIndicator } from '../../../../HOC/withLoadingIndicator';
+import { makeOnSelectSelector } from './categorySelector.selectors';
+
+const VirtualizedSelectLoadingIndicatorHOC =
+    withLoadingIndicator(
+        () => ({ marginTop: 5, paddingTop: 3, height: 0 }),
+        () => ({ size: 22 }),
+        (props: Object) => props.options)(OptionsSelectVirtualized);
+
+type SelectOption = {
+    label: string,
+    value: string,
+};
+
+type Props = {
+    category: CategoryMetadata,
+    selectedOrgUnitId: ?string,
+    onSelect: (option: SelectOption) => void,
+};
+
+type State = {
+    options: ?Array<SelectOption>,
+    prevOrgUnitId: ?string,
+};
+
+export class CategorySelector extends React.Component<Props, State> {
+    static getOptionsAsync(
+        categoryId: string,
+        selectedOrgUnitId: ?string,
+        onIsAborted: Function,
+    ) {
+        const predicate = (categoryOption: Object) => {
+            if (!selectedOrgUnitId) {
+                return true;
+            }
+
+            const orgUnits = categoryOption.organisationUnits;
+            if (!orgUnits) {
+                return true;
+            }
+
+            return !!orgUnits[selectedOrgUnitId];
+        };
+
+        const project = (categoryOption: Object) => ({
+            label: categoryOption.displayName,
+            value: categoryOption.id,
+            writeAccess: categoryOption.access.data.write,
+        });
+
+        return buildCategoryOptionsAsync(
+            categoryId,
+            { predicate, project, onIsAborted },
+        );
+    }
+
+    static getDerivedStateFromProps(props: Props, state: State) {
+        if (props.selectedOrgUnitId !== state.prevOrgUnitId) {
+            return {
+                prevOrgUnitId: props.selectedOrgUnitId,
+                options: null,
+            };
+        }
+        return null;
+    }
+
+    onSelectSelector: Function;
+    cancelablePromise: Object;
+
+    constructor(props: Props) {
+        super(props);
+        this.state = {
+            options: null,
+            prevOrgUnitId: null,
+        };
+        this.onSelectSelector = makeOnSelectSelector();
+        // todo you cannot setState from this component (lgtm report)
+        this.loadCagoryOptions(this.props);
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        if (!this.state.options && prevProps.selectedOrgUnitId !== this.props.selectedOrgUnitId) {
+            this.loadCagoryOptions(this.props);
+        }
+    }
+
+    componentWillUnmount() {
+        this.cancelablePromise && this.cancelablePromise.cancel();
+        this.cancelablePromise = null;
+    }
+
+    loadCagoryOptions(props: Props) {
+        const { category, selectedOrgUnitId } = props;
+
+        this.setState({
+            options: null,
+        });
+        this.cancelablePromise && this.cancelablePromise.cancel();
+
+        let currentRequestCancelablePromise;
+
+        const isRequestAborted = () =>
+            (currentRequestCancelablePromise && this.cancelablePromise !== currentRequestCancelablePromise);
+
+        currentRequestCancelablePromise = makeCancelablePromise(
+            CategorySelector
+                .getOptionsAsync(
+                    category.id,
+                    selectedOrgUnitId,
+                    isRequestAborted,
+                ),
+        );
+
+        currentRequestCancelablePromise
+            .promise
+            .then((options) => {
+                options.sort((a, b) => {
+                    if (a.label === b.label) {
+                        return 0;
+                    }
+                    if (a.label < b.label) {
+                        return -1;
+                    }
+                    return 1;
+                });
+
+                this.setState({
+                    options,
+                });
+                this.cancelablePromise = null;
+            })
+            .catch((error) => {
+                if (!(error && (error.aborted || error.isCanceled))) {
+                    log.error(
+                        errorCreator('An error occured loading category options')({ error }),
+                    );
+                    this.setState({
+                        options: [],
+                    });
+                }
+            });
+
+        this.cancelablePromise = currentRequestCancelablePromise;
+    }
+
+    render() {
+        const { selectedOrgUnitId, onSelect, ...passOnProps } = this.props;
+        const { options } = this.state;
+        const handleSelect = this.onSelectSelector({ options, onSelect });
+
+        return (
+            // $FlowFixMe[cannot-spread-inexact] automated comment
+            <VirtualizedSelectLoadingIndicatorHOC
+                options={options}
+                value={''}
+                placeholder={i18n.t('Select')}
+                {...passOnProps}
+                onSelect={handleSelect}
+            />
+        );
+    }
+}

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/Program/ProgramList.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/Program/ProgramList.js
@@ -1,0 +1,72 @@
+// @flow
+import * as React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+
+const getStyles = () => ({
+    list: {
+        padding: 0,
+    },
+    item: {
+        wordBreak: 'break-word',
+        hyphens: 'auto',
+        backgroundColor: '#ffffff',
+        borderRadius: 5,
+        marginBottom: 5,
+        padding: 5,
+        border: '1px solid lightGrey',
+        '&:hover': {
+            backgroundColor: 'white',
+            borderColor: '#71a4f8',
+        },
+    },
+    itemContents: {
+        display: 'flex',
+        alignItems: 'center',
+    },
+});
+
+type Item = { label: string, value: string, iconLeft: React.Node };
+
+type Props = {
+    items: Array<Item>,
+    onSelect: (id: string) => void,
+    classes: {
+        list: string,
+        item: string,
+        itemContents: string,
+    },
+};
+
+const ProgramListPlain = (props: Props) => {
+    const { items, onSelect, classes } = props;
+    return (
+        <List className={classes.list}>
+            {items.map(item =>
+                (
+                    <ListItem
+                        className={classes.item}
+                        button
+                        onClick={() => onSelect(item.value)}
+                        key={item.value}
+                    >
+                        <ListItemText
+                            primary={(
+                                <div
+                                    className={classes.itemContents}
+                                >
+                                    {item.iconLeft}
+                                    {item.label}
+                                </div>
+                            )}
+                        />
+                    </ListItem>
+                ),
+            )}
+        </List>
+    );
+};
+
+export const ProgramList = withStyles(getStyles)(ProgramListPlain);

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/Program/ProgramSelector.component.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/Program/ProgramSelector.component.js
@@ -1,0 +1,381 @@
+// @flow
+
+import React, { Component, useEffect } from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import { useHistory } from 'react-router';
+import { useSelector } from 'react-redux';
+import Paper from '@material-ui/core/Paper';
+import IconButton from '@material-ui/core/IconButton';
+import ClearIcon from '@material-ui/icons/Clear';
+import Grid from '@material-ui/core/Grid';
+import i18n from '@dhis2/d2-i18n';
+import { colors } from '@dhis2/ui';
+import { programCollection } from '../../../../metaDataMemoryStores';
+import { OptionsSelectVirtualized } from '../../../FormFields/Options/SelectVirtualizedV2/OptionsSelectVirtualized.component';
+import { ProgramList } from './ProgramList';
+import { CategorySelector } from './CategorySelector.component';
+
+import type { Program } from '../../../../metaData';
+import { resetProgramIdBase } from '../actions/QuickSelector.actions';
+import './programSelector.css';
+import { LinkButton } from '../../../Buttons/LinkButton.component';
+import { urlArguments } from '../../../../utils/url';
+import { NonBundledDhis2Icon } from '../../../NonBundledDhis2Icon';
+
+const EmptyPrograms = ({ classes, handleResetOrgUnit }) => {
+    const { push } = useHistory();
+    const pathname: string = useSelector(({ router: { location } }) => location.pathname);
+    const { enrollmentId, teiId, orgUnitId } = useSelector(({ router: { location: { query } } }) => query);
+
+
+    useEffect(() => {
+        const navigateToEventRegistrationPage = () => {
+            push(`${pathname}?${urlArguments({ enrollmentId, teiId, orgUnitId })}`);
+        };
+
+        navigateToEventRegistrationPage();
+    }, [push, pathname, enrollmentId, teiId, orgUnitId]);
+
+    return (
+        <Paper square elevation={0} className={classes.paper}>
+            <h4 className={classes.title}>{ i18n.t('Program') }</h4>
+            <div
+                className={classes.noProgramsContainer}
+            >
+                {i18n.t('No programs available.')}
+                <LinkButton
+                    className={classes.programsHiddenTextResetOrgUnit}
+                    onClick={handleResetOrgUnit}
+                >
+                    {i18n.t('Show all')}
+                </LinkButton>
+            </div>
+        </Paper>
+    );
+};
+
+const styles = (theme: Theme) => ({
+    border: {
+        borderRight: `1px solid ${colors.grey500}`,
+    },
+    paper: {
+        padding: 8,
+        backgroundColor: theme.palette.grey.lighter,
+    },
+    title: {
+        margin: 0,
+        fontWeight: 425,
+        fontSize: 15,
+        paddingBottom: 5,
+    },
+    form: {
+        width: '100%',
+    },
+    selectedText: {
+        marginTop: 6,
+        marginBottom: 4,
+        padding: 5,
+        borderLeft: `2px solid ${colors.blue600}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+    },
+    selectedTextContainer: {
+        display: 'flex',
+        alignItems: 'center',
+        overflow: 'hidden',
+    },
+    selectedTextAndIconContainer: {
+        display: 'flex',
+        alignItems: 'center',
+        overflow: 'hidden',
+    },
+    selectedProgramNameContainer: {
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+    },
+    selectedCategoryNameContainer: {
+        whiteSpace: 'nowrap',
+        textOverflow: 'ellipsis',
+        overflow: 'hidden',
+    },
+    selectedPaper: {
+        backgroundColor: theme.palette.grey.lighter,
+        padding: 8,
+    },
+    selectedButton: {
+        float: 'right',
+        width: 20,
+        height: 20,
+        padding: 0,
+    },
+    selectedButtonIcon: {
+        width: 20,
+        height: 20,
+    },
+    programsHiddenText: {
+        fontSize: 12,
+        color: theme.palette.grey.dark,
+        paddingTop: 5,
+    },
+    programsHiddenTextResetOrgUnit: {
+        cursor: 'pointer',
+        color: 'inherit',
+        paddingLeft: 2,
+    },
+    noProgramsContainer: {
+        fontSize: 14,
+        textAlign: 'center',
+        backgroundColor: 'white',
+        padding: 10,
+        borderRadius: 5,
+        border: '1px solid lightGrey',
+    },
+    iconContainer: {
+        display: 'flex',
+        alignItems: 'center',
+        paddingRight: 5,
+    },
+});
+
+type Props = {
+    handleClickProgram: (value: string) => void,
+    handleSetCatergoryCombo: (category: Object, categoryId: string) => void,
+    onResetProgramId: (baseAction: ReduxAction<any, any>) => void,
+    onResetCategoryOption: (categoryId: string) => void,
+    onResetOrgUnit: () => void,
+    buttonModeMaxLength: number,
+    selectedProgram: string,
+    selectedOrgUnitId: string,
+    selectedCategories: Object,
+    classes: Object,
+};
+
+class ProgramSelectorPlain extends Component<Props> {
+    handleClick: (program: Object) => void;
+    handleClickCategoryOption: (value: string, value: string) => void;
+    programsArray: Array<Program>;
+    constructor(props) {
+        super(props);
+        this.handleClick = this.handleClick.bind(this);
+        this.handleClickCategoryOption = this.handleClickCategoryOption.bind(this);
+        this.buildProgramsArray();
+    }
+
+    buildProgramsArray() {
+        this.programsArray = Array.from(programCollection.values());
+    }
+
+    getProgramIcon({ icon: { color, name } = {}, name: programName }: Program) {
+        const { classes } = this.props;
+
+        return (
+            <div
+                className={classes.iconContainer}
+            >
+                <NonBundledDhis2Icon
+                    name={name || 'clinical_fe_outline'}
+                    color={color || '#e0e0e0'}
+                    alternativeText={programName}
+                    width={22}
+                    height={22}
+                    cornerRadius={2}
+                />
+            </div>
+        );
+    }
+
+    getOptionsFromPrograms(programs: Array<Program>) {
+        return programs
+            .map(program => ({
+                label: program.name,
+                value: program.id,
+                iconLeft: this.getProgramIcon(program),
+            }));
+    }
+
+    handleClick(program) {
+        this.props.handleClickProgram(program.value);
+    }
+
+    handleClickCategoryOption(selectedCategoryOption, categoryId) {
+        this.props.handleSetCatergoryCombo(selectedCategoryOption, categoryId);
+    }
+
+    handleResetProgram() {
+        this.props.onResetProgramId(resetProgramIdBase());
+    }
+
+    handleResetCategoryOption(categoryId) {
+        this.props.onResetCategoryOption(categoryId);
+    }
+
+    handleResetOrgUnit() {
+        this.props.onResetOrgUnit();
+    }
+
+    getOptions() {
+        let programOptions = [];
+        if (this.props.selectedOrgUnitId) {
+            programOptions = this.getOptionsFromPrograms(this.programsArray
+                .filter(program =>
+                    program.organisationUnits[this.props.selectedOrgUnitId] &&
+                    program.access.data.read),
+            );
+        } else {
+            programOptions = this.getOptionsFromPrograms(this.programsArray
+                .filter(program => program.access.data.read),
+            );
+        }
+        return programOptions;
+    }
+
+    areAllProgramsAvailable(programOptions) {
+        return (programOptions.length === this.programsArray
+            .filter(program => program.access.data.read).length);
+    }
+
+    renderSelectedProgram(selectedProgram) {
+        return (
+            <React.Fragment>
+                <h4 className={this.props.classes.title}>{ i18n.t('Selected program') }</h4>
+                <div className={this.props.classes.selectedText}>
+                    <div
+                        className={this.props.classes.selectedTextAndIconContainer}
+                    >
+                        {this.getProgramIcon(selectedProgram)}
+                        <div
+                            className={this.props.classes.selectedProgramNameContainer}
+                        >
+                            {selectedProgram.name}
+                        </div>
+                    </div>
+                    <IconButton data-test="reset-selection-button" className={this.props.classes.selectedButton} onClick={() => this.handleResetProgram()}>
+                        <ClearIcon className={this.props.classes.selectedButtonIcon} />
+                    </IconButton>
+                </div>
+            </React.Fragment>
+        );
+    }
+
+    renderWithSelectedProgram(selectedProgram) {
+        if (selectedProgram.categoryCombination) {
+            const { classes, selectedCategories, selectedOrgUnitId } = this.props;
+            return (
+                <Grid container>
+                    <Grid item xs={12} sm={6} className={this.props.classes.border}>
+                        <Paper square elevation={0} className={classes.selectedPaper}>
+                            {this.renderSelectedProgram(selectedProgram)}
+                        </Paper>
+                    </Grid>
+                    {
+                        // $FlowFixMe
+                        Array.from(selectedProgram.categoryCombination.categories.values()).map(category =>
+                            (<Grid key={category.id} item xs={12} sm={6}>
+                                <Paper square elevation={0} className={classes.selectedPaper}>
+                                    <h4 className={classes.title}>{category.name}</h4>
+                                    {
+                                        (() => {
+                                            if (selectedCategories && selectedCategories[category.id]) {
+                                                return (
+                                                    <div className={classes.selectedText}>
+                                                        <div className={classes.selectedCategoryNameContainer}>{selectedCategories[category.id].name}</div>
+                                                        <IconButton data-test="reset-selection-button" className={classes.selectedButton} onClick={() => this.handleResetCategoryOption(category.id)}>
+                                                            <ClearIcon className={classes.selectedButtonIcon} />
+                                                        </IconButton>
+                                                    </div>
+                                                );
+                                            }
+                                            return (
+                                                <CategorySelector
+                                                    category={category}
+                                                    // $FlowFixMe[incompatible-call] automated comment
+                                                    onSelect={(option) => { this.handleClickCategoryOption(option, category.id); }}
+                                                    selectedOrgUnitId={selectedOrgUnitId}
+                                                />
+                                            );
+                                        })()
+                                    }
+                                </Paper>
+                            </Grid>))
+                    }
+                </Grid>
+            );
+        }
+
+        return (
+            <Paper square elevation={0} className={this.props.classes.selectedPaper}>
+                {this.renderSelectedProgram(selectedProgram)}
+            </Paper>
+        );
+    }
+
+    renderWithoutSelectedProgram(programOptions) {
+        const { handleClickProgram, classes } = this.props;
+        const areAllProgramsAvailable = this.areAllProgramsAvailable(programOptions);
+        const footer = !areAllProgramsAvailable
+            ? (
+                <div
+                    className={this.props.classes.programsHiddenText}
+                >
+                    {i18n.t('Some programs are being filtered.')}
+                    <LinkButton
+                        className={this.props.classes.programsHiddenTextResetOrgUnit}
+                        onClick={() => this.handleResetOrgUnit()}
+                    >
+                        {i18n.t('Show all')}
+                    </LinkButton>
+                </div>
+            )
+            : null;
+
+        return (
+            <Paper square elevation={0} className={classes.paper} data-test="program-selector-container">
+                <h4 className={classes.title}>
+                    { i18n.t('Program') }
+                </h4>
+                {
+                    (() => {
+                        if (programOptions.length <= this.props.buttonModeMaxLength) {
+                            return (
+                                <ProgramList
+                                    items={programOptions}
+                                    onSelect={handleClickProgram}
+                                />
+                            );
+                        }
+                        return (
+                            <div>
+                                <div id="program-selector">
+                                    <OptionsSelectVirtualized
+                                        options={programOptions}
+                                        onSelect={handleClickProgram}
+                                        placeholder={i18n.t('Select program')}
+                                        value={''}
+                                    />
+                                </div>
+                            </div>
+                        );
+                    })()
+                }
+                {footer}
+            </Paper>
+        );
+    }
+
+    render() {
+        const programOptions = this.getOptions();
+
+        if (programOptions.length === 0) {
+            return <EmptyPrograms classes={this.props.classes} handleResetOrgUnit={this.props.onResetOrgUnit} />;
+        }
+
+        const selectedProgram = this.props.selectedProgram ? programCollection.get(this.props.selectedProgram) : null;
+        if (selectedProgram) {
+            return this.renderWithSelectedProgram(selectedProgram);
+        }
+        return this.renderWithoutSelectedProgram(programOptions);
+    }
+}
+export const ProgramSelector = withStyles(styles, { index: 1 })(ProgramSelectorPlain);

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/Program/categorySelector.selectors.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/Program/categorySelector.selectors.js
@@ -1,0 +1,21 @@
+// @flow
+import { createSelector } from 'reselect';
+
+const filteredOptionsSelector = data => data.options;
+const onSelectFromPropsSelector = data => data.onSelect;
+
+// $FlowFixMe
+export const makeOnSelectSelector = () => createSelector(
+    filteredOptionsSelector,
+    onSelectFromPropsSelector,
+    (filteredOptions, onSelect) => (optionId) => {
+        const option = filteredOptions
+            .find(o => o.value === optionId);
+
+        onSelect({
+            name: option.label,
+            id: option.value,
+            writeAccess: option.writeAccess,
+        });
+    },
+);

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/Program/programSelector.css
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/Program/programSelector.css
@@ -1,0 +1,4 @@
+#program-selector .Select-control {
+    height: 40px;
+    line-height: 40px;
+}

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/QuickSelector.component.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/QuickSelector.component.js
@@ -1,0 +1,188 @@
+// @flow
+
+import React, { Component } from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import i18n from '@dhis2/d2-i18n';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import { colors } from '@dhis2/ui';
+import { programCollection } from 'capture-core/metaDataMemoryStores/programCollection/programCollection';
+
+import { ProgramSelector } from './Program/ProgramSelector.component';
+import { OrgUnitSelector } from './OrgUnitSelector.component';
+import { ActionButtons } from './ActionButtons.component';
+import { SingleLockedSelect } from './SingleLockedSelect.component';
+
+const styles = ({ palette }) => ({
+    paper: {
+        flexGrow: 1,
+    },
+    programSelector: {
+        backgroundColor: palette.grey.lighter,
+        margin: '0 0 0 -1px',
+    },
+    orgUnitSelector: {
+        backgroundColor: palette.grey.lighter,
+        margin: '0 0 0 -1px',
+        borderRight: `1px solid ${colors.grey500}`,
+        borderLeft: `1px solid ${colors.grey500}`,
+    },
+});
+
+type Props = {
+    selectedOrgUnitId: string,
+    selectedProgramId: string,
+    selectedCategories: Object,
+    selectedOrgUnit: Object,
+    classes: Object,
+    onSetOrgUnit: (orgUnitId: string, orgUnitObject: Object) => void,
+    onSetProgramId: (programId: string) => void,
+    onSetCategoryOption: (categoryId: string, categoryOptionId: string) => void,
+    onResetOrgUnitId: () => void,
+    onResetProgramId: (baseAction: ReduxAction<any, any>) => void,
+    onResetCategoryOption: (categoryId: string) => void,
+    onResetAllCategoryOptions: () => void,
+    onStartAgain: () => void,
+    onNewClick: () => void,
+    onNewClickWithoutProgramId: () => void,
+    onFindClick: () => void,
+    onFindClickWithoutProgramId: () => void,
+    currentPage: string,
+    selectedEnrollmentId: string,
+    selectedTeiName: string,
+    selectedTetName: string,
+    enrollmentsAsOptions: Array<Object>,
+    onTeiSelectionReset: () => void,
+    onEnrollmentSelectionSet: () => void,
+    onEnrollmentSelectionReset: () => void,
+    enrollmentLockedSelectReady: boolean,
+};
+
+class QuickSelectorPlain extends Component<Props> {
+    static getSelectedProgram(selectedProgramId: string) {
+        return programCollection.get(selectedProgramId) || {};
+    }
+
+    handleClickProgram: (programId: string) => void;
+    handleSetCatergoryCombo: (selectedCategoryOption: string, categoryId: string) => void;
+    handleClickOrgUnit: (orgUnit: Object) => void;
+    constructor(props) {
+        super(props);
+
+        this.handleClickProgram = this.handleClickProgram.bind(this);
+        this.handleSetCatergoryCombo = this.handleSetCatergoryCombo.bind(this);
+        this.handleClickOrgUnit = this.handleClickOrgUnit.bind(this);
+    }
+
+    handleClickProgram(programId: string) {
+        this.props.onSetProgramId(programId);
+    }
+
+    handleSetCatergoryCombo(selectedCategoryOption, categoryId) {
+        this.props.onSetCategoryOption(categoryId, selectedCategoryOption);
+    }
+
+    handleClickOrgUnit(orgUnitId, orgUnitObject) {
+        this.props.onSetOrgUnit(orgUnitId, orgUnitObject);
+    }
+
+    calculateColumnWidths() {
+        // The grid has a total width of 12 columns, we need to calculate how much width each selector should have.
+        const selectedProgramId = this.props.selectedProgramId;
+        const selectedProgram = QuickSelectorPlain.getSelectedProgram(selectedProgramId);
+
+        return {
+            programSelectorWidth: selectedProgram && selectedProgram.categoryCombination ? 4 : 2,
+            width: 2,
+        };
+    }
+
+    render() {
+        const { width, programSelectorWidth } = this.calculateColumnWidths();
+        const {
+            currentPage,
+            selectedTeiName,
+            selectedTetName,
+            enrollmentsAsOptions,
+            selectedEnrollmentId,
+            onTeiSelectionReset,
+            onEnrollmentSelectionSet,
+            onEnrollmentSelectionReset,
+            enrollmentLockedSelectReady,
+        } = this.props;
+
+        return (
+            <Paper className={this.props.classes.paper}>
+                <Grid container spacing={0}>
+                    <Grid item xs={12} sm={programSelectorWidth * 3} md={programSelectorWidth * 2} lg={programSelectorWidth} className={this.props.classes.programSelector}>
+                        <ProgramSelector
+                            selectedProgram={this.props.selectedProgramId}
+                            selectedOrgUnitId={this.props.selectedOrgUnitId}
+                            selectedCategories={this.props.selectedCategories}
+                            handleClickProgram={this.handleClickProgram}
+                            handleSetCatergoryCombo={this.handleSetCatergoryCombo}
+                            handleResetCategorySelections={this.props.onResetAllCategoryOptions}
+                            buttonModeMaxLength={5}
+                            onResetProgramId={this.props.onResetProgramId}
+                            onResetCategoryOption={this.props.onResetCategoryOption}
+                            onResetOrgUnit={this.props.onResetOrgUnitId}
+                        />
+                    </Grid>
+                    <Grid item xs={12} sm={width * 3} md={width * 2} lg={width} className={this.props.classes.orgUnitSelector}>
+                        <OrgUnitSelector
+                            selectedOrgUnitId={this.props.selectedOrgUnitId}
+                            handleClickOrgUnit={this.handleClickOrgUnit}
+                            selectedOrgUnit={this.props.selectedOrgUnit}
+                            onReset={this.props.onResetOrgUnitId}
+                        />
+                    </Grid>
+                    {
+                        currentPage === 'enrollment' &&
+                        <>
+                            <Grid item xs={12} sm={width * 3} md={width * 2} lg={2} className={this.props.classes.orgUnitSelector}>
+                                <SingleLockedSelect
+                                    ready={enrollmentLockedSelectReady}
+                                    onClear={onTeiSelectionReset}
+                                    options={[{
+                                        label: selectedTeiName,
+                                        value: 'alwaysPreselected',
+
+                                    }]}
+                                    selectedValue="alwaysPreselected"
+                                    title={selectedTetName}
+                                />
+                            </Grid>
+                            {
+                                enrollmentsAsOptions &&
+                                <Grid item xs={12} sm={width * 3} md={width * 2} lg={2} className={this.props.classes.orgUnitSelector}>
+                                    <SingleLockedSelect
+                                        onClear={onEnrollmentSelectionReset}
+                                        ready={enrollmentLockedSelectReady}
+                                        onSelect={onEnrollmentSelectionSet}
+                                        options={enrollmentsAsOptions}
+                                        selectedValue={selectedEnrollmentId}
+                                        title={i18n.t('Enrollment')}
+                                    />
+                                </Grid>
+                            }
+                        </>
+
+                    }
+                    <Grid item xs={12} sm={width * 3} md={width * 2} lg={2} >
+                        <ActionButtons
+                            selectedProgramId={this.props.selectedProgramId}
+                            onStartAgainClick={this.props.onStartAgain}
+                            onFindClick={this.props.onFindClick}
+                            onFindClickWithoutProgramId={this.props.onFindClickWithoutProgramId}
+                            onNewClick={this.props.onNewClick}
+                            onNewClickWithoutProgramId={this.props.onNewClickWithoutProgramId}
+                            showResetButton={!!(this.props.selectedProgramId || this.props.selectedOrgUnitId)}
+                        />
+                    </Grid>
+                </Grid>
+            </Paper>
+        );
+    }
+}
+
+export const QuickSelectorComponent = withStyles(styles)(QuickSelectorPlain);

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/QuickSelector.container.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/QuickSelector.container.js
@@ -1,0 +1,66 @@
+// @flow
+
+import { connect } from 'react-redux';
+import { QuickSelectorComponent } from './QuickSelector.component';
+import { convertValue } from '../../../converters/clientToView';
+import { dataElementTypes } from '../../../metaData/DataElement';
+import {
+    resetEnrollmentSelection,
+    resetTeiSelection,
+    setEnrollmentSelection,
+} from '../ScopeSelector.actions';
+import { deriveUrlQueries } from '../../../utils/url';
+import { getScopeInfo } from '../../../metaData';
+
+const buildEnrollmentsAsOptions = (enrollments = [], selectedProgramId) =>
+    enrollments
+        .filter(({ program }) => program === selectedProgramId)
+        .map(({ created, enrollment }) => (
+            {
+                label: convertValue(created, dataElementTypes.DATETIME),
+                value: enrollment,
+            }
+        ));
+
+const mapStateToProps = (state: Object) => {
+    const { orgUnitId, programId } = deriveUrlQueries(state);
+    const {
+        router: { location: { pathname, query: { enrollmentId } } },
+        currentSelections: { categoriesMeta },
+        organisationUnits,
+        enrollmentPage: { enrollments, teiDisplayName, tetId },
+    } = state;
+
+    const enrollmentsAsOptions = buildEnrollmentsAsOptions(enrollments, programId);
+    const { trackedEntityName } = getScopeInfo(tetId);
+
+    const enrollmentLockedSelectReady = Array.isArray(enrollments);
+    return {
+        selectedProgramId: programId,
+        selectedOrgUnitId: orgUnitId,
+        selectedCategories: categoriesMeta,
+        selectedOrgUnit: orgUnitId ? organisationUnits[orgUnitId] : null,
+        currentPage: pathname.substring(1),
+        selectedTeiName: teiDisplayName,
+        selectedTetName: trackedEntityName,
+        selectedEnrollmentId: enrollmentId,
+        enrollmentsAsOptions,
+        enrollmentLockedSelectReady,
+    };
+};
+
+
+const mapDispatchToProps = (dispatch: ReduxDispatch) => ({
+    onTeiSelectionReset: () => {
+        dispatch(resetTeiSelection());
+    },
+    onEnrollmentSelectionSet: (enrollmentId) => {
+        dispatch(setEnrollmentSelection({ enrollmentId }));
+    },
+    onEnrollmentSelectionReset: () => {
+        dispatch(resetEnrollmentSelection());
+    },
+});
+
+// $FlowFixMe[missing-annot] automated comment
+export const QuickSelector = connect(mapStateToProps, mapDispatchToProps)(QuickSelectorComponent);

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/SingleLockedSelect.component.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/SingleLockedSelect.component.js
@@ -1,0 +1,134 @@
+// @flow
+import React, { type ComponentType, useCallback, useState } from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
+import IconButton from '@material-ui/core/IconButton';
+import ClearIcon from '@material-ui/icons/Clear';
+import i18n from '@dhis2/d2-i18n';
+import Select from 'react-virtualized-select';
+import { compose } from 'redux';
+import { withLoadingIndicator } from '../../../HOC';
+
+const styles = (theme: Theme) => ({
+    paper: {
+        padding: 8,
+        backgroundColor: theme.palette.grey.lighter,
+    },
+    title: {
+        margin: 0,
+        fontWeight: 425,
+        fontSize: 15,
+        paddingBottom: 5,
+    },
+    form: {
+        width: '100%',
+    },
+    listItem: {
+        backgroundColor: '#ffffff',
+        borderRadius: 5,
+        marginBottom: 5,
+        padding: 5,
+        border: '1px solid lightGrey',
+    },
+    selectedPaper: {
+        backgroundColor: theme.palette.grey.lighter,
+        padding: 8,
+    },
+    selectedButton: {
+        width: 20,
+        height: 20,
+        padding: 0,
+    },
+    selectedButtonIcon: {
+        width: 20,
+        height: 20,
+    },
+    selectedItemContainer: {
+        display: 'flex',
+        alignItems: 'center',
+        minHeight: 28,
+        marginTop: 8,
+        marginBottom: 4,
+        paddingLeft: 5,
+        borderLeft: `2px solid ${theme.palette.primary.light}`,
+    },
+    selectedItemClear: {
+        flexGrow: 1,
+        display: 'flex',
+        justifyContent: 'flex-end',
+    },
+});
+
+type Props = {|
+    options: Array<{|label: string, value: any, |}>,
+    onClear?: () => void,
+    onSelect?: (value: string) => void,
+    title: string,
+    selectedValue: string,
+    ...CssClasses
+|};
+
+type ReadyProp = {|
+    ready: boolean,
+|};
+
+const SingleLockedSelectPlain =
+  ({
+      onClear,
+      onSelect,
+      title,
+      selectedValue,
+      options,
+      classes,
+  }: Props) => {
+      const [selected, toggleSelected] = useState((Boolean(selectedValue)));
+
+      const handleOnClear = () => {
+          toggleSelected(false);
+          onClear && onClear();
+      };
+      const handleOnSelect = useCallback(({ value }) => {
+          toggleSelected(true);
+          onSelect && onSelect(value);
+      },
+      [onSelect]);
+
+      const { label } = options.find((({ value }) => value === selectedValue)) || {};
+      return (<>
+          {
+              selected && label ?
+                  <Paper square elevation={0} className={classes.selectedPaper}>
+                      <h4 className={classes.title}>
+                          {i18n.t('Selected')} {title.toLowerCase()}
+                      </h4>
+                      <div className={classes.selectedItemContainer}>
+                          <div>{label}</div>
+
+                          <div className={classes.selectedItemClear}>
+                              <IconButton data-test="reset-selection-button" className={classes.selectedButton} onClick={handleOnClear}>
+                                  <ClearIcon className={classes.selectedButtonIcon} />
+                              </IconButton>
+                          </div>
+                      </div>
+                  </Paper>
+                  :
+                  <div data-test="org-unit-selector-container">
+                      <Paper square elevation={0} className={classes.paper}>
+                          <h4 className={classes.title}>
+                              { title }
+                          </h4>
+                          <Select
+                              onChange={handleOnSelect}
+                              options={options}
+                          />
+                      </Paper>
+                  </div>
+          }
+      </>);
+  };
+
+export const SingleLockedSelect: ComponentType<$Diff<Props & ReadyProp, CssClasses>>
+  = compose(
+      withLoadingIndicator(() => ({ height: '100%', alignItems: 'center', justifyContent: 'center' }), () => ({ size: 15 })),
+      withStyles(styles),
+  )(SingleLockedSelectPlain);

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/actions/QuickSelector.actions.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/actions/QuickSelector.actions.js
@@ -1,0 +1,34 @@
+// @flow
+import { actionCreator } from '../../../../actions/actions.utils';
+
+export const actionTypes = {
+    SET_ORG_UNIT_ID: 'setOrgUnitId',
+    STORE_ORG_UNIT_OBJECT: 'storeOrgUnitObject',
+    SET_PROGRAM_ID: 'setProgramId',
+    SET_CATEGORY_ID: 'setCategoryId',
+    RESET_CATEGORY_SELECTIONS: 'resetCategorySelections',
+    GO_BACK_TO_LIST_CONTEXT: 'goBackToListContext',
+    RESET_PROGRAM_ID_BASE: 'resetProgramIdBase',
+};
+
+export const setOrgUnitId =
+    (orgUnitId: string) => actionCreator(actionTypes.SET_ORG_UNIT_ID)(orgUnitId);
+
+export const storeOrgUnitObject =
+    (orgUnitObject: Object) => actionCreator(actionTypes.STORE_ORG_UNIT_OBJECT)(orgUnitObject);
+
+export const setProgramId =
+    (programId: string) => actionCreator(actionTypes.SET_PROGRAM_ID)(programId);
+
+export const setCategoryId =
+    (categoryId: string, selectedCategoryOptionId: string) =>
+        actionCreator(actionTypes.SET_CATEGORY_ID)({ categoryId, selectedCategoryOptionId });
+
+export const resetCategorySelections =
+    () => actionCreator(actionTypes.RESET_CATEGORY_SELECTIONS)();
+
+export const goBackToListContext =
+    () => actionCreator(actionTypes.GO_BACK_TO_LIST_CONTEXT)();
+
+export const resetProgramIdBase =
+    () => actionCreator(actionTypes.RESET_PROGRAM_ID_BASE)();

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/actions/orgUnitList.actions.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/actions/orgUnitList.actions.js
@@ -1,0 +1,33 @@
+// @flow
+import { actionCreator } from 'capture-core/actions/actions.utils';
+
+export const actionTypes = {
+    INIT_REG_UNIT_LIST_ROOTS: 'initRegUnitListRoots',
+    INIT_REG_UNIT_LIST_ROOTS_FAILED: 'initRegUnitListRootsFailed',
+    SEARCH_ORG_UNITS: 'searchRegisteringUnits',
+    CLEAR_ORG_UNIT_SEARCH: 'clearOrgUnitSearch',
+    SET_SEARCH_ROOTS: 'setRegisteringUnitSearchRoots',
+    SET_SEARCH_ROOTS_FAILED: 'setSearchRootsFailed',
+    SHOW_LOADING_INDICATOR: 'showRegUnitLoadingIndicator',
+};
+
+export const initRegUnitListRoots = (roots: any) =>
+    actionCreator(actionTypes.INIT_REG_UNIT_LIST_ROOTS)({ roots });
+
+export const initRegUnitListRootsFailed = (message: string) =>
+    actionCreator(actionTypes.INIT_REG_UNIT_LIST_ROOTS_FAILED)({ message });
+
+export const searchOrgUnits = (searchText: string) =>
+    actionCreator(actionTypes.SEARCH_ORG_UNITS)({ searchText });
+
+export const setSearchRootsFailed = (message: string) =>
+    actionCreator(actionTypes.SET_SEARCH_ROOTS_FAILED)({ message });
+
+export const clearOrgUnitsSearch = () =>
+    actionCreator(actionTypes.CLEAR_ORG_UNIT_SEARCH)();
+
+export const setSearchRoots = (roots: Array<Object>, searchText: string) =>
+    actionCreator(actionTypes.SET_SEARCH_ROOTS)({ roots, searchText });
+
+export const showLoadingIndicator = () =>
+    actionCreator(actionTypes.SHOW_LOADING_INDICATOR)();

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/epics/orgUnitList.epics.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/epics/orgUnitList.epics.js
@@ -1,0 +1,76 @@
+// @flow
+import log from 'loglevel';
+import { map, switchMap, takeUntil } from 'rxjs/operators';
+import { ofType } from 'redux-observable';
+import { from } from 'rxjs';
+import { getD2 } from 'capture-core/d2/d2Instance';
+import { errorCreator } from 'capture-core-utils';
+import {
+    actionTypes as orgUnitListActions,
+    setSearchRoots,
+    setSearchRootsFailed,
+    showLoadingIndicator,
+} from '../actions/orgUnitList.actions';
+import { set as setStoreRoots } from '../../../FormFields/New/Fields/OrgUnitField/orgUnitRoots.store';
+import { LOADING_INDICATOR_TIMEOUT } from '../../../../constants';
+
+const RETRIEVE_ERROR = 'Could not retrieve registering unit list';
+
+// get organisation units based on search criteria
+export const searchRegisteringUnitListEpic = (action$: InputObservable) =>
+    action$.pipe(
+        ofType(orgUnitListActions.SEARCH_ORG_UNITS),
+        switchMap((action) => {
+            const searchText = action.payload.searchText;
+            return getD2()
+                .models
+                .organisationUnits
+                .list({
+                    fields: [
+                        'id,displayName,path,publicAccess,access,lastUpdated',
+                        'children[id,displayName,publicAccess,access,path,children::isNotEmpty]',
+                    ].join(','),
+                    paging: true,
+                    withinUserHierarchy: true,
+                    query: searchText,
+                    pageSize: 15,
+                })
+                .then(orgUnitCollection => ({ regUnitArray: orgUnitCollection.toArray(), searchText }))
+                .catch(error => ({ error }));
+        }),
+        map((resultContainer) => {
+            if (resultContainer.error) {
+                log.error(errorCreator(RETRIEVE_ERROR)(
+                    { error: resultContainer.error, method: 'searchRegisteringUnitListEpic' }),
+                );
+                return setSearchRootsFailed(RETRIEVE_ERROR);
+            }
+
+            const regUnitArray = resultContainer.regUnitArray;
+            setStoreRoots('regUnit', regUnitArray);
+            const regUnits = resultContainer.regUnitArray
+                .map(unit => ({
+                    id: unit.id,
+                    path: unit.path,
+                    displayName: unit.displayName,
+                }));
+            return setSearchRoots(regUnits, resultContainer.searchText);
+        }));
+
+// show loading indicator if api-request is not resolved when timeout expires
+export const showRegisteringUnitListIndicatorEpic = (action$: InputObservable) =>
+    action$.pipe(
+        ofType(orgUnitListActions.SEARCH_ORG_UNITS),
+        switchMap(() =>
+            from(new Promise((resolve) => {
+                setTimeout(() => resolve(), LOADING_INDICATOR_TIMEOUT);
+            }))
+                .pipe(
+                    takeUntil(action$.pipe(
+                        ofType(
+                            orgUnitListActions.SET_SEARCH_ROOTS,
+                            orgUnitListActions.SET_SEARCH_ROOTS_FAILED)),
+                    ),
+                ),
+        ),
+        map(() => showLoadingIndicator()));

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/index.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/index.js
@@ -1,0 +1,6 @@
+// epics
+export { searchRegisteringUnitListEpic, showRegisteringUnitListIndicatorEpic } from './epics/orgUnitList.epics';
+
+
+// actions
+export { actionTypes as orgUnitListActionTypes } from './actions/orgUnitList.actions';

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/programSelector.css
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/programSelector.css
@@ -1,0 +1,4 @@
+#program-selector .Select-control {
+    height: 46px;
+    line-height: 46px;    
+}

--- a/src/core_modules/capture-core/components/ScopeSelector/ScopeSelector.actions.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/ScopeSelector.actions.js
@@ -1,0 +1,98 @@
+// @flow
+import { batchActions } from 'redux-batched-actions';
+import { actionCreator } from '../../actions/actions.utils';
+import { resetProgramIdBase } from './QuickSelector/actions/QuickSelector.actions';
+
+export const lockedSelectorActionTypes = {
+    ORG_UNIT_ID_SET: 'LockedSelector.OrgUnitSet',
+    ORG_UNIT_ID_RESET: 'LockedSelector.OrgUnitIdReset',
+    PROGRAM_ID_SET: 'LockedSelector.ProgramIdSet',
+    PROGRAM_ID_RESET: 'LockedSelector.ProgramIdReset',
+    CATEGORY_OPTION_SET: 'LockedSelector.CategoryOptionSet',
+    CATEGORY_OPTION_RESET: 'LockedSelector.CategoryOptionReset',
+    ALL_CATEGORY_OPTIONS_RESET: 'LockedSelector.AllCategoryOptionsReset',
+    TEI_SELECTION_RESET: 'LockedSelector.TeiSelectionReset',
+    ENROLLMENT_SELECTION_SET: 'LockedSelector.EnrollmentSelectionSet',
+    ENROLLMENT_SELECTION_RESET: 'LockedSelector.EnrollmentSelectionReset',
+
+    LOADING_START: 'LockedSelector.Loading',
+    FROM_URL_UPDATE: 'LockedSelector.FromUrlUpdate',
+    FROM_URL_UPDATE_COMPLETE: 'LockedSelector.FromUrlUpdateComplete',
+    FROM_URL_CURRENT_SELECTIONS_VALID: 'LockedSelector.FromUrlQueriesValid',
+    FROM_URL_CURRENT_SELECTIONS_INVALID: 'LockedSelector.FromUrlQueriesInvalid',
+    EMPTY_ORG_UNIT_SET: 'LockedSelector.EmptyOrgUnitSet',
+
+    NEW_REGISTRATION_PAGE_OPEN: 'LockedSelector.NewRegistrationPageOpen',
+    SEARCH_PAGE_OPEN: 'LockedSelector.SearchPageOpen',
+
+    FETCH_ORG_UNIT: 'LockedSelector.FetchOrgUnit',
+    FETCH_ORG_UNIT_SUCCESS: 'LockedSelector.FetchOrgUnitSuccess',
+    FETCH_ORG_UNIT_ERROR: 'LockedSelector.FetchOrgUnitError',
+
+    PROGRAM_ID_STORE: 'LockedSelector.StoreProgramId',
+};
+
+export const lockedSelectorBatchActionTypes = {
+    AGAIN_START: 'LockedSelector.BatchAgainStart',
+    PROGRAM_ID_RESET_BATCH: 'LockedSelector.BatchProgramIdReset',
+    ORG_UNIT_ID_RESET_BATCH: 'LockedSelector.BatchOrgUnitIdReset',
+};
+
+export const setOrgUnitFromLockedSelector = (orgUnitId: string, orgUnit: Object, pageToPush: string) => actionCreator(lockedSelectorActionTypes.ORG_UNIT_ID_SET)({ orgUnitId, orgUnit, pageToPush });
+export const setProgramIdFromLockedSelector = (programId: string, pageToPush: string) => actionCreator(lockedSelectorActionTypes.PROGRAM_ID_SET)({ programId, pageToPush });
+export const setCategoryOptionFromLockedSelector = (categoryId: string, categoryOption: Object) => actionCreator(lockedSelectorActionTypes.CATEGORY_OPTION_SET)({ categoryId, categoryOption });
+
+export const resetOrgUnitIdFromLockedSelector = (pageToPush: string) => actionCreator(lockedSelectorActionTypes.ORG_UNIT_ID_RESET)({ pageToPush });
+export const resetProgramIdFromLockedSelector = (pageToPush: string) => actionCreator(lockedSelectorActionTypes.PROGRAM_ID_RESET)({ pageToPush });
+export const resetCategoryOptionFromLockedSelector = (categoryId: string) => actionCreator(lockedSelectorActionTypes.CATEGORY_OPTION_RESET)({ categoryId });
+export const resetAllCategoryOptionsFromLockedSelector = () => actionCreator(lockedSelectorActionTypes.ALL_CATEGORY_OPTIONS_RESET)();
+
+export const openNewRegistrationPageFromLockedSelector = () => actionCreator(lockedSelectorActionTypes.NEW_REGISTRATION_PAGE_OPEN)();
+export const openSearchPageFromLockedSelector = () => actionCreator(lockedSelectorActionTypes.SEARCH_PAGE_OPEN)();
+
+
+// these actions are being triggered only when the user updates the url from the url bar.
+// this way we keep our stored data in sync with the page the user is.
+export const updateSelectionsFromUrl = (data: Object) => actionCreator(lockedSelectorActionTypes.FROM_URL_UPDATE)(data);
+export const validSelectionsFromUrl = () => actionCreator(lockedSelectorActionTypes.FROM_URL_CURRENT_SELECTIONS_VALID)();
+export const invalidSelectionsFromUrl = (error: string) => actionCreator(lockedSelectorActionTypes.FROM_URL_CURRENT_SELECTIONS_INVALID)({ error });
+export const setCurrentOrgUnitBasedOnUrl = (orgUnit: Object) => actionCreator(lockedSelectorActionTypes.FETCH_ORG_UNIT_SUCCESS)(orgUnit);
+export const startLoading = () => actionCreator(lockedSelectorActionTypes.LOADING_START)();
+export const completeUrlUpdate = () => actionCreator(lockedSelectorActionTypes.FROM_URL_UPDATE_COMPLETE)();
+export const errorRetrievingOrgUnitBasedOnUrl = (error: string) => actionCreator(lockedSelectorActionTypes.FETCH_ORG_UNIT_ERROR)({ error });
+export const setEmptyOrgUnitBasedOnUrl = () => actionCreator(lockedSelectorActionTypes.EMPTY_ORG_UNIT_SET)();
+
+// component Lifecycle
+export const fetchOrgUnit = (orgUnitId: string) => actionCreator(lockedSelectorActionTypes.FETCH_ORG_UNIT)({ orgUnitId });
+
+// enrollment related
+export const resetTeiSelection = () =>
+    actionCreator(lockedSelectorActionTypes.TEI_SELECTION_RESET)();
+
+export const setEnrollmentSelection = ({ enrollmentId }: Object) =>
+    actionCreator(lockedSelectorActionTypes.ENROLLMENT_SELECTION_SET)({ enrollmentId });
+
+export const resetEnrollmentSelection = () =>
+    actionCreator(lockedSelectorActionTypes.ENROLLMENT_SELECTION_RESET)();
+
+// batch related actions
+export const resetProgramIdBatchAction = (actions: Array<Object>, pageToPush: string) =>
+    batchActions([
+        ...actions,
+        resetAllCategoryOptionsFromLockedSelector(),
+        resetProgramIdFromLockedSelector(pageToPush),
+    ], lockedSelectorBatchActionTypes.PROGRAM_ID_RESET_BATCH);
+
+export const resetOrgUnitIdBatchAction = (customActionsOnOrgUnitIdReset: Array<Object>, pageToPush: string) =>
+    batchActions([
+        resetOrgUnitIdFromLockedSelector(pageToPush),
+        ...customActionsOnOrgUnitIdReset,
+    ], lockedSelectorBatchActionTypes.ORG_UNIT_ID_RESET_BATCH);
+
+export const startAgainBatchAction = () =>
+    batchActions([
+        resetProgramIdFromLockedSelector(''),
+        resetOrgUnitIdFromLockedSelector(''),
+        resetAllCategoryOptionsFromLockedSelector(),
+        resetProgramIdBase(),
+    ], lockedSelectorBatchActionTypes.AGAIN_START);

--- a/src/core_modules/capture-core/components/ScopeSelector/ScopeSelector.component.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/ScopeSelector.component.js
@@ -1,0 +1,190 @@
+// @flow
+import React, { Component, type ComponentType } from 'react';
+import { compose } from 'redux';
+import i18n from '@dhis2/d2-i18n';
+import { QuickSelector } from './QuickSelector/QuickSelector.container';
+import { ConfirmDialog } from '../Dialogs/ConfirmDialog.component';
+import type { Props, State } from './ScopeSelector.types';
+import { withLoadingIndicator } from '../../HOC';
+
+const defaultDialogProps = {
+    header: i18n.t('Unsaved changes'),
+    text: i18n.t('Leaving this page will discard the changes you made to this event.'),
+    confirmText: i18n.t('Yes, discard'),
+    cancelText: i18n.t('No, stay here'),
+};
+
+
+class ScopeSelectorClass extends Component<Props, State> {
+    constructor(props: Props) {
+        super(props);
+
+        this.state = {
+            openStartAgainWarning: false,
+            openOrgUnitWarning: false,
+            openProgramWarning: null,
+            openCatComboWarning: false,
+            categoryIdToReset: '',
+            openNewEventWarning: false,
+        };
+    }
+
+    dontShowWarning = () => !this.props.isUserInteractionInProgress;
+
+    handleOpenStartAgainWarning=() => {
+        if (this.dontShowWarning()) {
+            this.props.onStartAgain();
+            return;
+        }
+        this.setState({ openStartAgainWarning: true });
+    }
+
+    openNewRegistrationPage = () => {
+        if (this.props.isUserInteractionInProgress) {
+            this.setState({ openStartAgainWarning: true });
+            return;
+        }
+        this.props.onOpenNewEventPage();
+    }
+
+    handleOpenNewRegistrationPageWithoutProgramId = () => {
+        if (this.dontShowWarning()) {
+            this.props.onOpenNewRegistrationPageWithoutProgramId();
+            return;
+        }
+        this.setState({ openStartAgainWarning: true });
+    }
+
+    handleOpenSearchPage = () => {
+        if (this.dontShowWarning()) {
+            this.props.onOpenSearchPage();
+            return;
+        }
+        this.setState({ openStartAgainWarning: true });
+    }
+
+    handleOpenSearchPageWithoutProgramId = () => {
+        if (this.dontShowWarning()) {
+            this.props.onOpenSearchPageWithoutProgramId();
+            return;
+        }
+        this.setState({ openStartAgainWarning: true });
+    }
+
+    handleOpenOrgUnitWarning = () => {
+        if (this.dontShowWarning()) {
+            this.props.onResetOrgUnitId();
+            return;
+        }
+        this.setState({ openOrgUnitWarning: true });
+    }
+
+    handleOpenProgramWarning = (baseAction: ReduxAction<any, any>) => {
+        if (this.dontShowWarning()) {
+            this.props.onResetProgramId(baseAction);
+            return;
+        }
+        this.setState({ openProgramWarning: baseAction });
+    }
+
+    handleOpenCatComboWarning = (categoryId: string) => {
+        if (this.dontShowWarning()) {
+            this.props.onResetCategoryOption(categoryId);
+            return;
+        }
+        this.setState({ openCatComboWarning: true, categoryIdToReset: categoryId });
+    }
+
+    handleClose = () => {
+        this.setState({
+            openStartAgainWarning: false,
+            openOrgUnitWarning: false,
+            openProgramWarning: null,
+            openCatComboWarning: false,
+            openNewEventWarning: false,
+        });
+    }
+
+    handleAcceptStartAgain = () => {
+        this.props.onStartAgain();
+        this.handleClose();
+    }
+
+    handleAcceptOrgUnit = () => {
+        this.props.onResetOrgUnitId();
+        this.handleClose();
+    }
+
+    handleAcceptProgram = () => {
+        if (this.state.openProgramWarning) {
+            this.props.onResetProgramId(this.state.openProgramWarning);
+        }
+        this.handleClose();
+    }
+
+    handleAcceptCatCombo = () => {
+        this.props.onResetCategoryOption(this.state.categoryIdToReset);
+        this.handleClose();
+    }
+
+    handleAcceptNew = () => {
+        this.props.onOpenNewEventPage();
+        this.handleClose();
+    }
+
+    render() {
+        const { onSetOrgUnit, onSetProgramId, onSetCategoryOption, onResetAllCategoryOptions } = this.props;
+        return (
+            <div data-test={'locked-selector'}>
+                <QuickSelector
+                    onSetOrgUnit={onSetOrgUnit}
+                    onSetProgramId={onSetProgramId}
+                    onSetCategoryOption={onSetCategoryOption}
+                    onResetAllCategoryOptions={onResetAllCategoryOptions}
+                    onResetOrgUnitId={this.handleOpenOrgUnitWarning}
+                    onResetProgramId={this.handleOpenProgramWarning}
+                    onResetCategoryOption={this.handleOpenCatComboWarning}
+                    onStartAgain={this.handleOpenStartAgainWarning}
+                    onNewClick={this.openNewRegistrationPage}
+                    onNewClickWithoutProgramId={this.handleOpenNewRegistrationPageWithoutProgramId}
+                    onFindClick={this.handleOpenSearchPage}
+                    onFindClickWithoutProgramId={this.handleOpenSearchPageWithoutProgramId}
+                />
+                <ConfirmDialog
+                    onConfirm={this.handleAcceptStartAgain}
+                    open={this.state.openStartAgainWarning}
+                    onCancel={this.handleClose}
+                    {...defaultDialogProps}
+                />
+                <ConfirmDialog
+                    onConfirm={this.handleAcceptOrgUnit}
+                    open={this.state.openOrgUnitWarning}
+                    onCancel={this.handleClose}
+                    {...defaultDialogProps}
+                />
+                <ConfirmDialog
+                    onConfirm={this.handleAcceptProgram}
+                    open={!!this.state.openProgramWarning}
+                    onCancel={this.handleClose}
+                    {...defaultDialogProps}
+                />
+                <ConfirmDialog
+                    onConfirm={this.handleAcceptCatCombo}
+                    open={this.state.openCatComboWarning}
+                    onCancel={this.handleClose}
+                    {...defaultDialogProps}
+                />
+                <ConfirmDialog
+                    onConfirm={this.handleAcceptNew}
+                    open={this.state.openNewEventWarning}
+                    onCancel={this.handleClose}
+                    {...defaultDialogProps}
+                />
+            </div>
+        );
+    }
+}
+
+export const ScopeSelectorComponent: ComponentType<$Diff<Props, CssClasses>> = compose(
+    withLoadingIndicator(() => ({ height: '100px' })),
+)(ScopeSelectorClass);

--- a/src/core_modules/capture-core/components/ScopeSelector/ScopeSelector.container.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/ScopeSelector.container.js
@@ -1,0 +1,195 @@
+// @flow
+import React, { type ComponentType, useEffect, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useLocation } from 'react-router';
+import { ScopeSelectorComponent } from './ScopeSelector.component';
+import {
+    setOrgUnitFromLockedSelector,
+    setProgramIdFromLockedSelector,
+    setCategoryOptionFromLockedSelector,
+    resetCategoryOptionFromLockedSelector,
+    resetAllCategoryOptionsFromLockedSelector,
+    openNewRegistrationPageFromLockedSelector,
+    openSearchPageFromLockedSelector,
+    fetchOrgUnit,
+    resetProgramIdBatchAction,
+    startAgainBatchAction,
+    resetOrgUnitIdBatchAction,
+} from './ScopeSelector.actions';
+import { resetProgramIdBase } from './QuickSelector/actions/QuickSelector.actions';
+import type { OwnProps } from './ScopeSelector.types';
+import { pageFetchesOrgUnitUsingTheOldWay } from '../../utils/url';
+
+const deriveReadiness = (lockedSelectorLoads, selectedOrgUnitId, organisationUnits) => {
+    // because we want the orgUnit to be fetched and stored
+    // before allowing the user to view the locked selector
+    if (selectedOrgUnitId) {
+        const orgUnit = organisationUnits[selectedOrgUnitId];
+        return Boolean(orgUnit && orgUnit.id && !lockedSelectorLoads);
+    }
+    return !lockedSelectorLoads;
+};
+
+const useUrlQueries = (): { selectedProgramId: string, selectedOrgUnitId: string, pathname: string } =>
+    useSelector(({
+        currentSelections: {
+            programId: selectedProgramId,
+            orgUnitId: selectedOrgUnitId,
+        },
+        router: {
+            location: {
+                query: {
+                    programId: routerProgramId,
+                    orgUnitId: routerOrgUnitId,
+                },
+                pathname,
+            },
+        },
+    }) =>
+        ({
+            selectedProgramId: routerProgramId || selectedProgramId,
+            selectedOrgUnitId: routerOrgUnitId || selectedOrgUnitId,
+            pathname,
+        }),
+    );
+
+const useComponentLifecycle = () => {
+    const dispatch = useDispatch();
+    const { selectedOrgUnitId } = useUrlQueries();
+    const { pathname } = useLocation();
+    const pageFetchesOrgUnit = !pageFetchesOrgUnitUsingTheOldWay(pathname.substring(1));
+
+    useEffect(() => {
+        pageFetchesOrgUnit && selectedOrgUnitId && dispatch(fetchOrgUnit(selectedOrgUnitId));
+    },
+    [dispatch, selectedOrgUnitId, pageFetchesOrgUnit]);
+};
+
+export const ScopeSelector: ComponentType<OwnProps> =
+  ({
+      customActionsOnProgramIdReset = [],
+      customActionsOnOrgUnitIdReset = [],
+      pageToPush = '',
+      isUserInteractionInProgress = false,
+  }) => {
+      const dispatch = useDispatch();
+
+      const dispatchOnSetOrgUnit = useCallback(
+          (id: string, orgUnit: Object) => {
+              dispatch(setOrgUnitFromLockedSelector(id, orgUnit, pageToPush));
+          },
+          [pageToPush, dispatch]);
+
+      const dispatchOnSetProgramId = useCallback(
+          (id: string) => {
+              dispatch(setProgramIdFromLockedSelector(id, pageToPush));
+          },
+          [pageToPush, dispatch]);
+
+      const dispatchOnSetCategoryOption = useCallback(
+          (categoryId: string, categoryOption: Object) => {
+              dispatch(setCategoryOptionFromLockedSelector(categoryId, categoryOption));
+          },
+          [dispatch]);
+
+      const dispatchOnResetCategoryOption = useCallback(
+          (categoryId: string) => {
+              dispatch(resetCategoryOptionFromLockedSelector(categoryId));
+          },
+          [dispatch]);
+
+      const dispatchOnResetAllCategoryOptions = useCallback(
+          () => {
+              dispatch(resetAllCategoryOptionsFromLockedSelector());
+          },
+          [dispatch]);
+
+      const dispatchOnOpenNewEventPage = useCallback(
+          () => {
+              dispatch(openNewRegistrationPageFromLockedSelector());
+          },
+          [dispatch]);
+
+      const dispatchOnOpenNewRegistrationPageWithoutProgramId = useCallback(
+          () => {
+              const actions = [
+                  resetProgramIdBase(),
+                  openNewRegistrationPageFromLockedSelector(),
+              ];
+              dispatch(resetProgramIdBatchAction(actions, 'new'));
+          },
+          [dispatch]);
+
+      const dispatchOnOpenSearchPage = useCallback(
+          () => {
+              dispatch(openSearchPageFromLockedSelector());
+          },
+          [dispatch]);
+
+      const dispatchOnOpenSearchPageWithoutProgramId = useCallback(
+          () => {
+              const actions = [
+                  resetProgramIdBase(),
+                  openSearchPageFromLockedSelector(),
+                  ...customActionsOnProgramIdReset,
+              ];
+              dispatch(resetProgramIdBatchAction(actions, 'search'));
+          },
+          [customActionsOnProgramIdReset, dispatch]);
+
+      const dispatchOnStartAgain = useCallback(
+          () => {
+              dispatch(startAgainBatchAction());
+          }, [dispatch]);
+
+      const dispatchOnResetOrgUnitId = useCallback(
+          () => {
+              dispatch(resetOrgUnitIdBatchAction(customActionsOnOrgUnitIdReset, pageToPush));
+          },
+          [pageToPush, customActionsOnOrgUnitIdReset, dispatch]);
+
+      const dispatchOnResetProgramId = useCallback(
+          (baseAction: ReduxAction<any, any>) => {
+              const actions = [
+                  baseAction,
+                  ...customActionsOnProgramIdReset,
+              ];
+
+              dispatch(resetProgramIdBatchAction(actions, pageToPush));
+          },
+          [pageToPush, customActionsOnProgramIdReset, dispatch]);
+
+      const { selectedOrgUnitId, selectedProgramId } = useUrlQueries();
+
+      const lockedSelectorLoads: string =
+        useSelector(({ activePage }) => activePage.lockedSelectorLoads);
+
+
+      const organisationUnits: Object =
+        useSelector(({ organisationUnits: orgUnits }) => orgUnits);
+
+      const ready = deriveReadiness(lockedSelectorLoads, selectedOrgUnitId, organisationUnits);
+
+      useComponentLifecycle();
+
+      return (
+          <ScopeSelectorComponent
+              onStartAgain={dispatchOnStartAgain}
+              onOpenSearchPageWithoutProgramId={dispatchOnOpenSearchPageWithoutProgramId}
+              onOpenSearchPage={dispatchOnOpenSearchPage}
+              onOpenNewRegistrationPageWithoutProgramId={dispatchOnOpenNewRegistrationPageWithoutProgramId}
+              onOpenNewEventPage={dispatchOnOpenNewEventPage}
+              onResetProgramId={dispatchOnResetProgramId}
+              onResetOrgUnitId={dispatchOnResetOrgUnitId}
+              onResetAllCategoryOptions={dispatchOnResetAllCategoryOptions}
+              onResetCategoryOption={dispatchOnResetCategoryOption}
+              onSetCategoryOption={dispatchOnSetCategoryOption}
+              onSetProgramId={dispatchOnSetProgramId}
+              onSetOrgUnit={dispatchOnSetOrgUnit}
+              selectedOrgUnitId={selectedOrgUnitId}
+              selectedProgramId={selectedProgramId}
+              isUserInteractionInProgress={isUserInteractionInProgress}
+              ready={ready}
+          />
+      );
+  };

--- a/src/core_modules/capture-core/components/ScopeSelector/ScopeSelector.epics.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/ScopeSelector.epics.js
@@ -1,0 +1,181 @@
+// @flow
+import i18n from '@dhis2/d2-i18n';
+import { push } from 'connected-react-router';
+import { ofType } from 'redux-observable';
+import { catchError, filter, flatMap, map, startWith, switchMap } from 'rxjs/operators';
+import { from, of } from 'rxjs';
+import {
+    lockedSelectorActionTypes,
+    lockedSelectorBatchActionTypes,
+    invalidSelectionsFromUrl,
+    validSelectionsFromUrl,
+    setCurrentOrgUnitBasedOnUrl,
+    errorRetrievingOrgUnitBasedOnUrl,
+    setEmptyOrgUnitBasedOnUrl,
+    startLoading,
+    completeUrlUpdate,
+} from './ScopeSelector.actions';
+import { programCollection } from '../../metaDataMemoryStores';
+import { deriveUrlQueries, pageFetchesOrgUnitUsingTheOldWay, urlArguments } from '../../utils/url';
+
+const derivePayloadFromAction = (batchPayload, actionType) => {
+    // $FlowFixMe
+    const { payload } = Object.values(batchPayload).find(({ type }) => type === actionType);
+    return payload;
+};
+
+const orgUnitsQuery = id => ({ resource: 'organisationUnits', id });
+
+export const setOrgUnitIdEpic = (action$: InputObservable, store: ReduxStore) =>
+    action$.pipe(
+        ofType(lockedSelectorActionTypes.ORG_UNIT_ID_SET),
+        map(({ payload: { orgUnitId, pageToPush } }) => {
+            const { programId, ...restOfQueries } = deriveUrlQueries(store.value);
+
+            if (programId) {
+                const programContainsOrgUnitId = programCollection.get(programId)?.organisationUnits[orgUnitId];
+                if (orgUnitId && !programContainsOrgUnitId) {
+                    return push(`/${pageToPush}?${urlArguments({ ...restOfQueries, orgUnitId })}`);
+                }
+            }
+
+            return push(`/${pageToPush}?${urlArguments({ ...restOfQueries, programId, orgUnitId })}`);
+        }));
+
+export const resetOrgUnitId = (action$: InputObservable, store: ReduxStore) =>
+    action$.pipe(
+        ofType(lockedSelectorBatchActionTypes.ORG_UNIT_ID_RESET_BATCH),
+        map(({ payload: batchPayload }) => {
+            const { pageToPush } = derivePayloadFromAction(batchPayload, lockedSelectorActionTypes.ORG_UNIT_ID_RESET);
+            const { orgUnitId, ...restOfQueries } = deriveUrlQueries(store.value);
+
+            return push(`/${pageToPush}?${urlArguments({ ...restOfQueries })}`);
+        }));
+
+export const setProgramIdEpic = (action$: InputObservable, store: ReduxStore) =>
+    action$.pipe(
+        ofType(lockedSelectorActionTypes.PROGRAM_ID_SET),
+        map(({ payload: { programId, pageToPush } }) => {
+            const queries = deriveUrlQueries(store.value);
+
+            return push(`/${pageToPush}?${urlArguments({ ...queries, programId })}`);
+        }));
+
+export const resetProgramIdEpic = (action$: InputObservable, store: ReduxStore) =>
+    action$.pipe(
+        ofType(lockedSelectorBatchActionTypes.PROGRAM_ID_RESET_BATCH),
+        map(({ payload: batchPayload }) => {
+            const { pageToPush } = derivePayloadFromAction(batchPayload, lockedSelectorActionTypes.PROGRAM_ID_RESET);
+            const { programId, ...restOfQueries } = deriveUrlQueries(store.value);
+
+            return push(`/${pageToPush}?${urlArguments({ ...restOfQueries })}`);
+        }),
+    );
+
+export const startAgainEpic = (action$: InputObservable) =>
+    action$.pipe(
+        ofType(lockedSelectorBatchActionTypes.AGAIN_START),
+        map(() => push('/')));
+
+export const getOrgUnitDataBasedOnUrlUpdateEpic = (
+    action$: InputObservable,
+    store: ReduxStore,
+    { querySingleResource }: ApiUtils) =>
+    action$.pipe(
+        ofType(lockedSelectorActionTypes.FROM_URL_UPDATE),
+        filter(action => action.payload.nextProps.orgUnitId),
+        switchMap((action) => {
+            const { organisationUnits } = store.value;
+            const { orgUnitId } = action.payload.nextProps;
+            if (organisationUnits[orgUnitId]) {
+                return of(completeUrlUpdate());
+            }
+            return from(querySingleResource(orgUnitsQuery(action.payload.nextProps.orgUnitId)))
+                .pipe(
+                    flatMap(response =>
+                        of(setCurrentOrgUnitBasedOnUrl({ id: response.id, name: response.displayName }))),
+                    catchError(() =>
+                        of(errorRetrievingOrgUnitBasedOnUrl(i18n.t('Could not get organisation unit')))),
+                    startWith(startLoading()),
+                );
+        },
+        ));
+
+export const setOrgUnitDataEmptyBasedOnUrlUpdateEpic = (action$: InputObservable) =>
+    action$.pipe(
+        ofType(lockedSelectorActionTypes.FROM_URL_UPDATE),
+        filter(action => !action.payload.nextProps.orgUnitId),
+        map(() => setEmptyOrgUnitBasedOnUrl()));
+
+export const validateSelectionsBasedOnUrlUpdateEpic = (action$: InputObservable, store: ReduxStore) =>
+    action$.pipe(
+        ofType(
+            lockedSelectorActionTypes.FROM_URL_UPDATE_COMPLETE,
+            lockedSelectorActionTypes.FETCH_ORG_UNIT_SUCCESS,
+            lockedSelectorActionTypes.EMPTY_ORG_UNIT_SET,
+        ),
+        filter(() => {
+            const { location: { pathname } } = store.value.router;
+            return pageFetchesOrgUnitUsingTheOldWay(pathname.substring(1));
+        }),
+        map(() => {
+            const { programId, orgUnitId } = store.value.currentSelections;
+
+            if (programId) {
+                const program = programCollection.get(programId);
+                if (!program) {
+                    return invalidSelectionsFromUrl(i18n.t("Program doesn't exist"));
+                }
+
+                if (orgUnitId && !program.organisationUnits[orgUnitId]) {
+                    return invalidSelectionsFromUrl(i18n.t('Selected program is invalid for selected registering unit'));
+                }
+            }
+
+            return validSelectionsFromUrl();
+        }));
+
+export const fetchOrgUnitEpic = (
+    action$: InputObservable,
+    _: ReduxStore,
+    { querySingleResource }: ApiUtils,
+) =>
+    action$.pipe(
+        ofType(lockedSelectorActionTypes.FETCH_ORG_UNIT),
+        switchMap(({ payload: { orgUnitId } }) =>
+            from(querySingleResource(orgUnitsQuery(orgUnitId)))
+                .pipe(
+                    map(({ id, displayName: name }) =>
+                        setCurrentOrgUnitBasedOnUrl({ id, name })),
+                )),
+        catchError(() => of(errorRetrievingOrgUnitBasedOnUrl(i18n.t('Could not get organisation unit')))),
+    );
+
+export const resetTeiSelectionEpic = (action$: InputObservable, store: ReduxStore) =>
+    action$.pipe(
+        ofType(lockedSelectorActionTypes.TEI_SELECTION_RESET),
+        map(() => {
+            const { query: { programId, orgUnitId } } = store.value.router.location;
+
+            return push(`/?${urlArguments({ programId, orgUnitId })}`);
+        }),
+    );
+
+export const setEnrollmentSelectionEpic = (action$: InputObservable, store: ReduxStore) =>
+    action$.pipe(
+        ofType(lockedSelectorActionTypes.ENROLLMENT_SELECTION_SET),
+        map(({ payload: { enrollmentId } }) => {
+            const { query: { programId, orgUnitId, teiId } } = store.value.router.location;
+
+            return push(`/enrollment?${urlArguments({ programId, orgUnitId, teiId, enrollmentId })}`);
+        }),
+    );
+
+export const resetEnrollmentSelectionEpic = (action$: InputObservable, store: ReduxStore) =>
+    action$.pipe(
+        ofType(lockedSelectorActionTypes.ENROLLMENT_SELECTION_RESET),
+        map(() => {
+            const { query: { orgUnitId, programId, teiId } } = store.value.router.location;
+            return push(`/enrollment?${urlArguments({ programId, orgUnitId, teiId })}`);
+        }),
+    );

--- a/src/core_modules/capture-core/components/ScopeSelector/ScopeSelector.types.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/ScopeSelector.types.js
@@ -1,0 +1,46 @@
+// @flow
+export type OwnProps = $ReadOnly<{|
+  isUserInteractionInProgress?: boolean,
+  customActionsOnOrgUnitIdReset?: Array<any>,
+  customActionsOnProgramIdReset?: Array<any>,
+  pageToPush?: string,
+|}>
+
+export type PropsFromRedux = $ReadOnly<{|
+  selectedOrgUnitId: string,
+  selectedProgramId: string,
+  ready: boolean,
+|}>
+
+export type DispatchersFromRedux = $ReadOnly<{|
+  onOpenNewEventPage: () => void,
+  onOpenNewRegistrationPageWithoutProgramId: Function,
+  onOpenSearchPage: () => void,
+  onOpenSearchPageWithoutProgramId: () => void,
+  onSetOrgUnit: (id: string, orgUnit: Object) => void,
+  onResetOrgUnitId: () => void,
+  onSetProgramId: (id: string) => void,
+  onSetCategoryOption: (categoryId: string, categoryOptionId: string) => void,
+  onResetCategoryOption: (categoryId: string) => void,
+  onResetAllCategoryOptions: () => void,
+  onStartAgain: () => void,
+  onResetProgramId: (baseAction: ReduxAction<any, any>) => void,
+|}>
+
+
+export type Props = {|
+  ...OwnProps,
+  ...CssClasses,
+  ...DispatchersFromRedux,
+  ...PropsFromRedux,
+|}
+
+
+export type State = {|
+  openStartAgainWarning: boolean;
+  openOrgUnitWarning: boolean;
+  openProgramWarning: ?Object;
+  openCatComboWarning: boolean;
+  categoryIdToReset: string;
+  openNewEventWarning: boolean;
+|};

--- a/src/core_modules/capture-core/components/ScopeSelector/index.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/index.js
@@ -1,0 +1,21 @@
+// @flow
+export {
+    lockedSelectorBatchActionTypes,
+    lockedSelectorActionTypes,
+    updateSelectionsFromUrl,
+} from './ScopeSelector.actions';
+export {
+    validateSelectionsBasedOnUrlUpdateEpic,
+    setOrgUnitDataEmptyBasedOnUrlUpdateEpic,
+    getOrgUnitDataBasedOnUrlUpdateEpic,
+    setOrgUnitIdEpic,
+    setProgramIdEpic,
+    startAgainEpic,
+    setEnrollmentSelectionEpic,
+    resetProgramIdEpic,
+    resetOrgUnitId,
+    fetchOrgUnitEpic,
+    resetTeiSelectionEpic,
+    resetEnrollmentSelectionEpic,
+} from './ScopeSelector.epics';
+export { ScopeSelector } from './ScopeSelector.container';


### PR DESCRIPTION
I created a new component `ScopeSelector` and copied the files from `LockerSelector`. I used the ScopeSelector instead of the LockerSelector on the enrollment page. Nothing else changed. 

 I prefer to split the refactor into 2 parts to be able to differentiate between the logic that was copy-pasted from the  `LockerSelector` and the new refactored hooks. The real changes are implemented in https://github.com/dhis2/capture-app/pull/1878 