### PR TITLE
chore: jest config update

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+const config = {
+    moduleDirectories: ['core_modules', 'node_modules'],
+};
+
+module.exports = config;


### PR DESCRIPTION
Fixed an issue where jest was using stale code for internal core modules. When importing modules from capture-core, capture-core-utils or capture-ui using the absolute path, jest would get the modules from the ".d2" folder (and ".d2" is only updated when running yarn start or yarn build).