### PR TITLE
fix: remove fields query arg

### DIFF
--- a/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.epics.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchForm/SearchForm.epics.js
@@ -166,7 +166,6 @@ export const searchViaAttributesOnScopeProgramEpic: Epic = (action$, store) =>
                 page,
                 pageSize: 5,
                 ouMode: 'ACCESSIBLE',
-                fields: '*',
             };
 
             return searchViaAttributesStream(queryArgs, attributes, triggeredFrom);

--- a/src/core_modules/capture-core/components/PossibleDuplicatesDialog/possibleDuplicatesDialog.epics.js
+++ b/src/core_modules/capture-core/components/PossibleDuplicatesDialog/possibleDuplicatesDialog.epics.js
@@ -71,7 +71,6 @@ export const loadSearchGroupDuplicatesForReviewEpic: Epic = (action$, store) =>
                     pageSize,
                     page,
                     filter: filters,
-                    fields: '*',
                     ...contextParam,
                 };
                 const attributes = getAttributesFromScopeId(selectedScopeId);

--- a/src/core_modules/capture-core/components/TeiSearch/epics/teiSearch.epics.js
+++ b/src/core_modules/capture-core/components/TeiSearch/epics/teiSearch.epics.js
@@ -69,7 +69,6 @@ const searchTei = (state: ReduxState, searchId: string, formId: string, searchGr
 
     const queryArgs = {
         filter: filters,
-        fields: '*',
         ...getOuQueryArgs(selectedOrgUnit, selectedOrgUnitScope),
         // $FlowFixMe[exponential-spread] automated comment
         ...getContextQueryArgs(selectedProgramId, selectedTrackedEntityTypeId),


### PR DESCRIPTION
Removed `fields=*` from some api requests.