### PR TITLE
fix: up cache version for 2.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "homepage": ".",
   "version": "1.72.1",
   "cacheVersion": "1",
-  "serverVersion": "37",
+  "serverVersion": "38",
   "private": true,
   "dependencies": {
     "@dhis2/app-runtime": "^3.3.0",


### PR DESCRIPTION
Ensure old client caches are updated when loading the 2.38 version of the app.