### PR TITLE
fix: [DHIS2-11797] clean the dataElements sent to the server

### DIFF
--- a/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/runRulesForEnrollment.js
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/runRulesForEnrollment.js
@@ -30,7 +30,7 @@ const getEventValuesFromEvent = (enrollment, eventId, dataElements) => {
     if (currentEvent) {
         return currentEvent.dataValues.reduce((acc, dataValue) => {
             const { dataElement: id, value } = dataValue;
-            acc[id] = convertValue(value, dataElements[id].valueType);
+            acc[id] = convertValue(value, dataElements[id]?.valueType);
             return acc;
         }, {});
     }

--- a/src/core_modules/capture-core/rules/actionsCreator/postProcessRulesEffects.js
+++ b/src/core_modules/capture-core/rules/actionsCreator/postProcessRulesEffects.js
@@ -89,18 +89,23 @@ function postProcessAssignEffects(
     }, {});
 }
 
-function buildEffectsHierarchy(effects: Array<OutputEffect>) {
+function buildEffectsHierarchy(effects: Array<OutputEffect>, foundation: RenderFoundation) {
+    const formDataElements = foundation.getElements();
+
     return effects.reduce((accEffectsObject, effect) => {
         const actionType = effect.type;
         accEffectsObject[actionType] = accEffectsObject[actionType] || {};
 
         const id = effect.id;
+        const isDataElementInForm = formDataElements.find(dataElement => dataElement.id === id);
 
-        // $FlowFixMe[incompatible-use] automated comment
-        accEffectsObject[actionType][id] = accEffectsObject[actionType][id] || [];
+        if (isDataElementInForm) {
+            // $FlowFixMe[incompatible-use] automated comment
+            accEffectsObject[actionType][id] = accEffectsObject[actionType][id] || [];
 
-        // $FlowFixMe[incompatible-use] automated comment
-        accEffectsObject[actionType][id].push(effect);
+            // $FlowFixMe[incompatible-use] automated comment
+            accEffectsObject[actionType][id].push(effect);
+        }
         return accEffectsObject;
     }, {});
 }
@@ -174,7 +179,7 @@ export function postProcessRulesEffects(
         return null;
     }
 
-    const effectsHierarchy = buildEffectsHierarchy(rulesEffects);
+    const effectsHierarchy = buildEffectsHierarchy(rulesEffects, foundation);
 
     effectsHierarchy[effectActions.HIDE_FIELD] =
         filterFieldsHideEffects(


### PR DESCRIPTION
Remove the dataElements that don't belong to the program stage when creating a new event. The tests will be added in 
[TECH-686 ](https://jira.dhis2.org/browse/TECH-686) as we previously agreed upon in https://github.com/dhis2/capture-app/pull/2119


Cypress tests failures are related to a BE change see more in [Cypress known issues](https://github.com/dhis2/capture-app/wiki/Pull-Request-Guidelines#cypress-known-issues) 