### PR TITLE
chore(workflow): fix concurrency issue and decrease dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: weekly
+  open-pull-requests-limit: 5
   target-branch: master
   versioning-strategy: increase

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 env:
   GIT_AUTHOR_NAME: '@dhis2-bot'
   GIT_AUTHOR_EMAIL: 'apps@dhis2.org'


### PR DESCRIPTION
This should fix the concurrency issue @jasminenguyennn experienced earlier (where one of the commits was missing in the build).

Also, I'm decreasing the Dependabot pull requests limit to 5, opened on a weekly basis. I think this might help us actually follow up on some of those, at the moment it feels a bit overwhelming.