### PR TITLE
fix: [DHIS2-12120] conversion of program indicators to program rules

### DIFF
--- a/src/core_modules/capture-core-utils/rulesEngine/commonUtils/index.js
+++ b/src/core_modules/capture-core-utils/rulesEngine/commonUtils/index.js
@@ -1,0 +1,4 @@
+// @flow
+
+export { normalizeRuleVariable } from './normalizeRuleVariable';
+export { numberToString } from './numberToString';

--- a/src/core_modules/capture-core-utils/rulesEngine/commonUtils/numberToString.js
+++ b/src/core_modules/capture-core-utils/rulesEngine/commonUtils/numberToString.js
@@ -1,0 +1,4 @@
+// @flow
+
+export const numberToString = (number: number): string =>
+    (isNaN(number) || number === Infinity ? '' : String(number));

--- a/src/core_modules/capture-core-utils/rulesEngine/index.js
+++ b/src/core_modules/capture-core-utils/rulesEngine/index.js
@@ -1,6 +1,7 @@
 // @flow
 export { RulesEngine } from './RulesEngine';
 export { effectActions, rulesEngineEffectTargetDataTypes, environmentTypes } from './constants';
+export { variableSourceTypes } from './services/VariableService';
 export type * from './rulesEngine.types';
 export type {
     Enrollment,

--- a/src/core_modules/capture-core-utils/rulesEngine/processors/rulesEffectsProcessor/rulesEffectsProcessor.js
+++ b/src/core_modules/capture-core-utils/rulesEngine/processors/rulesEffectsProcessor/rulesEffectsProcessor.js
@@ -211,7 +211,7 @@ export function getRulesEffectsProcessor(
             displayKeyValuePair: {
                 id: effect.id,
                 key: effect.content,
-                value: effect.data,
+                value: String(effect.data),
                 ...effect.style,
             },
         };

--- a/src/core_modules/capture-core-utils/rulesEngine/processors/rulesEffectsProcessor/rulesEffectsProcessor.js
+++ b/src/core_modules/capture-core-utils/rulesEngine/processors/rulesEffectsProcessor/rulesEffectsProcessor.js
@@ -18,7 +18,7 @@ import type {
     CompulsoryEffect,
     OutputEffects,
 } from '../../rulesEngine.types';
-import { normalizeRuleVariable } from '../../commonUtils/normalizeRuleVariable';
+import { normalizeRuleVariable, numberToString } from '../../commonUtils';
 
 const sanitiseFalsy = (value) => {
     if (value) {
@@ -211,7 +211,7 @@ export function getRulesEffectsProcessor(
             displayKeyValuePair: {
                 id: effect.id,
                 key: effect.content,
-                value: String(effect.data),
+                value: typeof effect.data == 'number' ? numberToString(effect.data) : String(effect.data),
                 ...effect.style,
             },
         };

--- a/src/core_modules/capture-core-utils/rulesEngine/services/VariableService/VariableService.js
+++ b/src/core_modules/capture-core-utils/rulesEngine/services/VariableService/VariableService.js
@@ -49,7 +49,7 @@ const variableSourceTypesTrackedEntitySpecific = {
     TEI_ATTRIBUTE: 'TEI_ATTRIBUTE',
 };
 
-const variableSourceTypes = {
+export const variableSourceTypes = {
     ...variableSourceTypesDataElementSpecific,
     ...variableSourceTypesTrackedEntitySpecific,
     CALCULATED_VALUE: 'CALCULATED_VALUE',

--- a/src/core_modules/capture-core-utils/rulesEngine/services/VariableService/helpers/structureEvents.js
+++ b/src/core_modules/capture-core-utils/rulesEngine/services/VariableService/helpers/structureEvents.js
@@ -19,21 +19,21 @@ const createEventsContainer = (events: EventsData) => {
 export const getStructureEvents = (compareDates: CompareDates) => {
     const compareEvents = (first: EventData, second: EventData): number => {
         let result;
-        if (!first.eventDate && !second.eventDate) {
+        if (!first.occurredAt && !second.occurredAt) {
             result = 0;
-        } else if (!first.eventDate) {
+        } else if (!first.occurredAt) {
             result = 1;
-        } else if (!second.eventDate) {
+        } else if (!second.occurredAt) {
             result = -1;
         } else {
-            result = compareDates(first.eventDate, second.eventDate);
+            result = compareDates(first.occurredAt, second.occurredAt);
         }
         return result;
     };
 
     return (currentEvent: EventData = {}, otherEvents: EventsData = []) => {
         const otherEventsFiltered = otherEvents
-            .filter(event => event.eventDate &&
+            .filter(event => event.occurredAt &&
                     [eventStatuses.COMPLETED, eventStatuses.ACTIVE, eventStatuses.VISITED].includes(event.status) &&
                     event.eventId !== currentEvent.eventId,
             );

--- a/src/core_modules/capture-core-utils/rulesEngine/services/VariableService/index.js
+++ b/src/core_modules/capture-core-utils/rulesEngine/services/VariableService/index.js
@@ -1,5 +1,5 @@
 // @flow
-export { VariableService } from './VariableService';
+export { VariableService, variableSourceTypes } from './VariableService';
 export type {
     ProgramRuleVariable,
     EventData,

--- a/src/core_modules/capture-core/components/Pages/EnrollmentEditEvent/EnrollmentEditEventPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/EnrollmentEditEvent/EnrollmentEditEventPage.container.js
@@ -26,7 +26,7 @@ export const EnrollmentEditEventPage = () => {
     const currentPageMode = showEditEvent ? pageMode.EDIT : pageMode.VIEW;
     const dataEntryKey = `singleEvent-${currentPageMode}`;
     const outputEffects = useWidgetDataFromStore(dataEntryKey);
-    const hideWidgets = useHideWidgetByRuleLocations(program.programRules);
+    const hideWidgets = useHideWidgetByRuleLocations(program.programRules.concat(programStage?.programRules));
 
     const onDelete = () => {
         history.push(`/enrollment?${buildUrlQueryString({ orgUnitId, programId, teiId })}`);

--- a/src/core_modules/capture-core/components/WidgetIndicator/WidgetIndicatorContent/WidgetIndicatorContent.js
+++ b/src/core_modules/capture-core/components/WidgetIndicator/WidgetIndicatorContent/WidgetIndicatorContent.js
@@ -86,7 +86,7 @@ const WidgetIndicatorContentComponent = ({ widgetData, emptyText, classes }: Con
             className={cx(classes.indicatorRow, { isLastItem })}
         >
             <div>{indicator.key}</div>
-            {(String(indicator.value) || indicator.color) && ( // convert to string to make sure 0 gets displayed
+            {(indicator.value || indicator.color) && (
                 <div className={classes.indicatorValue}>
                     {indicator.color ? renderLegend(indicator.color) : null}
                     {indicator.value}

--- a/src/core_modules/capture-core/components/WidgetIndicator/WidgetIndicatorContent/WidgetIndicatorContent.js
+++ b/src/core_modules/capture-core/components/WidgetIndicator/WidgetIndicatorContent/WidgetIndicatorContent.js
@@ -86,7 +86,7 @@ const WidgetIndicatorContentComponent = ({ widgetData, emptyText, classes }: Con
             className={cx(classes.indicatorRow, { isLastItem })}
         >
             <div>{indicator.key}</div>
-            {(indicator.value || indicator.color) && (
+            {(String(indicator.value) || indicator.color) && ( // convert to string to make sure 0 gets displayed
                 <div className={classes.indicatorValue}>
                     {indicator.color ? renderLegend(indicator.color) : null}
                     {indicator.value}

--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/getRulesAndVariablesFromIndicators.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/getRulesAndVariablesFromIndicators.js
@@ -152,7 +152,7 @@ function buildIndicatorRuleAndVariables(programIndicator: CachedProgramIndicator
     // $FlowFixMe[prop-missing] automated comment
     const newAction: ProgramRuleAction = {
         id: programIndicator.id,
-        content: programIndicator.shortName || programIndicator.displayName,
+        content: programIndicator.displayName || programIndicator.shortName,
         data: programIndicator.expression,
         programRuleActionType: 'DISPLAYKEYVALUEPAIR',
         location: 'indicators',

--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/getRulesAndVariablesFromIndicators.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/getRulesAndVariablesFromIndicators.js
@@ -2,6 +2,7 @@
 import isString from 'd2-utilizr/lib/isString';
 
 import type { ProgramRule, ProgramRuleAction, ProgramRuleVariable } from 'capture-core-utils/rulesEngine';
+import { variableSourceTypes } from 'capture-core-utils/rulesEngine';
 
 export type CachedProgramIndicator = {
     id: string,
@@ -52,7 +53,7 @@ function getDirectAddressedVariable(variableWithCurls, programId) {
         newVariableObject = {
             id: variableName,
             displayName: variableName,
-            programRuleVariableSourceType: 'DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE',
+            programRuleVariableSourceType: variableSourceTypes.DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE,
             valueType: 'TEXT',
             programStageId: variableNameParts[0],
             dataElementId: variableNameParts[1],
@@ -63,7 +64,7 @@ function getDirectAddressedVariable(variableWithCurls, programId) {
         newVariableObject = {
             id: variableName,
             displayName: variableName,
-            programRuleVariableSourceType: 'TEI_ATTRIBUTE',
+            programRuleVariableSourceType: variableSourceTypes.TEI_ATTRIBUTE,
             valueType: 'TEXT',
             trackedEntityAttributeId: variableNameParts[0],
             programId,

--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/getRulesAndVariablesFromIndicators.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/getRulesAndVariablesFromIndicators.js
@@ -52,8 +52,9 @@ function getDirectAddressedVariable(variableWithCurls, programId) {
         newVariableObject = {
             id: variableName,
             displayName: variableName,
-            programRuleVariableSourceType: 'DATAELEMENT_CURRENT_EVENT',
+            programRuleVariableSourceType: 'DATAELEMENT_NEWEST_EVENT_PROGRAM_STAGE',
             valueType: 'TEXT',
+            programStageId: variableNameParts[0],
             dataElementId: variableNameParts[1],
             programId,
         };

--- a/src/core_modules/capture-core/rules/__tests__/ruleEffectsForEventProgram.test.js
+++ b/src/core_modules/capture-core/rules/__tests__/ruleEffectsForEventProgram.test.js
@@ -77,15 +77,15 @@ describe('Event rules engine', () => {
     describe.each([
         [
             { oZg33kd9taw: 'Female', SWfdB5lX0fk: null },
-            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: NaN }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
+            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: '' }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
         ],
         [
             { oZg33kd9taw: 'Male', SWfdB5lX0fk: null },
-            [{ id: 'SWfdB5lX0fk', targetDataType: rulesEngineEffectTargetDataTypes.DATA_ELEMENT, type: 'HIDEFIELD' }, { displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: NaN }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
+            [{ id: 'SWfdB5lX0fk', targetDataType: rulesEngineEffectTargetDataTypes.DATA_ELEMENT, type: 'HIDEFIELD' }, { displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: '' }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
         ],
         [
             { oZg33kd9taw: null, SWfdB5lX0fk: null },
-            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: NaN }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
+            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: '' }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
         ],
     ])('where field is hidden regarding the gender of the event', (currentEvent, expected) => {
         test(`and given value(s): ${JSON.stringify(currentEvent)}`, () => {
@@ -104,35 +104,35 @@ describe('Event rules engine', () => {
     describe.each([
         [
             { qrur9Dvnyt5: null, GieVkTxp4HH: null, vV9UWAZohSf: null },
-            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: NaN }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
+            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: '' }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
         ],
         [
             { qrur9Dvnyt5: null, GieVkTxp4HH: null, vV9UWAZohSf: 85 },
-            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: Infinity }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
+            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: '' }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
         ],
         [
             { qrur9Dvnyt5: null, GieVkTxp4HH: 180, vV9UWAZohSf: null },
-            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: 0 }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
+            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: '0' }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
         ],
         [
             { qrur9Dvnyt5: null, GieVkTxp4HH: 180, vV9UWAZohSf: 85 },
-            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: 26.234567901234566 }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
+            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: '26.234567901234566' }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
         ],
         [
             { qrur9Dvnyt5: 40, GieVkTxp4HH: null, vV9UWAZohSf: null },
-            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: NaN }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
+            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: '' }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
         ],
         [
             { qrur9Dvnyt5: 40, GieVkTxp4HH: null, vV9UWAZohSf: 85 },
-            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: Infinity }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
+            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: '' }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
         ],
         [
             { qrur9Dvnyt5: 40, GieVkTxp4HH: 180, vV9UWAZohSf: null },
-            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: 0 }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
+            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: '0' }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
         ],
         [
             { qrur9Dvnyt5: 40, GieVkTxp4HH: 180, vV9UWAZohSf: 85 },
-            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: 26.234567901234566 }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
+            [{ displayKeyValuePair: { id: 'x7PaHGvgWY2', key: 'BMI', value: '26.234567901234566' }, id: 'indicators', type: 'DISPLAYKEYVALUEPAIR' }],
         ],
     ])('where BMI is calculated', (currentEvent, expected) => {
         test(`and given value(s): ${JSON.stringify(currentEvent)}`, () => {

--- a/src/core_modules/capture-core/rules/__tests__/rulesEffectsForTrackerProgram.test.js
+++ b/src/core_modules/capture-core/rules/__tests__/rulesEffectsForTrackerProgram.test.js
@@ -40,7 +40,7 @@ test('TEI rules engine effects with functions and effects', () => {
         { type: 'DISPLAYTEXT', id: 'feedback', displayText: { id: 'xIUDr1lRV6N', message: "d2:addDays( '2018-04-20', 100 ) =  2018-07-29" } },
         { type: 'DISPLAYTEXT', id: 'feedback', displayText: { id: 'RXmprywJ0Rb', message: 'd2:floor( 11.5 ) =  11' } },
         { type: 'DISPLAYTEXT', id: 'feedback', displayText: { id: 'cZQngI2IC1a', message: "d2:length( 'dhis2 rocks' ) =  11" } },
-        { type: 'DISPLAYKEYVALUEPAIR', id: 'feedback', displayKeyValuePair: { id: 'qSe8GmlwpgZ', key: "d2:weeksBetween('2020-01-28', V{enrollment_date} ) = ", value: 15 } },
+        { type: 'DISPLAYKEYVALUEPAIR', id: 'feedback', displayKeyValuePair: { id: 'qSe8GmlwpgZ', key: "d2:weeksBetween('2020-01-28', V{enrollment_date} ) = ", value: '15' } },
         { type: 'DISPLAYTEXT', id: 'feedback', displayText: { id: 'Tx4gHcLselM', message: 'd2:oizp( 10000000 ) =  1' } },
         { type: 'DISPLAYTEXT', id: 'feedback', displayText: { id: 'f3MrrcCf1z2', message: 'd2:modulus( 12 , 100 ) =  12' } },
     ]);

--- a/src/core_modules/capture-core/rules/getApplicableRuleEffects.js
+++ b/src/core_modules/capture-core/rules/getApplicableRuleEffects.js
@@ -88,6 +88,9 @@ flattenedResult: boolean = false,
     }
 
     if (currentEvent) {
+        if (!currentEvent.programStageId && stage) {
+            currentEvent.programStageId = stage.id;
+        }
         currentEvent.programStageName = program.stages.get(currentEvent.programStageId)?.untranslatedName;
     }
 


### PR DESCRIPTION
- Renamed `eventDate` -> `occurredAt` to fix behaviour of source type `DATAELEMENT_PREVIOUS_EVENT`.
- Changed parsing of variables appearing as `programStageId.dataElementId` in program indicator expressions.