### PR TITLE
chore(release): migrate to new app version scheme

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# default code owner for repo
+*        @dhis2/team-tracker
+
+# code owners for functionality
+/src/    @dhis2/team-tracker @dhis2/team-qa
+/docs/   @dhis2/team-tracker @dhis2/team-qa

--- a/d2.config.js
+++ b/d2.config.js
@@ -2,6 +2,9 @@ const config = {
     name: 'capture',
     title: 'Capture',
     type: 'app',
+
+    id: '92b75fd0-34cc-451c-942f-3dd0f283bcbd',
+    minDHIS2Version: '2.38',
     coreApp: true,
 
     entryPoints: {


### PR DESCRIPTION
Align all our application versions that range between 0.x.x and 36.x.x
with different semantics to a single version scheme with distinct
semantics for what constitutes a breaking change.

We have chosen to bump to v100.0.0 to signify the depature from the old
version scheme to the new.

For more information:
dhis2/notes#293

BREAKING CHANGE: App version becomes decoupled from DHIS2 versions, see
the d2.config.js or App Hub for DHIS2 version compatibility.