### PR TITLE
fix: [TECH-617] behaviour of "hide section" rule actions

### DIFF
--- a/src/core_modules/capture-core/components/D2Form/D2Section.component.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Section.component.js
@@ -24,6 +24,7 @@ type Props = {
     sectionId: string,
     formBuilderId: string,
     formId: string,
+    onFieldsValidated: ?(any, formBuilderId: string) => void,
 };
 
 class D2SectionPlain extends React.PureComponent<Props> {
@@ -59,6 +60,10 @@ class D2SectionPlain extends React.PureComponent<Props> {
         const { sectionMetaData, isHidden, classes, sectionId, ...passOnProps } = this.props;
 
         if (isHidden) {
+            this.props.onFieldsValidated && this.props.onFieldsValidated(
+                {},
+                this.props.formBuilderId,
+            );
             return null;
         }
 

--- a/src/core_modules/capture-core/components/D2Form/D2Section.container.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Section.container.js
@@ -3,12 +3,17 @@ import { connect } from 'react-redux';
 import { D2Section } from './D2Section.component';
 import type { Section as MetaDataSection } from '../../metaData';
 
-const mapStateToProps = (state: Object, props: { sectionMetaData: MetaDataSection, formId: string }) => ({
-    isHidden: !!(
-        state.rulesEffectsHiddenSections[props.formId] &&
-        state.rulesEffectsHiddenSections[props.formId][props.sectionMetaData.id]
-    ),
-});
+const mapStateToProps = (state: Object, props: { sectionMetaData: MetaDataSection, formId: string }) => {
+    const fieldsHiddenByRules = state.rulesEffectsHiddenFields[props.formId];
+    if (fieldsHiddenByRules) {
+        const visibleFields = Array.from(props.sectionMetaData.elements.keys())
+            .filter(id => !fieldsHiddenByRules[id]);
+
+        return { isHidden: visibleFields.length == 0 };
+    }
+
+    return { isHidden: props.sectionMetaData.elements.size == 0 };
+};
 
 const mapDispatchToProps = () => ({});
 


### PR DESCRIPTION
 - Fields hidden explicitly get their values erased
 - Fields in hidden sections do not get their values erased (unless the point above applies)
 - Compulsory fields will remain visible even if the hosting section is hidden
 - Sections with no visible elements are not shown

The above behaviour was accomplished by first creating assign `value = null` effects for each hide field effect that comes straight out of the rules engine, and thereafter convert the hide section effects into hide field effects. By taking this approach we obtain a simple condition for when the form should display a given field: a field is hidden if and only if there is a hide field effect on the field. I have applied a similar condition for sections too; a section is hidden if and only if all fields in the section are subject to a hide field effect.