### PR TITLE
[DHIS2-11425] feat: enable PWA with basic online/offline badge

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -2,6 +2,9 @@ const config = {
     name: 'capture',
     title: 'Capture',
     type: 'app',
+    pwa: {
+        enabled: true,
+    },
     coreApp: true,
 
     entryPoints: {


### PR DESCRIPTION
Enable PWA with a basic online/offline badge. To be able to add our custom text [LIBS-229](https://jira.dhis2.org/browse/LIBS-229)  and [LIBS-230](https://jira.dhis2.org/browse/LIBS-230) needs to be implemented. 