### PR TITLE
fix: [DHIS2-13906] variable names with spaces in rules engine

### DIFF
--- a/src/core_modules/capture-core-utils/rulesEngine/services/expressionService/injectVariableValues.js
+++ b/src/core_modules/capture-core-utils/rulesEngine/services/expressionService/injectVariableValues.js
@@ -36,8 +36,7 @@ const preprocessD2FunctionArguments = (expression: string) => {
             .replace('A{', "'")
             .replace('C{', "'")
             .replace('V{', "'")
-            .replace('}', "'")
-            .replace(/ /g, '');
+            .replace('}', "'");
 
         return accExpression.replace(match, processedMatch);
     }, expression);


### PR DESCRIPTION
Fixes a problem where program rule variable names with spaces don't work when used in some d2 functions.