### PR TITLE
fix: [DHIS2-12929] use interface language for localeCompare

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-03-14T12:24:43.099Z\n"
-"PO-Revision-Date: 2022-03-14T12:24:43.099Z\n"
+"POT-Creation-Date: 2022-03-22T16:35:05.434Z\n"
+"PO-Revision-Date: 2022-03-22T16:35:05.434Z\n"
 
 msgid "Choose one or more dates..."
 msgstr "Choose one or more dates..."
@@ -1034,6 +1034,9 @@ msgstr "Write a comment about this enrollment"
 
 msgid "This enrollment doesn't have any comments"
 msgstr "This enrollment doesn't have any comments"
+
+msgid "organisation unit could not be retrieved. Please try again later."
+msgstr "organisation unit could not be retrieved. Please try again later."
 
 msgid "Saving to {{stageName}} for {{programName}} in {{orgUnitName}}"
 msgstr "Saving to {{stageName}} for {{programName}} in {{orgUnitName}}"

--- a/src/core_modules/capture-core/components/FormFields/OrgUnitTree/OrgUnitTree.component.js
+++ b/src/core_modules/capture-core/components/FormFields/OrgUnitTree/OrgUnitTree.component.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { getInstance } from 'd2';
+import { localeCompareStrings } from '../../../utils/localeCompareStrings';
 import { Tree } from './Tree';
 
 export class OrgUnitTree extends React.Component {
@@ -103,7 +104,7 @@ export class OrgUnitTree extends React.Component {
                           label: v.displayName,
                       });
                   }
-                  items.sort((a, b) => a.label.localeCompare(b.label));
+                  items.sort(({ label: labelA }, { label: labelB }) => localeCompareStrings(labelA, labelB));
 
                   const { list } = this.state;
                   this.setChildren(path, items, list);

--- a/src/core_modules/capture-core/components/WidgetIndicator/WidgetIndicatorContent/sortIndicatorsFn.js
+++ b/src/core_modules/capture-core/components/WidgetIndicator/WidgetIndicatorContent/sortIndicatorsFn.js
@@ -1,13 +1,18 @@
-// eslint-disable-next-line complexity
+/* eslint-disable complexity */
+import { localeCompareStrings } from '../../../utils/localeCompareStrings';
+
 export const sortIndicatorsFn = (a, b) => {
     if (typeof b === 'string') {
-        return (((a.key && a.key.localeCompare(b)) || (a.message && a.message.localeCompare(b))));
+        return ((a.key && localeCompareStrings(a.key, b)) || (a.message && localeCompareStrings(a.message, b)));
     }
     if (b.message) {
-        return (((a.key && a.key.localeCompare(b.message)) || (a.message && a.message.localeCompare(b.message))));
+        return (
+            (a.key && localeCompareStrings(a.key, b.message)) ||
+            (a.message && localeCompareStrings(a.message, b.message))
+        );
     }
     if (b.key) {
-        return (((a.key && a.key.localeCompare(b.key)) || (a.message && a.message.localeCompare(b.key))));
+        return ((a.key && localeCompareStrings(a.key, b.key)) || (a.message && localeCompareStrings(a.message, b.key)));
     }
     return 1;
 };

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/TemplateSelector.component.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/TemplateSelector.component.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
+import { localeCompareStrings } from '../../../utils/localeCompareStrings';
 import { TemplateSelectorChip } from './TemplateSelectorChip.component';
 import { CaptureScrollHeight } from './CaptureScrollHeight.component';
 import { LinkButton } from '../../Buttons/LinkButton.component';
@@ -79,7 +80,7 @@ const TemplateSelectorPlain = (props: Props) => {
             } else if (orderB) {
                 sortResult = -1;
             } else {
-                sortResult = nameA.localeCompare(nameB);
+                sortResult = localeCompareStrings(nameA, nameB);
             }
             return sortResult;
         }), [templates]);

--- a/src/core_modules/capture-core/utils/localeCompareStrings/index.js
+++ b/src/core_modules/capture-core/utils/localeCompareStrings/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { localeCompareStrings } from './localeCompareStrings';

--- a/src/core_modules/capture-core/utils/localeCompareStrings/localeCompareStrings.js
+++ b/src/core_modules/capture-core/utils/localeCompareStrings/localeCompareStrings.js
@@ -1,0 +1,4 @@
+// @flow
+import i18n from '@dhis2/d2-i18n';
+
+export const localeCompareStrings = (a: string, b: string) => a.localeCompare(b, i18n.language);

--- a/src/core_modules/capture-core/utils/routing/buildUrlQueryString.js
+++ b/src/core_modules/capture-core/utils/routing/buildUrlQueryString.js
@@ -1,9 +1,11 @@
 // @flow
 
+const LOCALE_EN = 'en';
+
 export const buildUrlQueryString = (queryArgs: { [id: string]: ?string }) =>
     Object
         .entries(queryArgs)
-        .sort((a, b) => a[0].localeCompare(b[0]))
+        .sort((a, b) => a[0].localeCompare(b[0], LOCALE_EN))
         .reduce((searchParams, [key, value]) => {
             // $FlowFixMe
             value && searchParams.append(key, value);


### PR DESCRIPTION
By default localeCompare uses the locale from your browser and this can lead to some unexpected behaviour. Changed localeCompare to use the interface language from DHIS. 