### PR TITLE
fix: [TECH-813] reset enrollmentId when updating event without id

### DIFF
--- a/src/core_modules/capture-core/reducers/descriptions/enrollmentDomain.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/enrollmentDomain.reducerDescription.js
@@ -67,7 +67,7 @@ export const enrollmentDomainDesc = createReducerDescription(
         ) => {
             const events = [...state.enrollment.events, { ...eventData, uid, pendingApiResponse: true }];
 
-            return { ...state, enrollment: { ...state.enrollment, events } };
+            return { ...state, enrollment: { ...state.enrollment, events }, enrollmentId: undefined };
         },
         [ROLLBACK_ENROLLMENT_EVENT_WITHOUT_ID]: (state, { payload: { uid } }) => {
             const events = state.enrollment.events.filter(event => (event.uid !== uid));


### PR DESCRIPTION
### Issue:
New and schedule events not show up in overview page

#### Explanation
`useCommonEnrollmentDomainData` only refetch when the `enrollmentId` changes, when navigating back the id stays the same, my idea is to set the enrollmentId to undefined in `UPDATE_ENROLLMENT_EVENTS_WITHOUT_ID` then it should be automatically updated when it lands back on the page