### PR TITLE
chore: [TECH-1345] fix cypress test

### DIFF
--- a/cypress/integration/ScopeSelector.feature
+++ b/cypress/integration/ScopeSelector.feature
@@ -62,11 +62,11 @@ Feature: User uses the ScopeSelector to navigate
     And there should be visible a title with Child Program
     And there should be Child Programme domain forms visible to search with
 
-  # TECH-1345
-  # Scenario: Main page > Having a program preselected, select an org unit which does not contain the program
-  #  Given you land on a main event page with preselected program
-  #  When you select org unit that is incompatible with the already selected program
-  #  Then you can see message on the scope selector
+
+  Scenario: Main page > Having a program preselected, select an org unit which does not contain the program
+    Given you land on a main event page with preselected program
+    When you select org unit that is incompatible with the already selected program
+    Then you can see message on the scope selector
 
   # New Event page
   Scenario: New event page > Landing on the page

--- a/cypress/integration/ScopeSelector/index.js
+++ b/cypress/integration/ScopeSelector/index.js
@@ -378,8 +378,8 @@ And('you see message explaining this is an Event program', () => {
 
 When('you select org unit that is incompatible with the already selected program', () => {
     cy.get('[data-test="capture-ui-input"]')
-        .type('Bombal');
-    cy.contains('Bombali')
+        .type('Biriw');
+    cy.contains('Biriwa')
         .click();
 });
 


### PR DESCRIPTION
Follow up on https://github.com/dhis2/capture-app/pull/2983#discussion_r958359191

My interpretation was wrong here @simonadomnisoru. The problem was that the org unit was already visible of course. Your solution would definitely work, but to simplify it, I changed the test to select an org. unit that is not initially visible. 