### PR TITLE
chore: [DHIS2-13029] attempt to fix cypress test

### DIFF
--- a/cypress/integration/LockedSelector/index.js
+++ b/cypress/integration/LockedSelector/index.js
@@ -109,11 +109,13 @@ Then('you can see the view event page', () => {
 });
 
 Given('you land on a main page with an invalid program id', () => {
-    cy.visit('/#/?orgUnitId=invalid');
+    cy.forceVisit('/#/?programId=invalid');
+    cy.url().should('eq', `${Cypress.config().baseUrl}/#/?programId=invalid`);
 });
 
 Given('you land on a main page with an invalid org unit id', () => {
-    cy.visit('/#/?programId=invalid');
+    cy.forceVisit('/#/?orgUnitId=invalid');
+    cy.url().should('eq', `${Cypress.config().baseUrl}/#/?orgUnitId=invalid`);
 });
 
 Then('you should see error message', () => {
@@ -137,11 +139,13 @@ When('you click the cancel button', () => {
 });
 
 Given('you land on a new event page with an invalid program id', () => {
-    cy.visit('/#/new?orgUnitId=invalid');
+    cy.forceVisit('/#/new?programId=invalid');
+    cy.url().should('eq', `${Cypress.config().baseUrl}/#/new?programId=invalid`);
 });
 
 Given('you land on a new event page with an invalid org unit id', () => {
-    cy.visit('/#/new?programId=invalid');
+    cy.forceVisit('/#/new?orgUnitId=invalid');
+    cy.url().should('eq', `${Cypress.config().baseUrl}/#/new?orgUnitId=invalid`);
 });
 
 Given('you land on a new event page with preselected org unit', () => {

--- a/cypress/support/helpers.js
+++ b/cypress/support/helpers.js
@@ -23,3 +23,8 @@ Cypress.Commands.add('loginThroughForm', (username = 'dhis2Username', password =
     cy.get('[data-test="locked-selector"]', { timeout: 60000 })
         .should('exist');
 });
+
+Cypress.Commands.add('forceVisit', (url) => {
+    cy.visit(url);
+    cy.window().then((win) => { win.location.href = url; });
+});


### PR DESCRIPTION
### Issue 
Test scenario: New event page > Url with invalid program id randomly failed on PRs

I look into the capture of the run, the page url has not changed when `cy.visit`, this PR tried to fix that by reassign the url, make the page reload after that. 