### PR TITLE
fix: [DHIS2-12134] fetching logic in common enrollment hook

### DIFF
--- a/cypress/integration/LockedSelector.feature
+++ b/cypress/integration/LockedSelector.feature
@@ -156,25 +156,27 @@ Feature: User uses the LockedSelector to navigate
       | /#/enrollment?programId=qDkgAbB5Jlk&teiId=fhFQhO0xILJ                                                 | teiAndMalariaProgram | Carlos Cruz is a person and cannot be enrolled in the Malaria case diagnosis, treatment and investigation. Choose another program that allows person enrollment. Enroll a new malaria entity in this program.|
       | /#/enrollment?programId=lxAQ7Zs9VYR&teiId=fhFQhO0xILJ                                                 | teiAndEventProgram   | Antenatal care visit is an event program and does not have enrollments. |
 
-  Scenario: Enrollment page > resetting the tei
-   Given you land on the enrollment page by having typed only the enrollmentId on the url
-   When you reset the tei selection
-   And you navigated to the main page
+##### Can be readded after refactoring in ticket https://jira.dhis2.org/browse/TECH-818
+  # Scenario: Enrollment page > resetting the tei
+  #  Given you land on the enrollment page by having typed only the enrollmentId on the url
+  # When you reset the tei selection
+  # And you navigated to the main page
 
-  Scenario: Enrollment page > resetting the program
-   Given you land on the enrollment page by having typed only the enrollmentId on the url
-   When you reset the program selection
-   And you see message explaining you need to select a program
+  # Scenario: Enrollment page > resetting the program
+  # Given you land on the enrollment page by having typed only the enrollmentId on the url
+  # When you reset the program selection
+  # And you see message explaining you need to select a program
 
-  Scenario: Enrollment page > resetting the org unit
-   Given you land on the enrollment page by having typed only the enrollmentId on the url
-   When you reset the org unit selection
-   And you see the enrollment page but there is no org unit id in the url
+  # Scenario: Enrollment page > resetting the org unit
+  # Given you land on the enrollment page by having typed only the enrollmentId on the url
+  # When you reset the org unit selection
+  # And you see the enrollment page but there is no org unit id in the url
 
-  Scenario: Enrollment page > resetting the enrollment
-   Given you land on the enrollment page by having typed only the enrollmentId on the url
-   When you reset the enrollment selection
-   And you see message explaining you need to select an enrollment
+  # Scenario: Enrollment page > resetting the enrollment
+  #  Given you land on the enrollment page by having typed only the enrollmentId on the url
+  # When you reset the enrollment selection
+  # And you see message explaining you need to select an enrollment
+#####
 
   Scenario: Enrollment page > navigating using the scope selector
    Given you land on the enrollment page by having typed only the enrollmentId on the url

--- a/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPage.container.js
@@ -86,7 +86,7 @@ export const EnrollmentPage: ComponentType<{||}> = () => {
     useComponentLifecycle();
 
     const dispatch = useDispatch();
-    const { programId, orgUnitId, enrollmentId } = useSelector(
+    const { programId, orgUnitId, enrollmentId, teiId } = useSelector(
         ({ router: { location: { query } } }) => ({
             teiId: query.teiId,
             programId: query.programId,
@@ -104,6 +104,7 @@ export const EnrollmentPage: ComponentType<{||}> = () => {
     },
     [
         dispatch,
+        teiId,
     ]);
 
     const error: boolean =

--- a/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/useCommonEnrollmentDomainData.js
+++ b/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/useCommonEnrollmentDomainData.js
@@ -1,5 +1,5 @@
 // @flow
-import { useMemo, useEffect } from 'react';
+import { useEffect } from 'react';
 // $FlowFixMe
 import { useSelector, useDispatch } from 'react-redux';
 import { useDataQuery } from '@dhis2/app-runtime';
@@ -14,28 +14,18 @@ export const useCommonEnrollmentDomainData = (teiId: string, enrollmentId: strin
         attributeValues: storedAttributeValues,
     } = useSelector(({ enrollmentDomain }) => enrollmentDomain);
 
-    const { data, error, refetch } = useDataQuery(
-        useMemo(
-            () => ({
-                trackedEntityInstance: {
-                    resource: 'trackedEntityInstances',
-                    id: teiId,
-                    params: {
-                        program: programId,
-                        fields: ['enrollments[*],attributes'],
-                    },
-                },
+    const { data, error, refetch } = useDataQuery({
+        trackedEntityInstance: {
+            resource: 'trackedEntityInstances',
+            id: ({ variables: { teiId: updatedTeiId } }) => updatedTeiId,
+            params: ({ variables: { programId: updatedProgramId } }) => ({
+                program: updatedProgramId,
+                fields: ['enrollments[*],attributes'],
             }),
-            [teiId, programId],
-        ),
-        { lazy: true },
-    );
-
-    useEffect(() => {
-        if (storedEnrollmentId !== enrollmentId) {
-            refetch();
-        }
-    }, [refetch, storedEnrollmentId, enrollmentId]);
+        },
+    }, {
+        lazy: true,
+    });
 
     const fetchedEnrollmentData = {
         reference: data,
@@ -58,6 +48,12 @@ export const useCommonEnrollmentDomainData = (teiId: string, enrollmentId: strin
         fetchedEnrollmentData.enrollment,
         fetchedEnrollmentData.attributeValues,
     ]);
+
+    useEffect(() => {
+        if (storedEnrollmentId !== enrollmentId) {
+            refetch({ variables: { teiId, programId } });
+        }
+    }, [refetch, storedEnrollmentId, enrollmentId, teiId, programId]);
 
     const inEffectData = enrollmentId === storedEnrollmentId ? {
         enrollment: storedEnrollment,


### PR DESCRIPTION
Even though we don't use app-runtime v3 in the v37 branch it makes sense to back port this.