### PR TITLE
fix: [DHIS2-11986] use react-router location in new enrollment event page

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-leaflet-search-unpolyfilled": "^0.1.0",
     "react-popper": "^2.2.4",
     "react-redux": "^7.2.5",
-    "react-router": "^5.2.1",
+    "react-router-dom": "^5.3.0",
     "react-rte": "^0.16.3",
     "react-select": "^1.2.1",
     "react-transform-tree": "^1.0.35",

--- a/src/components/App/AppPages.component.js
+++ b/src/components/App/AppPages.component.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import { Route, Switch } from 'react-router';
+import { Route, Switch } from 'react-router-dom';
 import { ViewEventPage } from 'capture-core/components/Pages/ViewEvent';
 import { MainPage } from 'capture-core/components/Pages/MainPage';
 import { SearchPage } from 'capture-core/components/Pages/Search';

--- a/src/components/App/AppPagesLoader.component.js
+++ b/src/components/App/AppPagesLoader.component.js
@@ -1,6 +1,6 @@
 // @flow
 import { compose } from 'redux';
-import { withRouter } from 'react-router';
+import { withRouter } from 'react-router-dom';
 import { withAppUrlSync } from 'capture-core/components/App';
 import { withUrlSync } from 'capture-core/components/UrlSync';
 import { withD2InContext, withStateBoundLoadingIndicator } from 'capture-core/HOC';

--- a/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/EnrollmentRegistrationEntry.component.js
+++ b/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/EnrollmentRegistrationEntry.component.js
@@ -4,7 +4,7 @@ import { Button } from '@dhis2/ui';
 import i18n from '@dhis2/d2-i18n';
 import { withStyles } from '@material-ui/core';
 import { compose } from 'redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useScopeInfo } from '../../../hooks/useScopeInfo';
 import { scopeTypes } from '../../../metaData';
 import { EnrollmentDataEntry } from '../Enrollment';

--- a/src/core_modules/capture-core/components/DataEntries/TeiRegistrationEntry/TeiRegistrationEntry.component.js
+++ b/src/core_modules/capture-core/components/DataEntries/TeiRegistrationEntry/TeiRegistrationEntry.component.js
@@ -4,7 +4,7 @@ import { compose } from 'redux';
 import { Button } from '@dhis2/ui';
 import i18n from '@dhis2/d2-i18n';
 import { withStyles } from '@material-ui/core';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useScopeInfo } from '../../../hooks/useScopeInfo';
 import { scopeTypes } from '../../../metaData';
 import { TrackedEntityInstanceDataEntry } from '../TrackedEntityInstance';

--- a/src/core_modules/capture-core/components/DataEntry/withBrowserBackWarning.js
+++ b/src/core_modules/capture-core/components/DataEntry/withBrowserBackWarning.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import i18n from '@dhis2/d2-i18n';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import { withRouter } from 'react-router-dom';
 
 import { ConfirmDialog } from '../Dialogs/ConfirmDialog.component';
 import { getDataEntryKey } from './common/getDataEntryKey';

--- a/src/core_modules/capture-core/components/LockedSelector/LockedSelector.container.js
+++ b/src/core_modules/capture-core/components/LockedSelector/LockedSelector.container.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { type ComponentType, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom';
 import { LockedSelectorComponent } from './LockedSelector.component';
 import {
     setOrgUnitFromLockedSelector,

--- a/src/core_modules/capture-core/components/LockedSelector/QuickSelector/Program/ProgramSelector.component.js
+++ b/src/core_modules/capture-core/components/LockedSelector/QuickSelector/Program/ProgramSelector.component.js
@@ -2,7 +2,7 @@
 
 import React, { Component, useEffect } from 'react';
 import { withStyles } from '@material-ui/core/styles';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import Paper from '@material-ui/core/Paper';
 import IconButton from '@material-ui/core/IconButton';

--- a/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/EnrollmentPageDefault.container.js
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/EnrollmentPageDefault.container.js
@@ -4,7 +4,7 @@ import log from 'loglevel';
 import { errorCreator } from 'capture-core-utils';
 // $FlowFixMe
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useCommonEnrollmentDomainData } from '../../common/EnrollmentOverviewDomain';
 import { useProgramInfo } from '../../../../hooks/useProgramInfo';
 import { EnrollmentPageDefaultComponent } from './EnrollmentPageDefault.component';

--- a/src/core_modules/capture-core/components/Pages/Enrollment/MissingMessage.component.js
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/MissingMessage.component.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { useEffect, useState } from 'react';
 import i18n from '@dhis2/d2-i18n';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import { useScopeInfo } from '../../../hooks/useScopeInfo';

--- a/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/EnrollmentAddEventPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/EnrollmentAddEventPage.container.js
@@ -2,8 +2,9 @@
 import React, { useCallback, useMemo } from 'react';
 import { batchActions } from 'redux-batched-actions';
 // $FlowFixMe
-import { useDispatch, useSelector, shallowEqual } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
+import { useLocationQuery } from '../../../utils/routing';
 import { addEnrollmentEventPageActionTypes, navigateToEnrollmentPage } from './enrollmentAddEventPage.actions';
 import { useProgramInfo } from '../../../hooks/useProgramInfo';
 import { useEnrollmentAddEventTopBar, EnrollmentAddEventTopBar } from './TopBar';
@@ -15,20 +16,7 @@ import { useCommonEnrollmentDomainData, updateEnrollmentEventsWithoutId } from '
 import { dataEntryHasChanges as getDataEntryHasChanges } from '../../DataEntry/common/dataEntryHasChanges';
 
 export const EnrollmentAddEventPage = () => {
-    const { programId, stageId, orgUnitId, teiId, enrollmentId } = useSelector(
-        ({
-            router: {
-                location: { query },
-            },
-        }) => ({
-            programId: query.programId,
-            stageId: query.stageId,
-            orgUnitId: query.orgUnitId,
-            teiId: query.teiId,
-            enrollmentId: query.enrollmentId,
-        }),
-        shallowEqual,
-    );
+    const { programId, stageId, orgUnitId, teiId, enrollmentId } = useLocationQuery();
 
     const dispatch = useDispatch();
 

--- a/src/core_modules/capture-core/components/Pages/EnrollmentEditEvent/EnrollmentEditEventPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/EnrollmentEditEvent/EnrollmentEditEventPage.container.js
@@ -2,7 +2,7 @@
 import React from 'react';
 // $FlowFixMe
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useCommonEnrollmentDomainData } from '../common/EnrollmentOverviewDomain';
 import { useTeiDisplayName } from '../common/EnrollmentOverviewDomain/useTeiDisplayName';
 import { useProgramInfo } from '../../../hooks/useProgramInfo';

--- a/src/core_modules/capture-core/components/Pages/MainPage/MainPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/MainPage.container.js
@@ -2,7 +2,7 @@
 import React, { useEffect, useMemo } from 'react';
 // $FlowFixMe
 import { connect, useSelector, shallowEqual, useDispatch } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { programCollection } from 'capture-core/metaDataMemoryStores/programCollection/programCollection';
 import { MainPageComponent } from './MainPage.component';
 import { withErrorMessageHandler, withLoadingIndicator } from '../../../HOC';

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
@@ -1,6 +1,6 @@
 // @flow
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import React, { useCallback } from 'react';
 import type { ComponentType } from 'react';
 import { NewPageComponent } from './NewPage.component';

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
@@ -15,7 +15,7 @@ import { CircularLoader,
 } from '@dhis2/ui';
 import withStyles from '@material-ui/core/styles/withStyles';
 import Paper from '@material-ui/core/Paper/Paper';
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom';
 
 import { LockedSelector } from '../../LockedSelector';
 import type { ContainerProps, Props } from './SearchPage.types';

--- a/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/Program/ProgramSelector.component.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/QuickSelector/Program/ProgramSelector.component.js
@@ -2,7 +2,7 @@
 
 import React, { Component, useEffect } from 'react';
 import { withStyles } from '@material-ui/core/styles';
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import Paper from '@material-ui/core/Paper';
 import IconButton from '@material-ui/core/IconButton';

--- a/src/core_modules/capture-core/components/ScopeSelector/hooks/useReset.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/hooks/useReset.js
@@ -1,5 +1,5 @@
 // @flow
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 
 export const useReset = () => {
     const history = useHistory();

--- a/src/core_modules/capture-core/components/ScopeSelector/hooks/useResetEnrollmentId.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/hooks/useResetEnrollmentId.js
@@ -1,5 +1,5 @@
 // @flow
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { urlArguments, getUrlQueries } from '../../../utils/url';
 

--- a/src/core_modules/capture-core/components/ScopeSelector/hooks/useResetEventId.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/hooks/useResetEventId.js
@@ -1,5 +1,5 @@
 // @flow
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { urlArguments, getUrlQueries } from '../../../utils/url';
 

--- a/src/core_modules/capture-core/components/ScopeSelector/hooks/useResetOrgUnitId.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/hooks/useResetOrgUnitId.js
@@ -1,5 +1,5 @@
 // @flow
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { urlArguments, getUrlQueries } from '../../../utils/url';
 

--- a/src/core_modules/capture-core/components/ScopeSelector/hooks/useResetProgramId.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/hooks/useResetProgramId.js
@@ -1,5 +1,5 @@
 // @flow
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { urlArguments, getUrlQueries } from '../../../utils/url';
 

--- a/src/core_modules/capture-core/components/ScopeSelector/hooks/useResetStageId.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/hooks/useResetStageId.js
@@ -1,5 +1,5 @@
 // @flow
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { urlArguments, getUrlQueries } from '../../../utils/url';
 

--- a/src/core_modules/capture-core/components/ScopeSelector/hooks/useResetTeiId.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/hooks/useResetTeiId.js
@@ -1,5 +1,5 @@
 // @flow
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { urlArguments, getUrlQueries } from '../../../utils/url';
 

--- a/src/core_modules/capture-core/components/ScopeSelector/hooks/useSetEnrollmentId.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/hooks/useSetEnrollmentId.js
@@ -1,5 +1,5 @@
 // @flow
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { urlArguments, getUrlQueries } from '../../../utils/url';
 

--- a/src/core_modules/capture-core/components/ScopeSelector/hooks/useSetOrgUnitId.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/hooks/useSetOrgUnitId.js
@@ -1,5 +1,5 @@
 // @flow
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { urlArguments, getUrlQueries } from '../../../utils/url';
 

--- a/src/core_modules/capture-core/components/ScopeSelector/hooks/useSetProgramId.js
+++ b/src/core_modules/capture-core/components/ScopeSelector/hooks/useSetProgramId.js
@@ -1,5 +1,5 @@
 // @flow
-import { useHistory } from 'react-router';
+import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { urlArguments, getUrlQueries } from '../../../utils/url';
 

--- a/src/core_modules/capture-core/utils/routing/index.js
+++ b/src/core_modules/capture-core/utils/routing/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { useLocationQuery } from './useLocationQuery';

--- a/src/core_modules/capture-core/utils/routing/useLocationQuery.js
+++ b/src/core_modules/capture-core/utils/routing/useLocationQuery.js
@@ -1,0 +1,11 @@
+// @flow
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const useLocationQuery = (): { [key: string]: string } => {
+    const search = useLocation().search;
+    return useMemo(() => [...new URLSearchParams(search).entries()].reduce((accParams, entry) => {
+        accParams[entry[0]] = entry[1];
+        return accParams;
+    }, {}), [search]);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2320,10 +2320,17 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
   version "7.15.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b"
   integrity sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.12.13":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
+  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -12990,11 +12997,11 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
 mini-create-react-context@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz#df60501c83151db69e28eac0ef08b4002efab040"
-  integrity sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
+  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
   dependencies:
-    "@babel/runtime" "^7.5.5"
+    "@babel/runtime" "^7.12.1"
     tiny-warning "^1.0.3"
 
 mini-css-extract-plugin@0.9.0:
@@ -14150,9 +14157,9 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
 path-to-regexp@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
   dependencies:
     isarray "0.0.1"
 
@@ -15502,7 +15509,20 @@ react-redux@^7.2.5:
     prop-types "^15.7.2"
     react-is "^16.13.1"
 
-react-router@^5.2.1:
+react-router-dom@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.0.tgz#da1bfb535a0e89a712a93b97dd76f47ad1f32363"
+  integrity sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.2.1"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.1.tgz#4d2e4e9d5ae9425091845b8dbc6d9d276239774d"
   integrity sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==


### PR DESCRIPTION
Supersedes https://github.com/dhis2/capture-app/pull/2204

This PR will get the location query params from react-router instead of Redux. Follow up ticket in JIRA for a later time: https://jira.dhis2.org/browse/TECH-776
