### PR TITLE
fix: [DHIS-11745][TECH-634] Update the enrollments collection when saving new event

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -1096,6 +1096,9 @@ msgstr ""
 msgid "Error saving enrollment"
 msgstr ""
 
+msgid "Error saving the enrollment event"
+msgstr ""
+
 msgid "tracked entity instance"
 msgstr ""
 

--- a/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/enrollment.actions.js
+++ b/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/enrollment.actions.js
@@ -5,8 +5,12 @@ import type { EnrollmentData } from '../../Enrollment/EnrollmentPageDefault/type
 export const enrollmentActionTypes = {
     SET_ENROLLMENT: 'Enrollment.SetEnrollment',
     UPDATE_ENROLLMENT_EVENTS: 'Enrollment.UpdateEnrollmentEvents',
+    UPDATE_ENROLLMENT_EVENTS_WITHOUT_ID: 'Enrollment.UpdateEnrollmentEventsWithoutId',
     ROLLBACK_ENROLLMENT_EVENT: 'Enrollment.RollbackEnrollmentEvent',
+    ROLLBACK_ENROLLMENT_EVENT_WITHOUT_ID: 'Enrollment.RollbackEnrollmentEventWithoutId',
     COMMIT_ENROLLMENT_EVENT: 'Enrollment.CommitEnrollmentEvent',
+    COMMIT_ENROLLMENT_EVENT_WITHOUT_ID: 'Enrollment.CommitEnrollmentEventWithoutId',
+    SAVE_FAILED: 'Enrollment.SaveFailed',
 };
 
 export const setEnrollment = (enrollmentSite: EnrollmentData) =>
@@ -27,3 +31,21 @@ export const commitEnrollmentEvent = (eventId: string) =>
     actionCreator(enrollmentActionTypes.COMMIT_ENROLLMENT_EVENT)({
         eventId,
     });
+
+export const updateEnrollmentEventsWithoutId = (uid: string, eventData: Object) =>
+    actionCreator(enrollmentActionTypes.UPDATE_ENROLLMENT_EVENTS_WITHOUT_ID)({
+        eventData,
+        uid,
+    });
+
+export const rollbackEnrollmentEventWithoutId = (uid: string) =>
+    actionCreator(enrollmentActionTypes.ROLLBACK_ENROLLMENT_EVENT_WITHOUT_ID)({
+        uid,
+    });
+
+export const commitEnrollmentEventWithoutId = (uid: string, eventId: string) =>
+    actionCreator(enrollmentActionTypes.COMMIT_ENROLLMENT_EVENT_WITHOUT_ID)({
+        eventId,
+        uid,
+    });
+export const saveFailed = () => actionCreator(enrollmentActionTypes.SAVE_FAILED)();

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/index.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/index.js
@@ -1,3 +1,7 @@
 // @flow
 export { Validated } from './Validated.container';
-export { saveNewEnrollmentEventEpic } from './validated.epics';
+export {
+    saveNewEnrollmentEventEpic,
+    saveNewEventSucceededEpic,
+    saveNewEventFailedEpic,
+} from './validated.epics';

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/validated.actions.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/validated.actions.js
@@ -51,7 +51,7 @@ export const requestSaveEvent = ({
         onSaveErrorActionType,
     }, { skipLogging: ['formFoundation'] });
 
-export const saveEvent = (serverData: Object, onSaveSuccessActionType?: string, onSaveErrorActionType?: string) =>
+export const saveEvent = (serverData: Object, onSaveSuccessActionType?: string, onSaveErrorActionType?: string, uid: string) =>
     actionCreator(newEventWidgetActionTypes.EVENT_SAVE)({}, {
         offline: {
             effect: {
@@ -59,7 +59,7 @@ export const saveEvent = (serverData: Object, onSaveSuccessActionType?: string, 
                 method: effectMethods.POST,
                 data: serverData,
             },
-            commit: onSaveSuccessActionType && { type: onSaveSuccessActionType, meta: { serverData } },
-            rollback: onSaveErrorActionType && { type: onSaveErrorActionType, meta: { serverData } },
+            commit: onSaveSuccessActionType && { type: onSaveSuccessActionType, meta: { serverData, uid } },
+            rollback: onSaveErrorActionType && { type: onSaveErrorActionType, meta: { serverData, uid } },
         },
     });

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/validated.epics.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/validated.epics.js
@@ -1,19 +1,45 @@
 // @flow
 import { ofType } from 'redux-observable';
+import uuid from 'uuid/v4';
+import { batchActions } from 'redux-batched-actions';
 import { map } from 'rxjs/operators';
-import {
-    newEventWidgetActionTypes,
-    saveEvent,
-} from './validated.actions';
+import { newEventWidgetActionTypes, saveEvent } from './validated.actions';
 
 import { getDataEntryKey } from '../../DataEntry/common/getDataEntryKey';
 import { getAddEventEnrollmentServerData, getNewEventClientValues } from './getConvertedAddEvent';
+import { addEnrollmentEventPageActionTypes } from '../../Pages/EnrollmentAddEvent/enrollmentAddEventPage.actions';
+import {
+    updateEnrollmentEventsWithoutId,
+    commitEnrollmentEventWithoutId,
+    rollbackEnrollmentEventWithoutId,
+    saveFailed,
+} from '../../Pages/common/EnrollmentOverviewDomain/enrollment.actions';
+
+export const saveNewEventSucceededEpic = (action$: InputObservable) =>
+    action$.pipe(
+        ofType(addEnrollmentEventPageActionTypes.EVENT_SAVE_SUCCESS),
+        map((action) => {
+            const meta = action.meta;
+            const eventId = action.payload.response.importSummaries[0].reference;
+            return commitEnrollmentEventWithoutId(meta.uid, eventId);
+        }),
+    );
+
+export const saveNewEventFailedEpic = (action$: InputObservable) =>
+    action$.pipe(
+        ofType(addEnrollmentEventPageActionTypes.EVENT_SAVE_ERROR),
+        map((action) => {
+            const meta = action.meta;
+            return batchActions([saveFailed(), rollbackEnrollmentEventWithoutId(meta.uid)]);
+        }),
+    );
 
 export const saveNewEnrollmentEventEpic = (action$: InputObservable, store: ReduxStore) =>
     action$.pipe(
         ofType(newEventWidgetActionTypes.EVENT_SAVE_REQUEST),
         map((action) => {
             const state = store.value;
+            const uid = uuid();
             const {
                 formFoundation,
                 dataEntryId,
@@ -44,5 +70,9 @@ export const saveNewEnrollmentEventEpic = (action$: InputObservable, store: Redu
             });
 
             onSaveExternal && onSaveExternal(serverData);
-            return saveEvent(serverData, onSaveSuccessActionType, onSaveErrorActionType);
-        }));
+            return batchActions([
+                updateEnrollmentEventsWithoutId(uid, serverData.events[0]),
+                saveEvent(serverData, onSaveSuccessActionType, onSaveErrorActionType, uid),
+            ]);
+        }),
+    );

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/index.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/index.js
@@ -5,5 +5,5 @@ export {
     runRulesOnUpdateDataEntryFieldForNewEnrollmentEventEpic,
     runRulesOnUpdateFieldForNewEnrollmentEventEpic,
 } from './DataEntry';
-export { saveNewEnrollmentEventEpic } from './Validated';
+export { saveNewEnrollmentEventEpic, saveNewEventSucceededEpic, saveNewEventFailedEpic } from './Validated';
 export type { ExternalSaveHandler } from './common.types';

--- a/src/core_modules/capture-core/reducers/descriptions/enrollment.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/enrollment.reducerDescription.js
@@ -6,8 +6,11 @@ const initialReducerValue = {};
 const {
     SET_ENROLLMENT,
     UPDATE_ENROLLMENT_EVENTS,
+    UPDATE_ENROLLMENT_EVENTS_WITHOUT_ID,
     ROLLBACK_ENROLLMENT_EVENT,
+    ROLLBACK_ENROLLMENT_EVENT_WITHOUT_ID,
     COMMIT_ENROLLMENT_EVENT,
+    COMMIT_ENROLLMENT_EVENT_WITHOUT_ID,
 } = enrollmentActionTypes;
 
 export const enrollmentDesc = createReducerDescription(
@@ -52,6 +55,27 @@ export const enrollmentDesc = createReducerDescription(
                 return event;
             });
 
+            return { ...state, events };
+        },
+        [UPDATE_ENROLLMENT_EVENTS_WITHOUT_ID]: (
+            state,
+            { payload: { eventData, uid } },
+        ) => {
+            const events = [...state.events, { ...eventData, uid, pendingApiResponse: true }];
+            return { ...state, events };
+        },
+        [ROLLBACK_ENROLLMENT_EVENT_WITHOUT_ID]: (state, { payload: { uid } }) => {
+            const events = state.events?.filter(event => (event.uid !== uid));
+            return { ...state, events };
+        },
+        [COMMIT_ENROLLMENT_EVENT_WITHOUT_ID]: (state, { payload: { eventId, uid } }) => {
+            const events = state.events?.map((event) => {
+                if (event.uid === uid) {
+                    const { pendingApiResponse, uid: uidToRemove, ...dataToCommit } = event;
+                    return { ...dataToCommit, event: eventId };
+                }
+                return event;
+            });
             return { ...state, events };
         },
     },

--- a/src/core_modules/capture-core/reducers/descriptions/feedback.reducerDescriptionGetter.js
+++ b/src/core_modules/capture-core/reducers/descriptions/feedback.reducerDescriptionGetter.js
@@ -25,6 +25,7 @@ import { eventWorkingListsActionTypes } from '../../components/WorkingLists/Even
 import { workingListsCommonActionTypes } from '../../components/WorkingLists/WorkingListsCommon';
 import type { Updaters } from '../../trackerRedux/trackerReducer';
 import { registrationFormActionTypes } from '../../components/Pages/New/RegistrationDataEntry/RegistrationDataEntry.actions';
+import { enrollmentActionTypes as enrollmentEventActionTypes } from '../../components/Pages/common/EnrollmentOverviewDomain/enrollment.actions';
 
 function addErrorFeedback(state: ReduxState, message: string, action?: ?Node) {
     const newState = [...state];
@@ -126,5 +127,7 @@ export const getFeedbackDesc = (appUpdaters: Updaters) => createReducerDescripti
         addErrorFeedback(state, i18n.t('Error saving tracked entity instance')),
     [registrationFormActionTypes.NEW_TRACKED_ENTITY_INSTANCE_WITH_ENROLLMENT_SAVE_FAILED]: state =>
         addErrorFeedback(state, i18n.t('Error saving enrollment')),
+    [enrollmentEventActionTypes.SAVE_FAILED]: state =>
+        addErrorFeedback(state, i18n.t('Error saving the enrollment event')),
 }, 'feedbacks', []);
 

--- a/src/epics/trackerCapture.epics.js
+++ b/src/epics/trackerCapture.epics.js
@@ -206,6 +206,8 @@ import {
     runRulesOnUpdateDataEntryFieldForNewEnrollmentEventEpic,
     runRulesOnUpdateFieldForNewEnrollmentEventEpic,
     saveNewEnrollmentEventEpic,
+    saveNewEventSucceededEpic,
+    saveNewEventFailedEpic,
     addNoteForNewEnrollmentEventEpic,
 } from '../core_modules/capture-core/components/WidgetEnrollmentEventNew';
 
@@ -336,5 +338,7 @@ export const epics = combineEpics(
     runRulesOnUpdateDataEntryFieldForNewEnrollmentEventEpic,
     runRulesOnUpdateFieldForNewEnrollmentEventEpic,
     saveNewEnrollmentEventEpic,
+    saveNewEventSucceededEpic,
+    saveNewEventFailedEpic,
     addNoteForNewEnrollmentEventEpic,
 );


### PR DESCRIPTION
Backport to v37 with cherry-pick from https://github.com/dhis2/capture-app/pull/2083 for the bug https://jira.dhis2.org/browse/DHIS2-11745.