### PR TITLE
fix: prevent sending empty data values to the api

### DIFF
--- a/src/core_modules/capture-core/components/DataEntries/SingleEventRegistrationEntry/DataEntryWrapper/DataEntry/epics/getConvertedNewSingleEvent.js
+++ b/src/core_modules/capture-core/components/DataEntries/SingleEventRegistrationEntry/DataEntryWrapper/DataEntry/epics/getConvertedNewSingleEvent.js
@@ -39,7 +39,8 @@ export const getNewEventServerData = (state: ReduxState, formFoundation: RenderF
             .map(key => ({
                 dataElement: key,
                 value: formServerValues[key],
-            })),
+            }))
+            .filter(({ value }) => value != null),
     };
 };
 

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/getConvertedAddEvent.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/getConvertedAddEvent.js
@@ -53,7 +53,8 @@ export const getAddEventEnrollmentServerData = ({
                     .map(key => ({
                         dataElement: key,
                         value: formServerValues[key],
-                    })),
+                    }))
+                    .filter(({ value }) => value != null),
             },
         ],
     };

--- a/src/core_modules/capture-core/components/WidgetEventEdit/EditEventDataEntry/editEventDataEntry.epics.js
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/EditEventDataEntry/editEventDataEntry.epics.js
@@ -111,7 +111,8 @@ export const saveEditedEventEpic = (action$: InputObservable, store: ReduxStore)
                     .map(key => ({
                         dataElement: key,
                         value: formServerValues[key],
-                    })),
+                    }))
+                    .filter(({ value }) => value != null),
             };
 
             const metadataContainer = getProgramAndStageFromEvent(eventContainer.event);


### PR DESCRIPTION
When doing a POST or PUT to the events endpoint, it's unnecessary to send in empty data values (the reason this is unnecessary for the PUT, is that the old values are not preserved)