### PR TITLE
fix: cypress test year change

### DIFF
--- a/cypress/integration/NewPage/index.js
+++ b/cypress/integration/NewPage/index.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import '../sharedSteps';
 
 beforeEach(() => {
@@ -369,7 +370,7 @@ And('you are in Child programme registration page', () => {
 And('you fill the form with age 0', () => {
     cy.get('[data-test="capture-ui-input"]')
         .eq(9)
-        .type('2021-01-01')
+        .type(moment().format('YYYY-MM-DD'))
         .blur();
 });
 


### PR DESCRIPTION
The test was based on a hardcoded year value. It started falling after the 1st of January. 