### PR TITLE
fix: [DHIS2-12077] fix i18n string

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-10-14T05:38:33.109Z\n"
-"PO-Revision-Date: 2021-10-14T05:38:33.109Z\n"
+"POT-Creation-Date: 2021-11-04T12:22:50.798Z\n"
+"PO-Revision-Date: 2021-11-04T12:22:50.798Z\n"
 
 msgid "Choose one or more dates..."
 msgstr ""
@@ -579,6 +579,9 @@ msgstr ""
 msgid "Enrollment with id \"{{enrollmentId}}\" does not exist"
 msgstr ""
 
+msgid "Enrollment Dashboard"
+msgstr ""
+
 msgid "No indicator output for this enrollment yet"
 msgstr ""
 
@@ -671,6 +674,9 @@ msgid "Or see all records accessible to you in {{program}} "
 msgstr ""
 
 msgid "Or see all events accessible to you in {{program}}"
+msgstr ""
+
+msgid "Please select an organisation unit."
 msgstr ""
 
 msgid "Choose the {{missingCategories}} to start reporting"
@@ -937,6 +943,9 @@ msgstr ""
 msgid "This enrollment doesn't have any comments"
 msgstr ""
 
+msgid "Saving to {{stageName}} for {{programName}} in {{orgUnitName}}"
+msgstr ""
+
 msgid "organisation unit could not be retrieved. Please try again later."
 msgstr ""
 
@@ -956,6 +965,9 @@ msgid "Write a comment about this event"
 msgstr ""
 
 msgid "This event doesn't have any comments"
+msgstr ""
+
+msgid "Event completed"
 msgstr ""
 
 msgid "Back to all stages and events"

--- a/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/EnrollmentPageDefault.component.js
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/EnrollmentPageDefault.component.js
@@ -53,7 +53,7 @@ export const EnrollmentPageDefaultPlain = ({
     onEventClick,
 }: PlainProps) => (
     <>
-        <div className={classes.title}>Enrollment Dashboard</div>
+        <div className={classes.title}>{i18n.t('Enrollment Dashboard')}</div>
         <div className={classes.columns}>
             <div className={classes.leftColumn}>
                 <WidgetStagesAndEvents

--- a/src/core_modules/capture-core/components/Pages/MainPage/WithoutOrgUnitSelectedMessage/WithoutOrgUnitSelectedMessage.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/WithoutOrgUnitSelectedMessage/WithoutOrgUnitSelectedMessage.js
@@ -56,7 +56,7 @@ const WithoutOrgUnitSelectedMessagePlain = ({ programId, setShowAccessible, clas
         >
             <IncompleteSelectionsMessage>
                 <div className={classes.incompleteMessageContent}>
-                    <span>Please select an organisation unit.</span>
+                    <span>{i18n.t('Please select an organisation unit.')}</span>
                     <button
                         className={classes.incompleteMessageButton}
                         onClick={() => setShowAccessible()}

--- a/src/core_modules/capture-core/components/WidgetEnrollment/Actions/Complete/Complete.component.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollment/Actions/Complete/Complete.component.js
@@ -30,6 +30,6 @@ export const Complete = ({ enrollment, onUpdate }: Props) =>
                 })
             }
             icon={<IconCheckmark16 />}
-            label={i18n.t('Complete')}
+            label={i18n.t('Completed')}
         />
     ));

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/SavingText/SavingText.component.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/SavingText/SavingText.component.js
@@ -7,8 +7,8 @@ import type { Props } from './savingText.types';
 export const SavingText = ({ orgUnitName, stageName, programName }: Props) => (
     <InfoIconText>
         <span>
-            {i18n.t(`Saving to ${stageName} for ${programName} in ${orgUnitName}`,
-                { interpolation: { escapeValue: false } })}
+            {i18n.t('Saving to {{stageName}} for {{programName}} in {{orgUnitName}}',
+                { orgUnitName, stageName, programName, interpolation: { escapeValue: false } })}
         </span>
     </InfoIconText>
 );

--- a/src/core_modules/capture-core/components/WidgetEventEdit/ViewEventDataEntry/ViewEventDataEntry.component.js
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/ViewEventDataEntry/ViewEventDataEntry.component.js
@@ -172,7 +172,7 @@ const buildCompleteFieldSettingsFn = () => {
     const completeSettings = {
         getComponent: () => viewModeComponent,
         getComponentProps: (props: Object) => createComponentProps(props, {
-            label: 'Event completed',
+            label: i18n.t('Event completed'),
             id: dataElement.id,
             valueConverter: value => dataElement.convertValue(value, valueConvertFn),
         }),

--- a/src/core_modules/capture-core/components/WidgetIndicator/WidgetIndicator.component.js
+++ b/src/core_modules/capture-core/components/WidgetIndicator/WidgetIndicator.component.js
@@ -1,4 +1,5 @@
 // @flow
+import i18n from '@dhis2/d2-i18n';
 import React, { useState } from 'react';
 import { Widget } from '../Widget';
 import type { IndicatorProps } from '../WidgetFeedback/WidgetFeedback.types';
@@ -11,7 +12,7 @@ export const WidgetIndicator = ({ indicators, emptyText }: IndicatorProps) => {
             data-test="indicator-widget"
         >
             <Widget
-                header={'Indicators'}
+                header={i18n.t('Indicators')}
                 open={openStatus}
                 onClose={() => setOpenStatus(false)}
                 onOpen={() => setOpenStatus(true)}


### PR DESCRIPTION
### Issue:
[DHIS2-12077](https://jira.dhis2.org/browse/DHIS2-12077): Non-translatable fields in Capture

**Note**
"Complete" has two different meanings but the string is translated just once.
Complete in Save event (as a verb) and Complete as a status in the Enrollment widget
will considere "Completed" as the status in the Enrollment widget