### PR TITLE
chore: skip CI release for dependabot PRs

### DIFF
--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -185,7 +185,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build
-    if: "!github.event.push.repository.fork && !contains(github.event.head_commit.message, '[skip ci]')"
+    if: "!github.event.push.repository.fork && !contains(github.event.head_commit.message, '[skip ci]') && github.actor != 'dependabot[bot]'"
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
skip CI release job for dependabot PRs.