### PR TITLE
fix: [DHIS2-13241] URL out of sync after adding event

### DIFF
--- a/cypress/integration/NewPage/index.js
+++ b/cypress/integration/NewPage/index.js
@@ -310,7 +310,7 @@ And('you fill in the hemoglobin', () => {
 
 And('you are navigated to the working list', () => {
     cy.url()
-        .should('eq', `${Cypress.config().baseUrl}/#/orgUnitId=DiszpKrYNg8&programId=lxAQ7Zs9VYR`);
+        .should('eq', `${Cypress.config().baseUrl}/#/?orgUnitId=DiszpKrYNg8&programId=lxAQ7Zs9VYR`);
 
     cy.get('[data-test="event-working-lists"]')
         .contains('2021-01-01')

--- a/src/core_modules/capture-core/components/DataEntries/SingleEventRegistrationEntry/DataEntryWrapper/DataEntry/epics/saveNewSingleEvent.epics.js
+++ b/src/core_modules/capture-core/components/DataEntries/SingleEventRegistrationEntry/DataEntryWrapper/DataEntry/epics/saveNewSingleEvent.epics.js
@@ -32,6 +32,6 @@ export const saveNewEventLocationChangeEpic = (action$: InputObservable, store: 
         map(() => {
             const { programId, orgUnitId } = deriveURLParamsFromLocation();
 
-            history.push(`/${buildUrlQueryString({ programId, orgUnitId })}`);
+            history.push(`/?${buildUrlQueryString({ programId, orgUnitId })}`);
             return resetLocationChange();
         }));


### PR DESCRIPTION
After adding an event, the user is redirected to the main-page with the programId and orgUnitId is stored in the URL. 
The URL is missing a "?", and the Ids are therefore interpreted as a part of the pathname, and not as a query parameter.
A refresh would cause the app to lose the program- and orgUnit-context.