### PR TITLE
fix: [DHIS2-12870] use api fields name for TEIFilters

### DIFF
--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/TeiWorkingListsSetup.component.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/TeiWorkingListsSetup.component.js
@@ -140,7 +140,7 @@ const useInjectDataFetchingMetaToLoadList = (defaultColumns, filtersOnly, onLoad
         const columnsMetaForDataFetching: TeiColumnsMetaForDataFetching = new Map(
             defaultColumns
                 // $FlowFixMe
-                .map(({ id, type, mainProperty, apiName, visible }) => [id, { id, type, mainProperty, apiName, visible }]),
+                .map(({ id, type, mainProperty, visible }) => [id, { id, type, mainProperty, visible }]),
         );
         const filtersOnlyMetaForDataFetching: TeiFiltersOnlyMetaForDataFetching = new Map(
             filtersOnly
@@ -154,7 +154,7 @@ const useInjectDataFetchingMetaToUpdateList = (defaultColumns, filtersOnly, onUp
         const columnsMetaForDataFetching: TeiColumnsMetaForDataFetching = new Map(
             defaultColumns
                 // $FlowFixMe
-                .map(({ id, type, apiName, mainProperty }) => [id, { id, type, apiName, mainProperty }]),
+                .map(({ id, type, mainProperty }) => [id, { id, type, mainProperty }]),
         );
         const filtersOnlyMetaForDataFetching: TeiFiltersOnlyMetaForDataFetching = new Map(
             filtersOnly

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/useDefaultColumnConfig.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/useDefaultColumnConfig.js
@@ -13,17 +13,15 @@ import type {
 } from '../types';
 
 const mainConfig: Array<MainColumnConfig> = [{
-    id: 'regUnit',
+    id: 'orgUnit',
     visible: false,
     type: dataElementTypes.ORGANISATION_UNIT,
     header: i18n.t('Registering unit'),
-    apiName: 'orgUnit',
 }, {
-    id: 'regDate',
+    id: 'createdAt',
     visible: false,
     type: dataElementTypes.DATE,
     header: i18n.t('Registration Date'),
-    apiName: 'createdAt',
     filterHidden: true,
 }, {
     id: 'inactive',

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/getTemplates.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/getTemplates.js
@@ -34,7 +34,7 @@ export const getTemplates = (
                 manage: false,
             },
             criteria: {
-                order: 'regDate:desc',
+                order: 'createdAt:desc',
             },
         };
         return {

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getTeiListData/convertToClientTeis.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getTeiListData/convertToClientTeis.js
@@ -14,10 +14,10 @@ export const convertToClientTeis = (apiTeis: ApiTeis, columnsMetaForDataFetching
         .map((tei) => {
             const attributeValuesById = getValuesById(tei.attributes);
             const record = columnsMetaForDataFetching
-                .map(({ id, mainProperty, type, apiName }) => {
+                .map(({ id, mainProperty, type }) => {
                     let value;
                     if (mainProperty) {
-                        value = tei[apiName || id];
+                        value = tei[id];
                     } else {
                         value = attributeValuesById[id];
                     }

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getTeiListData/getTeiListData.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getTeiListData/getTeiListData.js
@@ -37,17 +37,10 @@ const getMainApiFilterQueryArgs = (filters?: RawFilterQueryArgs = {}, filtersOnl
             };
         }, {});
 
-const getApiOrderById = (sortById: string, columnsMetaForDataFetching: TeiColumnsMetaForDataFetching) => {
-    const { id } = columnsMetaForDataFetching.get(sortById) || {};
-    return id;
-};
-
 const getApiOrderByQueryArgument = (sortById: string, sortByDirection: string, columnsMetaForDataFetching: TeiColumnsMetaForDataFetching) => {
-    const apiId = getApiOrderById(sortById, columnsMetaForDataFetching);
-    return `${apiId}:${sortByDirection}`;
+    const { id } = columnsMetaForDataFetching.get(sortById) || {};
+    return id ? `${id}:${sortByDirection}` : '';
 };
-
-
 const createApiQueryArgs = ({
     page,
     pageSize,

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getTeiListData/getTeiListData.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getTeiListData/getTeiListData.js
@@ -37,10 +37,6 @@ const getMainApiFilterQueryArgs = (filters?: RawFilterQueryArgs = {}, filtersOnl
             };
         }, {});
 
-const getApiOrderByQueryArgument = (sortById: string, sortByDirection: string, columnsMetaForDataFetching: TeiColumnsMetaForDataFetching) => {
-    const { id } = columnsMetaForDataFetching.get(sortById) || {};
-    return id ? `${id}:${sortByDirection}` : 'createdAt:desc';
-};
 const createApiQueryArgs = ({
     page,
     pageSize,
@@ -55,7 +51,7 @@ filtersOnlyMetaForDataFetching: TeiFiltersOnlyMetaForDataFetching,
 ): { [string]: any } => ({
     ...getApiFilterQueryArgs(filters, filtersOnlyMetaForDataFetching),
     ...getMainApiFilterQueryArgs(filters, filtersOnlyMetaForDataFetching),
-    order: getApiOrderByQueryArgument(sortById, sortByDirection, columnsMetaForDataFetching),
+    order: `${sortById}:${sortByDirection}`,
     page,
     pageSize,
     orgUnit,

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getTeiListData/getTeiListData.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getTeiListData/getTeiListData.js
@@ -38,8 +38,8 @@ const getMainApiFilterQueryArgs = (filters?: RawFilterQueryArgs = {}, filtersOnl
         }, {});
 
 const getApiOrderById = (sortById: string, columnsMetaForDataFetching: TeiColumnsMetaForDataFetching) => {
-    const { id, apiName } = columnsMetaForDataFetching.get(sortById) || {};
-    return apiName || id;
+    const { id } = columnsMetaForDataFetching.get(sortById) || {};
+    return id;
 };
 
 const getApiOrderByQueryArgument = (sortById: string, sortByDirection: string, columnsMetaForDataFetching: TeiColumnsMetaForDataFetching) => {

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getTeiListData/getTeiListData.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getTeiListData/getTeiListData.js
@@ -39,7 +39,7 @@ const getMainApiFilterQueryArgs = (filters?: RawFilterQueryArgs = {}, filtersOnl
 
 const getApiOrderByQueryArgument = (sortById: string, sortByDirection: string, columnsMetaForDataFetching: TeiColumnsMetaForDataFetching) => {
     const { id } = columnsMetaForDataFetching.get(sortById) || {};
-    return id ? `${id}:${sortByDirection}` : '';
+    return id ? `${id}:${sortByDirection}` : 'createdAt:desc';
 };
 const createApiQueryArgs = ({
     page,

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/initTeiWorkingListsView.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/initTeiWorkingListsView.js
@@ -21,7 +21,10 @@ export const initTeiWorkingListsViewAsync = async ({
     querySingleResource,
     absoluteApiPath,
 }: Input) => {
-    const { sortById, sortByDirection } = convertSortOrder(selectedTemplate?.criteria?.order);
+    const { sortById, sortByDirection } = convertSortOrder(
+        selectedTemplate?.criteria?.order,
+        columnsMetaForDataFetching,
+    );
     const customColumnOrder = getCustomColumnsConfiguration(selectedTemplate?.criteria?.displayColumnOrder, columnsMetaForDataFetching);
     const pageSize = 15;
     const page = 1;

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/apiTEIFilterToClientConfigConverter/convertSortToClient.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/apiTEIFilterToClientConfigConverter/convertSortToClient.js
@@ -1,15 +1,25 @@
 // @flow
-export const convertValue = (order: ?string) => {
+import type { TeiColumnsMetaForDataFetching } from '../../../types';
+
+const DEFAULT_SORT = {
+    sortById: 'createdAt',
+    sortByDirection: 'desc',
+};
+
+export const convertValue = (order: ?string, columnsMetaForDataFetching?: TeiColumnsMetaForDataFetching) => {
     const sortOrderParts = order && order.split(':');
     if (!sortOrderParts || sortOrderParts.length < 2) {
-        return {
-            sortById: 'createdAt',
-            sortByDirection: 'desc',
-        };
+        return DEFAULT_SORT;
+    }
+    const sortById = sortOrderParts[0];
+    const sortByDirection = sortOrderParts[1];
+
+    if (!columnsMetaForDataFetching?.get(sortById)?.id) {
+        return DEFAULT_SORT;
     }
 
     return {
-        sortById: sortOrderParts[0],
-        sortByDirection: sortOrderParts[1],
+        sortById,
+        sortByDirection,
     };
 };

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/apiTEIFilterToClientConfigConverter/convertSortToClient.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/apiTEIFilterToClientConfigConverter/convertSortToClient.js
@@ -3,7 +3,7 @@ export const convertValue = (order: ?string) => {
     const sortOrderParts = order && order.split(':');
     if (!sortOrderParts || sortOrderParts.length !== 2) {
         return {
-            sortById: 'regDate',
+            sortById: 'createdAt',
             sortByDirection: 'desc',
         };
     }

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/getCustomColumnsConfiguration.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/getCustomColumnsConfiguration.js
@@ -8,7 +8,9 @@ const buildCustomColumnsConfiguration = (
     customApiOrder: Array<string>,
     columnsMetaForDataFetching: TeiColumnsMetaForDataFetching,
 ): CustomColumnOrder => {
-    const columnsMetaForDataFetchingByApiName = new Map([...columnsMetaForDataFetching.entries()].map(([, config]) => [config.apiName, config]));
+    const columnsMetaForDataFetchingById = new Map(
+        [...columnsMetaForDataFetching.entries()].map(([, config]) => [config.id, config]),
+    );
 
     const visibleColumnsAsMap = new Map(
         customApiOrder
@@ -17,7 +19,7 @@ const buildCustomColumnsConfiguration = (
                     return id;
                 }
 
-                const element = columnsMetaForDataFetchingByApiName.get(id);
+                const element = columnsMetaForDataFetchingById.get(id);
                 if (!element) {
                     log.error(errorCreator('id specified in column order not valid')({ id }));
                     return null;

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/getCustomColumnsConfiguration.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/getCustomColumnsConfiguration.js
@@ -1,6 +1,4 @@
 // @flow
-import log from 'loglevel';
-import { errorCreator } from 'capture-core-utils';
 import type { CustomColumnOrder } from '../../../WorkingListsCommon';
 import type { TeiColumnsMetaForDataFetching } from '../../types';
 
@@ -8,25 +6,9 @@ const buildCustomColumnsConfiguration = (
     customApiOrder: Array<string>,
     columnsMetaForDataFetching: TeiColumnsMetaForDataFetching,
 ): CustomColumnOrder => {
-    const columnsMetaForDataFetchingById = new Map(
-        [...columnsMetaForDataFetching.entries()].map(([, config]) => [config.id, config]),
-    );
-
     const visibleColumnsAsMap = new Map(
         customApiOrder
-            .map((id: string) => {
-                if (columnsMetaForDataFetching.has(id)) {
-                    return id;
-                }
-
-                const element = columnsMetaForDataFetchingById.get(id);
-                if (!element) {
-                    log.error(errorCreator('id specified in column order not valid')({ id }));
-                    return null;
-                }
-
-                return element.id;
-            })
+            .map((id: string) => columnsMetaForDataFetching.has(id) && id)
             .filter(id => id)
             .map(id => [id, { id, visible: true }]),
     );

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/types/concept.types.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/types/concept.types.js
@@ -42,7 +42,6 @@ export type MetadataColumnConfig = {
 export type MainColumnConfig = {
     ...ColumnConfigBase,
     mainProperty: true,
-    apiName?: string,
 };
 
 export type TeiWorkingListsColumnConfig = MetadataColumnConfig | MainColumnConfig;
@@ -53,7 +52,6 @@ export type TeiColumnMetaForDataFetching = {
     id: string,
     type: $Values<dataElementTypes>,
     mainProperty?: boolean,
-    apiName?: string,
     visible: boolean,
 };
 

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/dateConverter.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/dateConverter.js
@@ -97,7 +97,8 @@ function getSelector(key: string, storeId: string, isInit: boolean) {
     if (!listSelectors[key]) {
         listSelectors[key] = createSelector(
             sourceValue => sourceValue,
-            sourceValue => relativeConvertersForPeriods[sourceValue.period](),
+            sourceValue =>
+                relativeConvertersForPeriods[sourceValue.period] && relativeConvertersForPeriods[sourceValue.period](),
         );
     }
 


### PR DESCRIPTION
Remove the conversion and use API fields name 
`regDate` to `createdAt`
`regUnit` to `orgUnit`
