### PR TITLE
fix: cypress test with hardcored 2021 year (#2390)

### DIFF
--- a/cypress/integration/NewPage/index.js
+++ b/cypress/integration/NewPage/index.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import '../sharedSteps';
 
 beforeEach(() => {
@@ -374,7 +375,7 @@ And('you are in Child programme registration page', () => {
 And('you fill the form with age 0', () => {
     cy.get('[data-test="capture-ui-input"]')
         .eq(9)
-        .type('2021-01-01')
+        .type(moment().format('YYYY-MM-DD'))
         .blur();
 });
 


### PR DESCRIPTION
(cherry picked from commit b658b10195e2e8dc16a8990ea26fc79ae3450b78)
The 10 failures in Cypress are [known issues ](https://github.com/dhis2/capture-app/wiki/Pull-Request-Guidelines#cypress-tests-to-follow-up-on-the-tests-are-commented-out-from-our-code-base)