### PR TITLE
fix: [DHIS2-14283] change format of TEA values dispatched to `enrollmentDomain`

### DIFF
--- a/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/EnrollmentPageDefault.container.js
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/EnrollmentPageDefault.container.js
@@ -75,7 +75,9 @@ export const EnrollmentPageDefault = () => {
         history.push(`/enrollmentEventEdit?${buildUrlQueryString({ orgUnitId, eventId })}`);
     };
     const onUpdateTeiAttributeValues = useCallback((updatedAttributeValues, teiDisplayName) => {
-        dispatch(updateEnrollmentAttributeValues(updatedAttributeValues));
+        dispatch(updateEnrollmentAttributeValues(updatedAttributeValues
+            .map(({ attribute, value }) => ({ id: attribute, value }))
+        ));
         dispatch(updateTeiDisplayName(teiDisplayName));
     }, [dispatch]);
 


### PR DESCRIPTION
There is a difference in format between `enrollmentDomain.attributeValues` and `trackedEntityInstance.attributeValues`:
(1) `enrollmentDomain.attributeValues: { id: string, value: any }`
(2) `trackedEntityInstance.attributeValues { attribute: string, value: any }`
The object property names of the second object are those received from the server.
To obtain the first object format the name change `attribute -> id` is done explicitly [here](https://github.com/dhis2/capture-app/blob/9c000efedb234989347cd3fdb0afad55abbe3253/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/useCommonEnrollmentDomainData/useCommonEnrollmentDomainData.js#L47).
I think the reason for doing this change is to make the object rule engine compatible.

When updating profile changes, the new TEA values gets pushed to `enrollmentDomain.attributeValues`.
Before this fix the pushed object had format (2).
This fix changes it to format (1).

An alternative approach to fix this bug would be to decide a common format for both objects.
I think that might be the better long term solution.

Yet another possibility might be to consider removing one of the objects entirely from the redux store?
This depends on whether the objects may or may not have different meaning in different contexts.