### PR TITLE
fix: [DHIS2-11745] add orgUnitName to the new enrollment event in Redux

### DIFF
--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/validated.epics.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/validated.epics.js
@@ -68,10 +68,13 @@ export const saveNewEnrollmentEventEpic = (action$: InputObservable, store: Redu
                 enrollmentId,
                 completed,
             });
+            const orgUnit = serverData.events[0]?.orgUnit || '';
+            const orgUnitName = state.organisationUnits[orgUnit]?.name || '';
+            const eventData = { ...serverData.events[0], orgUnitName };
 
             onSaveExternal && onSaveExternal(serverData);
             return batchActions([
-                updateEnrollmentEventsWithoutId(uid, serverData.events[0]),
+                updateEnrollmentEventsWithoutId(uid, eventData),
                 saveEvent(serverData, onSaveSuccessActionType, onSaveErrorActionType, uid),
             ]);
         }),


### PR DESCRIPTION
add `orgUnitName` to the new enrollment event in Redux to be able to display it in the Stage events table