### PR TITLE
fix: [DHIS2-12188] do not download program indicators unless displayInForm=true

### DIFF
--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/getRulesAndVariablesFromIndicators.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/getRulesAndVariablesFromIndicators.js
@@ -6,7 +6,6 @@ import type { ProgramRule, ProgramRuleAction, ProgramRuleVariable } from 'captur
 export type CachedProgramIndicator = {
     id: string,
     code: string,
-    displayInForm: boolean,
     displayName: string,
     description?: ?string,
     expression: string,
@@ -143,10 +142,6 @@ function replacePositiveValueCountIfPresent(rule, action, variableObjectsCurrent
 }
 
 function buildIndicatorRuleAndVariables(programIndicator: CachedProgramIndicator, programId: string) {
-    if (!programIndicator.displayInForm) {
-        return null;
-    }
-
     // $FlowFixMe[prop-missing] automated comment
     const newAction: ProgramRuleAction = {
         id: programIndicator.id,

--- a/src/core_modules/capture-core/metaDataStoreLoaders/programs/quickStoreOperations/storeProgramIndicators.js
+++ b/src/core_modules/capture-core/metaDataStoreLoaders/programs/quickStoreOperations/storeProgramIndicators.js
@@ -21,7 +21,7 @@ export const storeProgramIndicators = async (programIds: Array<string>) => {
         resource: 'programIndicators',
         params: {
             fields: fieldsParam,
-            filter: [`displayInForm:eq:true`, `program.id:in:[${programIds.join(',')}]`],
+            filter: ['displayInForm:eq:true', `program.id:in:[${programIds.join(',')}]`],
         },
     };
 

--- a/src/core_modules/capture-core/metaDataStoreLoaders/programs/quickStoreOperations/storeProgramIndicators.js
+++ b/src/core_modules/capture-core/metaDataStoreLoaders/programs/quickStoreOperations/storeProgramIndicators.js
@@ -21,7 +21,7 @@ export const storeProgramIndicators = async (programIds: Array<string>) => {
         resource: 'programIndicators',
         params: {
             fields: fieldsParam,
-            filter: `displayInForm:eq:true&filter=program.id:in:[${programIds.join(',')}]`,
+            filter: [`displayInForm:eq:true`, `program.id:in:[${programIds.join(',')}]`],
         },
     };
 

--- a/src/core_modules/capture-core/metaDataStoreLoaders/programs/quickStoreOperations/storeProgramIndicators.js
+++ b/src/core_modules/capture-core/metaDataStoreLoaders/programs/quickStoreOperations/storeProgramIndicators.js
@@ -13,7 +13,7 @@ const convert = (response) => {
         }));
 };
 
-const fieldsParam = 'id,displayName,code,shortName,style,displayInForm,expression,' +
+const fieldsParam = 'id,displayName,code,shortName,style,expression,' +
 'displayDescription,description,filter,program[id]';
 
 export const storeProgramIndicators = async (programIds: Array<string>) => {
@@ -21,7 +21,7 @@ export const storeProgramIndicators = async (programIds: Array<string>) => {
         resource: 'programIndicators',
         params: {
             fields: fieldsParam,
-            filter: `program.id:in:[${programIds.join(',')}]`,
+            filter: `displayInForm:eq:true&filter=program.id:in:[${programIds.join(',')}]`,
         },
     };
 


### PR DESCRIPTION
The app does not use program indicators with displayInForm=false, so we ask the backend to filter out these to cut down on the loading time.