### PR TITLE
fix: [DHIS2-8613] limit report date of new events to today or earlier

### DIFF
--- a/src/core_modules/capture-core-utils/validators/form/index.js
+++ b/src/core_modules/capture-core-utils/validators/form/index.js
@@ -2,6 +2,7 @@
 export { hasValue } from './compulsory.validator';
 export { isValidDate } from './date.validator';
 export { isValidDateTime } from './dateTime.validator';
+export { isValidNonFutureDate } from './nonFutureDate.validator';
 export { isValidEmail } from './email.validator';
 export { isValidInteger } from './integer.validator';
 export { isValidPositiveInteger } from './integerPositive.validator';

--- a/src/core_modules/capture-core-utils/validators/form/nonFutureDate.validator.js
+++ b/src/core_modules/capture-core-utils/validators/form/nonFutureDate.validator.js
@@ -1,0 +1,10 @@
+// @flow
+import moment from 'moment';
+import { parseDate } from 'capture-core/utils/converters/date';
+
+export const isValidNonFutureDate = (value: string) => {
+    const { isValid, momentDate } = parseDate(value);
+
+    // $FlowFixMe -> if parseDate returns isValid true, there should always be a momentDate
+    return isValid && momentDate.isSameOrBefore(moment());
+};

--- a/src/core_modules/capture-core/components/DataEntries/SingleEventRegistrationEntry/DataEntryWrapper/DataEntry/DataEntry.component.js
+++ b/src/core_modules/capture-core/components/DataEntries/SingleEventRegistrationEntry/DataEntryWrapper/DataEntry/DataEntry.component.js
@@ -11,7 +11,7 @@ import { withDataEntryNotesHandler } from '../../../../DataEntry/dataEntryNotes/
 import { Notes } from '../../../../Notes/Notes.component';
 import { withDataEntryRelationshipsHandler } from '../../../../DataEntry/dataEntryRelationships/withDataEntryRelationshipsHandler';
 import { Relationships } from '../../../../Relationships/Relationships.component';
-import { getEventDateValidatorContainers } from './fieldValidators/eventDate.validatorContainersGetter';
+import { getNoFutureEventDateValidatorContainers } from './fieldValidators/eventDate.validatorContainersGetter';
 import { type RenderFoundation } from '../../../../../metaData';
 import { withMainButton } from './withMainButton';
 import { getNoteValidatorContainers } from './fieldValidators/note.validatorContainersGetter';
@@ -161,7 +161,7 @@ const buildReportDateSettingsFn = () => {
             calendarMaxMoment: moment(),
         }),
         getPropName: () => 'occurredAt',
-        getValidatorContainers: () => getEventDateValidatorContainers(),
+        getValidatorContainers: () => getNoFutureEventDateValidatorContainers(),
         getMeta: () => ({
             placement: placements.TOP,
             section: dataEntrySectionNames.BASICINFO,

--- a/src/core_modules/capture-core/components/DataEntries/SingleEventRegistrationEntry/DataEntryWrapper/DataEntry/DataEntry.component.js
+++ b/src/core_modules/capture-core/components/DataEntries/SingleEventRegistrationEntry/DataEntryWrapper/DataEntry/DataEntry.component.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import { withStyles, withTheme } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
+import moment from 'moment';
 import { type OrgUnit } from 'capture-core-utils/rulesEngine';
 import { DataEntry as DataEntryContainer } from '../../../../DataEntry/DataEntry.container';
 import { withCancelButton } from '../../../../DataEntry/withCancelButton';
@@ -157,6 +158,7 @@ const buildReportDateSettingsFn = () => {
             required: true,
             calendarWidth: props.formHorizontal ? 250 : 350,
             popupAnchorPosition: getCalendarAnchorPosition(props.formHorizontal),
+            calendarMaxMoment: moment(),
         }),
         getPropName: () => 'occurredAt',
         getValidatorContainers: () => getEventDateValidatorContainers(),

--- a/src/core_modules/capture-core/components/DataEntries/SingleEventRegistrationEntry/DataEntryWrapper/DataEntry/fieldValidators/eventDate.validatorContainersGetter.js
+++ b/src/core_modules/capture-core/components/DataEntries/SingleEventRegistrationEntry/DataEntryWrapper/DataEntry/fieldValidators/eventDate.validatorContainersGetter.js
@@ -1,5 +1,5 @@
 // @flow
-import { hasValue } from 'capture-core-utils/validators/form';
+import { hasValue, isValidNonFutureDate } from 'capture-core-utils/validators/form';
 import i18n from '@dhis2/d2-i18n';
 import { isValidDate } from '../../../../../../utils/validators/form';
 
@@ -23,5 +23,14 @@ export const getEventDateValidatorContainers = () => {
             message: i18n.t('Please provide a valid date'),
         },
     ];
+    return validatorContainers;
+};
+
+export const getNoFutureEventDateValidatorContainers = () => {
+    const validatorContainers = getEventDateValidatorContainers();
+    validatorContainers.push({
+        validator: isValidNonFutureDate,
+        message: i18n.t('A future date is not allowed'),
+    });
     return validatorContainers;
 };

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/DataEntry/DataEntry.component.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/DataEntry/DataEntry.component.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { compose } from 'redux';
 import { withStyles, withTheme } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
+import moment from 'moment';
 import { DataEntry as DataEntryContainer } from '../../DataEntry/DataEntry.container';
 import { withDataEntryField } from '../../DataEntry/dataEntryField/withDataEntryField';
 import { withDataEntryNotesHandler } from '../../DataEntry/dataEntryNotes/withDataEntryNotesHandler';
@@ -141,6 +142,7 @@ const buildReportDateSettingsFn = () => {
             required: true,
             calendarWidth: props.formHorizontal ? 250 : 350,
             popupAnchorPosition: getCalendarAnchorPosition(props.formHorizontal),
+            calendarMaxMoment: moment(),
         }),
         getPropName: () => 'occurredAt',
         getValidatorContainers: () => getEventDateValidatorContainers(),

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/DataEntry/DataEntry.component.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/DataEntry/DataEntry.component.js
@@ -8,7 +8,7 @@ import { DataEntry as DataEntryContainer } from '../../DataEntry/DataEntry.conta
 import { withDataEntryField } from '../../DataEntry/dataEntryField/withDataEntryField';
 import { withDataEntryNotesHandler } from '../../DataEntry/dataEntryNotes/withDataEntryNotesHandler';
 import { Notes } from '../../Notes/Notes.component';
-import { getEventDateValidatorContainers } from './fieldValidators/eventDate.validatorContainersGetter';
+import { getNoFutureEventDateValidatorContainers } from './fieldValidators/eventDate.validatorContainersGetter';
 import { type RenderFoundation, type ProgramStage } from '../../../metaData';
 import { getNoteValidatorContainers } from './fieldValidators/note.validatorContainersGetter';
 import {
@@ -145,7 +145,7 @@ const buildReportDateSettingsFn = () => {
             calendarMaxMoment: moment(),
         }),
         getPropName: () => 'occurredAt',
-        getValidatorContainers: () => getEventDateValidatorContainers(),
+        getValidatorContainers: () => getNoFutureEventDateValidatorContainers(),
         getMeta: () => ({
             placement: placements.TOP,
             section: dataEntrySectionNames.BASICINFO,

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/DataEntry/fieldValidators/eventDate.validatorContainersGetter.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/DataEntry/fieldValidators/eventDate.validatorContainersGetter.js
@@ -1,5 +1,5 @@
 // @flow
-import { hasValue } from 'capture-core-utils/validators/form';
+import { hasValue, isValidNonFutureDate } from 'capture-core-utils/validators/form';
 import i18n from '@dhis2/d2-i18n';
 import { isValidDate } from '../../../../utils/validators/form';
 
@@ -23,5 +23,14 @@ export const getEventDateValidatorContainers = () => {
             message: i18n.t('Please provide a valid date'),
         },
     ];
+    return validatorContainers;
+};
+
+export const getNoFutureEventDateValidatorContainers = () => {
+    const validatorContainers = getEventDateValidatorContainers();
+    validatorContainers.push({
+        validator: isValidNonFutureDate,
+        message: i18n.t('A future date is not allowed'),
+    });
     return validatorContainers;
 };

--- a/src/core_modules/capture-core/components/WidgetEventEdit/DataEntry/fieldValidators/eventDate.validatorContainersGetter.js
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/DataEntry/fieldValidators/eventDate.validatorContainersGetter.js
@@ -1,5 +1,5 @@
 // @flow
-import { hasValue } from 'capture-core-utils/validators/form';
+import { hasValue, isValidNonFutureDate } from 'capture-core-utils/validators/form';
 import i18n from '@dhis2/d2-i18n';
 import { isValidDate } from '../../../../utils/validators/form';
 
@@ -22,5 +22,14 @@ export const getEventDateValidatorContainers = () => {
             message: i18n.t('Please provide a valid date'),
         },
     ];
+    return validatorContainers;
+};
+
+export const getNoFutureEventDateValidatorContainers = () => {
+    const validatorContainers = getEventDateValidatorContainers();
+    validatorContainers.push({
+        validator: isValidNonFutureDate,
+        message: i18n.t('A future date is not allowed'),
+    });
     return validatorContainers;
 };

--- a/src/core_modules/capture-core/components/WidgetEventEdit/EditEventDataEntry/EditEventDataEntry.component.js
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/EditEventDataEntry/EditEventDataEntry.component.js
@@ -2,8 +2,9 @@
 import React, { Component } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
+import moment from 'moment';
 import type { OrgUnit } from 'capture-core-utils/rulesEngine';
-import { getEventDateValidatorContainers } from '../DataEntry/fieldValidators/eventDate.validatorContainersGetter';
+import { getNoFutureEventDateValidatorContainers } from '../DataEntry/fieldValidators/eventDate.validatorContainersGetter';
 import type { RenderFoundation } from '../../../metaData';
 import { withMainButton } from '../DataEntry/withMainButton';
 import { withFilterProps } from '../../FormFields/New/HOC/withFilterProps';
@@ -119,9 +120,10 @@ const buildReportDateSettingsFn = () => {
             calendarWidth: 350,
             label: props.formFoundation.getLabel('occurredAt'),
             required: true,
+            calendarMaxMoment: moment(),
         }),
         getPropName: () => 'occurredAt',
-        getValidatorContainers: () => getEventDateValidatorContainers(),
+        getValidatorContainers: () => getNoFutureEventDateValidatorContainers(),
         getMeta: () => ({
             placement: placements.TOP,
             section: dataEntrySectionNames.BASICINFO,


### PR DESCRIPTION
Replacement of https://github.com/dhis2/capture-app/pull/2782.
This version follows the same pattern as was used for restricting enrollment dates.