### PR TITLE
fix: [DHIS2-14081] use static style for accessory row in events table

### DIFF
--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/StageDetail.component.js
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/StageDetail.component.js
@@ -247,7 +247,7 @@ const StageDetailPlain = (props: Props) => {
 
         return (
             <DataTableRow>
-                <DataTableCell colSpan={`${headerColumns.length}`}>
+                <DataTableCell staticStyle colSpan={`${headerColumns.length}`}>
                     {renderShowMoreButton()}
                     {renderViewAllButton()}
                     {renderCreateNewButton()}


### PR DESCRIPTION
Implements [DHIS2-14081](https://dhis2.atlassian.net/browse/DHIS2-14081).

- Uses the `DataTableCell` `staticStyle` prop on the "accessory row" in the Stages -> Events table on Enrollment dashboard to prevent hover styles. This row has no `onClick` and is not a data row, so should not have hover styles.