### PR TITLE
fix: [DHIS2-11791] widget comments don't show in edit mode (#2115)

### DIFF
--- a/cypress/integration/WidgetsForEnrollmentPages/WidgetEventComment/index.js
+++ b/cypress/integration/WidgetsForEnrollmentPages/WidgetEventComment/index.js
@@ -2,6 +2,12 @@ Then('the enrollment widget should be loaded', () => {
     cy.contains('The enrollment event data could not be found').should('not.exist');
 });
 
+When('you click edit mode', () => {
+    cy.get('[data-test="dhis2-uicore-button"]')
+        .contains('Edit event')
+        .click();
+    cy.contains('Enrollment: Edit Event').should('exist');
+});
 
 When(/^you fill in the comment: (.*)$/, (comment) => {
     cy.get('[data-test="event-comment-widget"]').within(() => {

--- a/cypress/integration/WidgetsForEnrollmentPages/WidgetsForEnrollmentEditEvent.feature
+++ b/cypress/integration/WidgetsForEnrollmentPages/WidgetsForEnrollmentEditEvent.feature
@@ -88,8 +88,14 @@ Feature: The user interacts with the widgets on the enrollment edit event
     And the user clicks on the delete action
     Then the user sees the delete enrollment modal
 
-  Scenario: User can add note on edit event page
+  Scenario: User can add note on edit event page view mode
     Given you land on the enrollment edit event page by having typed #/enrollmentEventEdit?programId=IpHINAT79UW&orgUnitId=UgYg0YW7ZIh&teiId=fhFQhO0xILJ&enrollmentId=gPDueU02tn8&eventId=lQQyjR73hHk&stageId=A03MvHHogjR
     Then the enrollment widget should be loaded
     When you fill in the comment: new test comment
+    Then list should contain the new comment: new test comment
+
+  Scenario: User can see note on edit event page edit mode
+    Given you land on the enrollment edit event page by having typed #/enrollmentEventEdit?programId=IpHINAT79UW&orgUnitId=UgYg0YW7ZIh&teiId=fhFQhO0xILJ&enrollmentId=gPDueU02tn8&eventId=lQQyjR73hHk&stageId=A03MvHHogjR
+    Then the enrollment widget should be loaded
+    When you click edit mode
     Then list should contain the new comment: new test comment

--- a/src/core_modules/capture-core/components/WidgetEventEdit/DataEntry/editEventDataEntry.actions.js
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/DataEntry/editEventDataEntry.actions.js
@@ -11,7 +11,9 @@ import {
     convertStatusIn,
     convertStatusOut,
 } from '../../DataEntries';
-import { getDataEntryMeta, validateDataEntryValues } from '../../DataEntry/actions/dataEntryLoad.utils';
+import {
+    getDataEntryMeta, validateDataEntryValues, getDataEntryNotes,
+} from '../../DataEntry/actions/dataEntryLoad.utils';
 import { loadEditDataEntry } from '../../DataEntry/actions/dataEntry.actions';
 import { addFormData } from '../../D2Form/actions/form.actions';
 import { EventProgram, TrackerProgram } from '../../../metaData/Program';
@@ -49,9 +51,10 @@ function getLoadActions(
     dataEntryValues: Object,
     formValues: Object,
     dataEntryPropsToInclude: Array<Object>,
-    formFoundation: RenderFoundation,
+    clientValuesForDataEntry: Object,
     extraProps: { [key: string]: any },
 ) {
+    const dataEntryNotes = getDataEntryNotes(clientValuesForDataEntry);
     const key = getDataEntryKey(dataEntryId, itemId);
     const dataEntryMeta = getDataEntryMeta(dataEntryPropsToInclude);
     const dataEntryUI = validateDataEntryValues(dataEntryValues, dataEntryPropsToInclude);
@@ -65,6 +68,7 @@ function getLoadActions(
             dataEntryValues,
             extraProps,
             dataEntryUI,
+            dataEntryNotes,
         }),
         addFormData(key, formValues),
     ];
@@ -111,7 +115,7 @@ export const openEventForEditInDataEntry = (
             dataEntryValues,
             formValues,
             dataEntryPropsToInclude,
-            foundation,
+            eventContainer.event,
             {
                 eventId: eventContainer.event.eventId,
             },


### PR DESCRIPTION
* fix: [DHIS2-11791] add eventnote to load event data entry

* chore: [DHIS2-11791] add cypress test to view comments in edit mode

* chore: [DHIS2-11791] change cypress wait