### PR TITLE
[TECH-681] Refactor api-calls to the /events-endpoint from the EventWorkingList

### DIFF
--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/eventList.epics.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/eventList.epics.js
@@ -31,6 +31,7 @@ export const initEventListEpic = (action$: InputObservable) =>
                             orgUnitId,
                             categories,
                             programStageId,
+                            ouMode: orgUnitId ? undefined : 'ACCESSIBLE',
                         },
                         columnsMetaForDataFetching,
                         categoryCombinationId,
@@ -54,6 +55,7 @@ export const updateEventListEpic = (action$: InputObservable) =>
         filter(({ payload: { workingListsType } }) => workingListsType === SINGLE_EVENT_WORKING_LISTS_TYPE),
         concatMap((action) => {
             const { queryArgs, columnsMetaForDataFetching, categoryCombinationId, storeId } = action.payload;
+            !queryArgs?.orgUnitId && (queryArgs.ouMode = 'ACCESSIBLE');
             const updatePromise = updateEventWorkingListAsync(queryArgs, { columnsMetaForDataFetching, categoryCombinationId, storeId });
             return from(updatePromise).pipe(
                 takeUntil(

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/getEventListData.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/getEventListData.js
@@ -177,6 +177,12 @@ export const getEventListData = async (
     categoryCombinationId?: ?string,
 ) => {
     const mainColumns = getMainColumns(columnsMetaForDataFetching);
+
+    // Remove programStageId from the API if program is single event
+    if (queryArgs?.programStageId === 'EventProgramStage') {
+        queryArgs.programStageId = undefined;
+    }
+
     const { eventContainers, pagingData, request } =
         await getEvents(createApiQueryArgs(queryArgs, mainColumns, categoryCombinationId));
 

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/getEventListData.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/getEventListData.js
@@ -177,7 +177,6 @@ export const getEventListData = async (
     categoryCombinationId?: ?string,
 ) => {
     const mainColumns = getMainColumns(columnsMetaForDataFetching);
-
     // Remove programStageId from the API if program is single event
     if (queryArgs?.programStageId === 'EventProgramStage') {
         queryArgs.programStageId = undefined;

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/getEventListData.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/getEventListData.js
@@ -179,7 +179,7 @@ export const getEventListData = async (
     const mainColumns = getMainColumns(columnsMetaForDataFetching);
     // Remove programStageId from the API if program is single event
     if (queryArgs?.programStageId === 'EventProgramStage') {
-        queryArgs.programStageId = undefined;
+        delete queryArgs.programStageId;
     }
 
     const { eventContainers, pagingData, request } =

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/types/apiTemplate.types.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/types/apiTemplate.types.js
@@ -68,5 +68,6 @@ export type CommonQueryData = {|
     programId: string,
     orgUnitId: string,
     categories: ?Object,
-    programStageId?: ?string
+    programStageId?: ?string,
+    ouMode?: ?string,
 |};


### PR DESCRIPTION
https://jira.dhis2.org/browse/TECH-681

On initial load, the eventWorkingList adds a `programStageId=eventProgramStage`-filter. This does nothing and should probably be removed.
The /events-endpoint has now been refactored and will require an ouMode if orgUnit is not selected. Add this to the API-call from the EventWorkingList.