### PR TITLE
fix: Fix sorting error on comment column

### DIFF
--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/StageDetail.component.js
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/StageDetail.component.js
@@ -104,7 +104,7 @@ const StageDetailPlain = (props: Props) => {
                     key={column.id}
                     name={column.id}
                     sortDirection={getSortDirection(column)}
-                    onSortIconClick={onSortIconClick}
+                    onSortIconClick={column.sortDirection && onSortIconClick}
                 >
                     {column.header}
                 </DataTableColumnHeader>


### PR DESCRIPTION
### Problem 
When trying to pass `sortDirection: null` on comment column , there is an error
`this prop is conditionally required but has value `undefined``

### Solution
After consulting #frontend channel we should only remove the `onSortClick` when there is no `sortDirection`
