### PR TITLE
fix: use api version 38

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 REACT_APP_CACHE_VERSION=$npm_package_cacheVersion
 REACT_APP_SERVER_VERSION=$npm_package_serverVersion
 REACT_APP_VERSION=$npm_package_version
-REACT_APP_DHIS2_API_VERSION=37
+REACT_APP_DHIS2_API_VERSION=38


### PR DESCRIPTION
Make api requests use the URL `api/38/....`. There should not be any differences in what we get the from the API, the versioning doesn't do much at the moment. Seems like a good time to reset anyway though, since we're switching to the new tracker endpoints. 