### PR TITLE
feat: [DHIS2-13285] Preserve view settings when changing org unit

### DIFF
--- a/src/core_modules/capture-core/components/List/OnlineList/OnlineList.component.js
+++ b/src/core_modules/capture-core/components/List/OnlineList/OnlineList.component.js
@@ -62,6 +62,9 @@ const getStyles = (theme: Theme) => ({
     loadingCell: {
         textAlign: 'center',
     },
+    loader: {
+        display: 'inline-block',
+    },
 });
 
 export type Column = {
@@ -96,6 +99,7 @@ type Props = {
         loadingRow: string,
         row: string,
         dataRow: string,
+        loader: string,
     }
 }
 
@@ -216,7 +220,7 @@ class Index extends React.Component<Props> {
                         colSpan={columnsCount}
                         className={classNames(classes.cell, classes.bodyCell, classes.loadingCell)}
                     >
-                        <CircularLoader />
+                        <CircularLoader className={classes.loader} />
                     </Cell>
                 </Row>
             ) : this.renderRows(visibleColumns, columnsCount);

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/ContextProviders/WorkingListsListViewUpdaterContextProvider.component.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/ContextProviders/WorkingListsListViewUpdaterContextProvider.component.js
@@ -12,6 +12,7 @@ export const WorkingListsListViewUpdaterContextProvider = ({
     customUpdateTrigger,
     forceUpdateOnMount,
     dirtyList,
+    loadedOrgUnitId,
     children,
 }: Props) => {
     const listViewUpdaterContextData = useMemo(() => ({
@@ -21,6 +22,7 @@ export const WorkingListsListViewUpdaterContextProvider = ({
         customUpdateTrigger,
         forceUpdateOnMount,
         dirtyList,
+        loadedOrgUnitId,
     }), [
         rowsPerPage,
         currentPage,
@@ -28,6 +30,7 @@ export const WorkingListsListViewUpdaterContextProvider = ({
         customUpdateTrigger,
         forceUpdateOnMount,
         dirtyList,
+        loadedOrgUnitId,
     ]);
 
     return (

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/ContextProviders/workingListsListViewUpdaterContextProvider.types.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/ContextProviders/workingListsListViewUpdaterContextProvider.types.js
@@ -11,4 +11,5 @@ export type Props = $ReadOnly<{|
     forceUpdateOnMount?: boolean,
     dirtyList: boolean,
     children: React$Node,
+    loadedOrgUnitId?: string,
 |}>;

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/WorkingListsContextBuilder.component.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ContextBuilder/WorkingListsContextBuilder.component.js
@@ -71,11 +71,9 @@ export const WorkingListsContextBuilder = (props: Props) => {
 
     const loadedViewContext = useMemo(() => ({
         programId: loadedContextDefined.programIdView,
-        orgUnitId: loadedContextDefined.orgUnitId,
         categories: loadedContextDefined.categories,
     }), [
         loadedContextDefined.programIdView,
-        loadedContextDefined.orgUnitId,
         loadedContextDefined.categories,
     ]);
 
@@ -122,6 +120,7 @@ export const WorkingListsContextBuilder = (props: Props) => {
                         customUpdateTrigger={customUpdateTrigger}
                         forceUpdateOnMount={forceUpdateOnMount}
                         dirtyList={dirtyListStateFirstRunRef.current}
+                        loadedOrgUnitId={loadedContextDefined.orgUnitId}
                     >
                         <WorkingListsListViewBuilderContextProvider
                             updating={updating}

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ListViewLoader/ListViewLoader.component.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ListViewLoader/ListViewLoader.component.js
@@ -7,14 +7,13 @@ import { useIsContextInSync } from './useIsContextInSync';
 import type { Props } from './listViewLoader.types';
 
 const EventListUpdaterWithLoadingIndicator = withErrorMessageHandler()(
-    withLoadingIndicator(() => ({ margin: 10 }))(ListViewUpdater));
+    withLoadingIndicator(() => ({ margin: 10, height: 60 }))(ListViewUpdater));
 
 const hasTemplateChange = (currentTemplate, prevTemplate, viewPreloaded) =>
     (prevTemplate && currentTemplate.id !== prevTemplate.id && !viewPreloaded);
 
 const useCalculateTriggerLoad = ({
     programId,
-    orgUnitId,
     categories,
     loadedViewContext,
     currentTemplate,
@@ -23,7 +22,7 @@ const useCalculateTriggerLoad = ({
     firstRun,
     prevTemplate,
 }) => {
-    const contextInSync = useIsContextInSync(programId, orgUnitId, categories, loadedViewContext);
+    const contextInSync = useIsContextInSync(programId, categories, loadedViewContext);
     let triggerLoad = false;
     if (!contextInSync || hasTemplateChange(currentTemplate, prevTemplate, viewPreloaded) || (dirtyView && firstRun)) {
         triggerLoad = true;
@@ -51,7 +50,6 @@ const useLoadView = ({
     const triggerLoad = useCalculateTriggerLoad({
         programId,
         programStageId,
-        orgUnitId,
         categories,
         loadedViewContext,
         currentTemplate,
@@ -61,7 +59,6 @@ const useLoadView = ({
         prevTemplate: prevTemplateRef.current,
     });
     triggerLoadRef.current = triggerLoad;
-
     const cancelLoadViewIfApplicable = useCallback(() => {
         triggerLoadRef.current && onCancelLoadView && onCancelLoadView();
     }, [onCancelLoadView]);
@@ -69,20 +66,19 @@ const useLoadView = ({
     useEffect(() => {
         prevTemplateRef.current = currentTemplate;
         firstRunRef.current = false;
-
         if (triggerLoad) {
             onLoadView(currentTemplate,
                 { programId, programStageId, orgUnitId, categories },
             );
         }
         return () => cancelLoadViewIfApplicable();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
         triggerLoad,
         onLoadView,
         currentTemplate,
         programId,
         programStageId,
-        orgUnitId,
         categories,
         cancelLoadViewIfApplicable,
     ]);

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ListViewLoader/useIsContextInSync.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ListViewLoader/useIsContextInSync.js
@@ -5,7 +5,6 @@ import type { Categories } from '../workingListsBase.types';
 
 export const useIsContextInSync = (
     programId: string,
-    orgUnitId: string,
     categories?: Categories,
     viewContext: ?Object,
 ) => useMemo(() => {
@@ -15,14 +14,12 @@ export const useIsContextInSync = (
 
     const currentSelections = {
         programId,
-        orgUnitId,
         categories,
     };
 
     return isSelectionsEqual(currentSelections, viewContext);
 }, [
     programId,
-    orgUnitId,
     categories,
     viewContext,
 ]);

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ListViewUpdater/ListViewUpdater.component.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/ListViewUpdater/ListViewUpdater.component.js
@@ -2,10 +2,14 @@
 import React, { useEffect, useRef, useContext } from 'react';
 import log from 'loglevel';
 import { errorCreator } from 'capture-core-utils';
+import { withLoadingIndicator } from '../../../../HOC';
 import { ListViewUpdaterContext } from '../workingListsBase.context';
 import { ListViewBuilder } from '../ListViewBuilder';
 import { areFiltersEqual } from '../utils';
 import type { Props } from './listViewUpdater.types';
+
+const ListViewBuilderWithLoadingIndicator = withLoadingIndicator(() => ({ margin: 10, height: 60 }))(ListViewBuilder);
+
 
 const useUpdateListMemoize = (value) => {
     const [filters, ...rest] = value;
@@ -60,9 +64,13 @@ export const ListViewUpdater = (props: Props) => {
         customUpdateTrigger,
         forceUpdateOnMount,
         dirtyList,
+        loadedOrgUnitId,
     } = context;
 
-    const forceFirstRunUpdateRef = useRef((forceUpdateOnMount || dirtyList) && !viewLoadedOnFirstRun);
+    const forceFirstRunUpdateRef = useRef(
+        (forceUpdateOnMount || dirtyList || loadedOrgUnitId !== orgUnitId) &&
+        !viewLoadedOnFirstRun,
+    );
 
     if (!currentPage || !rowsPerPage) {
         log.error(
@@ -71,16 +79,23 @@ export const ListViewUpdater = (props: Props) => {
         throw Error('currentPage and rowsPerPage needs to be set during list view loading. See console for details');
     }
 
+    const prevOrgUnitIdRef = useRef(loadedOrgUnitId);
+    const { computedPage, resetMode } = prevOrgUnitIdRef.current === orgUnitId ?
+        { computedPage: currentPage, resetMode: false } :
+        { computedPage: 1, resetMode: true };
+    prevOrgUnitIdRef.current = orgUnitId;
+
     useUpdateEffect(() => {
         onUpdateList({
             filters,
             sortById,
             sortByDirection,
-            currentPage,
+            currentPage: computedPage,
             rowsPerPage,
             programId,
             orgUnitId,
             categories,
+            resetMode,
         });
         return () => onCancelUpdateList && onCancelUpdateList();
     }, {
@@ -89,7 +104,7 @@ export const ListViewUpdater = (props: Props) => {
         restDependencies: [
             sortById,
             sortByDirection,
-            currentPage,
+            computedPage,
             rowsPerPage,
             programId,
             orgUnitId,
@@ -101,15 +116,15 @@ export const ListViewUpdater = (props: Props) => {
     });
 
     useEffect(() => () => onCancelUpdateList && onCancelUpdateList(), [onCancelUpdateList]);
-
     return (
-        <ListViewBuilder
+        <ListViewBuilderWithLoadingIndicator
             {...passOnProps}
             filters={filters}
             sortById={sortById}
             sortByDirection={sortByDirection}
-            currentPage={currentPage}
+            currentPage={computedPage}
             rowsPerPage={rowsPerPage}
+            ready={!resetMode}
         />
     );
 };

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/workingListsBase.types.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/workingListsBase.types.js
@@ -86,6 +86,7 @@ export type UpdateList = (data: {
     orgUnitId: string,
     categories?: Categories,
     lastIdDeleted?: string,
+    resetMode: boolean,
 }) => void;
 
 export type ManagerContextData = {|
@@ -124,6 +125,7 @@ export type ListViewUpdaterContextData = {|
     customUpdateTrigger?: any,
     forceUpdateOnMount?: boolean,
     dirtyList: boolean,
+    loadedOrgUnitId?: string,
 |};
 
 export type ListViewBuilderContextData = {|

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/hooks/useWorkingListsCommonStateManagement.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/hooks/useWorkingListsCommonStateManagement.js
@@ -183,15 +183,18 @@ const useView = (
                     workingListsType,
                 },
             )),
-        onUpdateList: (queryArgs: Object, meta: Object) =>
+        onUpdateList: (data: Object, meta: Object) => {
+            const { resetMode, ...queryArgs } = data;
             dispatch(updateList(
                 queryArgs, {
                     ...meta,
                     categoryCombinationId,
                     storeId,
                     workingListsType,
+                    resetMode,
                 },
-            )),
+            ));
+        },
         onCancelLoadView: () => dispatch(initListViewCancel(storeId)),
         onCancelUpdateList: () => dispatch(updateListCancel(storeId)),
         onSortList: (...args) => dispatch(sortList(...args, storeId)),

--- a/src/core_modules/capture-core/reducers/descriptions/workingLists/meta/meta.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/workingLists/meta/meta.reducerDescription.js
@@ -46,6 +46,14 @@ export const workingListsMetaDesc = createReducerDescription({
 
         return newState;
     },
+    [workingListsCommonActionTypes.LIST_UPDATE]: (state, { payload: { storeId, resetMode } }) => (
+        resetMode ? {
+            ...state,
+            [storeId]: {
+                ...state[storeId],
+                currentPage: 1,
+            },
+        } : state),
     [workingListsCommonActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => {
         const newState = { ...state };
         const { storeId, pagingData } = action.payload;

--- a/src/core_modules/capture-core/reducers/descriptions/workingLists/workingLists.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/workingLists/workingLists.reducerDescription.js
@@ -14,6 +14,11 @@ export const workingListsListRecordsDesc = createReducerDescription({
                 return acc;
             }, {}),
     }),
+    [workingListsCommonActionTypes.LIST_UPDATE]: (state, { payload: { storeId, resetMode } }) => (
+        resetMode ? {
+            ...state,
+            [storeId]: {},
+        } : state),
     [workingListsCommonActionTypes.LIST_UPDATE_SUCCESS]: (state, { payload: { storeId, recordContainers } }) => ({
         ...state,
         [storeId]: recordContainers
@@ -323,6 +328,14 @@ export const workingListsDesc = createReducerDescription({
         };
         return newState;
     },
+    [workingListsCommonActionTypes.LIST_UPDATE]: (state, { payload: { storeId, resetMode } }) => (
+        resetMode ? {
+            ...state,
+            [storeId]: {
+                order: [],
+                currentRequest: {},
+            },
+        } : state),
     [workingListsCommonActionTypes.LIST_UPDATE_SUCCESS]: (state, action) => {
         const newState = { ...state };
         const { storeId, recordContainers, request } = action.payload;
@@ -506,14 +519,17 @@ export const workingListsContextDesc = createReducerDescription({
             },
         };
     },
-    [workingListsCommonActionTypes.LIST_UPDATE]: (state, action) => {
-        const { storeId, lastTransaction } = action.payload;
+    [workingListsCommonActionTypes.LIST_UPDATE]: (state, { payload }) => {
+        const { storeId, lastTransaction } = payload;
+        const { orgUnitId } = payload.queryArgs;
+
         return {
             ...state,
             [storeId]: {
                 ...state[storeId],
                 listDataRefreshTimestamp: moment().toISOString(),
                 lastTransactionOnListDataRefresh: lastTransaction,
+                orgUnitId,
             },
         };
     },


### PR DESCRIPTION
[DHIS2-13285](https://jira.dhis2.org/browse/DHIS2-13285)

This PR ensure that changing the org. unit doesn't reset the view settings. Data will be fetched based on the previous view settings (but reset to the first page).