### PR TITLE
fix: adapt the requests to the latest API shape.

### DIFF
--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/getTemplates.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/getTemplates.js
@@ -12,7 +12,7 @@ const getApiTEIFilters = async (programId: string, querySingleResource: QuerySin
         resource: 'trackedEntityInstanceFilters',
         params: {
             filter: `program.id:eq:${programId}`,
-            fields: 'id,displayName,enrollmentStatus,enrollmentCreatedPeriod,incidentDate,order,displayColumnOrder,attributeValueFilters,sortOrder,access,assignedUserMode,assignedUsers',
+            fields: 'id,displayName,sortOrder,entityQueryCriteria,access',
         },
     });
     return apiRes && apiRes.trackedEntityInstanceFilters ? apiRes.trackedEntityInstanceFilters : [];
@@ -44,24 +44,26 @@ export const getTemplates = (
                     ({
                         displayName,
                         sortOrder,
-                        enrollmentStatus,
-                        enrollmentCreatedPeriod,
                         id,
                         access,
-                        attributeValueFilters,
-                        incidentDate,
-                        order,
-                        displayColumnOrder,
-                        assignedUserMode,
-                        assignedUsers,
+                        entityQueryCriteria: {
+                            enrollmentStatus,
+                            enrollmentCreatedDate,
+                            enrollmentIncidentDate,
+                            order,
+                            attributeValueFilters,
+                            displayColumnOrder,
+                            assignedUserMode,
+                            assignedUsers,
+                        },
                     }) => ({
                         id,
                         name: displayName,
                         order: sortOrder,
                         criteria: {
                             programStatus: enrollmentStatus,
-                            enrolledAt: enrollmentCreatedPeriod,
-                            occurredAt: incidentDate,
+                            enrolledAt: enrollmentCreatedDate,
+                            occurredAt: enrollmentIncidentDate,
                             order,
                             displayColumnOrder,
                             assignedUserMode,

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/templates.epics.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/templates.epics.js
@@ -52,19 +52,30 @@ export const addTemplateEpic = (action$: InputObservable, store: ReduxStore, { m
                 program,
                 storeId,
                 clientId,
-                criteria: { programStatus, enrolledAt, occurredAt, attributeValueFilters, order, displayOrderColumns, assignedUserMode, assignedUsers },
+                criteria: {
+                    programStatus,
+                    enrolledAt,
+                    occurredAt,
+                    attributeValueFilters,
+                    order,
+                    displayOrderColumns,
+                    assignedUserMode,
+                    assignedUsers,
+                },
             } = action.payload;
             const trackedEntityInstanceFilters = {
                 name,
                 program,
-                order,
-                displayOrderColumns,
-                ...(assignedUserMode && { assignedUserMode }),
-                ...(assignedUsers?.length > 0 && { assignedUsers }),
-                ...(programStatus && { enrollmentStatus: programStatus }),
-                ...(enrolledAt && { enrollmentCreatedPeriod: enrolledAt }),
-                ...(occurredAt && { incidentDate: occurredAt }),
-                ...(attributeValueFilters?.length > 0 && { attributeValueFilters }),
+                entityQueryCriteria: {
+                    displayOrderColumns,
+                    order,
+                    ...(assignedUserMode && { assignedUserMode }),
+                    ...(assignedUsers?.length > 0 && { assignedUsers }),
+                    ...(programStatus && { enrollmentStatus: programStatus }),
+                    ...(enrolledAt && { enrollmentCreatedDate: enrolledAt }),
+                    ...(occurredAt && { enrollmentIncidentDate: occurredAt }),
+                    ...(attributeValueFilters?.length > 0 && { attributeValueFilters }),
+                },
             };
 
             const requestPromise = mutate({
@@ -147,27 +158,21 @@ export const updateTemplateEpic = (action$: InputObservable, store: ReduxStore, 
                 storeId,
                 criteria,
             } = action.payload;
-            const {
-                programStatus,
-                enrolledAt,
-                occurredAt,
-                attributeValueFilters,
-                order,
-                displayOrderColumns,
-                assignedUserMode,
-                assignedUsers,
-            } = criteria;
+            const { programStatus, enrolledAt, occurredAt, attributeValueFilters, order, displayOrderColumns, assignedUserMode, assignedUsers } =
+                criteria;
             const trackedEntityInstanceFilters = {
                 name,
                 program,
-                order,
-                displayOrderColumns,
-                ...(assignedUserMode && { assignedUserMode }),
-                ...(assignedUsers?.length > 0 && { assignedUsers }),
-                ...(programStatus && { enrollmentStatus: programStatus }),
-                ...(enrolledAt && { enrollmentCreatedPeriod: enrolledAt }),
-                ...(occurredAt && { incidentDate: occurredAt }),
-                ...(attributeValueFilters?.length > 0 && { attributeValueFilters }),
+                entityQueryCriteria: {
+                    displayOrderColumns,
+                    order,
+                    ...(assignedUserMode && { assignedUserMode }),
+                    ...(assignedUsers?.length > 0 && { assignedUsers }),
+                    ...(programStatus && { enrollmentStatus: programStatus }),
+                    ...(enrolledAt && { enrollmentCreatedDate: enrolledAt }),
+                    ...(occurredAt && { enrollmentIncidentDate: occurredAt }),
+                    ...(attributeValueFilters?.length > 0 && { attributeValueFilters }),
+                },
             };
 
             const requestPromise = mutate({


### PR DESCRIPTION
While [DHIS2-12376](https://jira.dhis2.org/browse/DHIS2-12376) and [DHIS2-12574](https://jira.dhis2.org/browse/DHIS2-12574) are being developed, you can test the `entityQueryCriteria` field by modifying the code locally. For example:

```
const entityQueryCriteriaTest = {
    followup: false,
    enrollmentStatus: 'COMPLETED',
    enrollmentCreatedDate: {
        period: 'TODAY',
        endDate: '2019-03-20T00:00:00.000',
        type: 'ABSOLUTE',
        startDate: '2014-05-01T00:00:00.000',
    },
    enrollmentIncidentDate: {
        period: 'TODAY',
        endDate: '2019-03-20T00:00:00.000',
        type: 'RELATIVE',
        startDate: '2014-05-01T00:00:00.000',
    },
    ouMode: 'SELECTED',
    assignedUserMode: 'PROVIDED',
    assignedUsers: ['DLjZWMsVsq2'],
    trackedEntityInstances: ['a3kGcGDCuk7', 'a3kGcGDCuk8'],
    order: 'QRg7SZ6VOAV:desc',
    attributeValueFilters: [
        { attribute: 'coaSpbzZiTB', like: 'abc' },
        { attribute: 'qDQUHqdAXkT', le: '20', ge: '10' },
        { attribute: 'KrCahWFMYYz', in: ['RURAL', 'URBAN'] },
        { attribute: 'TgSJNUL2cqd', in: ['1-2KM'] },
        { attribute: 'mTg1B4t9Liz', in: ['true'] },
        { attribute: 'Z1rLc1rVHK8', in: ['true'] },
    ],
    displayColumnOrder: ['inactive', 'coaSpbzZiTB', 'QRg7SZ6VOAV', 'Kv4fmHVAzwX'],
};
```