### PR TITLE
fix: [DHIS2-15109] eventDate breaks saved working lists

### DIFF
--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/helpers/eventFilters/clientConfigToApiEventFilterQueryCriteriaConverter/convertToEventFilterEventQueryCriteria.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/helpers/eventFilters/clientConfigToApiEventFilterQueryCriteriaConverter/convertToEventFilterEventQueryCriteria.js
@@ -181,7 +181,7 @@ const structureFilters = (apiFilters: Array<Object>, columns: ColumnsForConverte
         dataFilters: [],
     });
 
-const getSortOrder = (sortById: string, sortByDirection: string) => `${sortById === 'occurredAt' ? 'occurredAt' : sortById}:${sortByDirection}`;
+const getSortOrder = (sortById: string, sortByDirection: string) => `${sortById}:${sortByDirection}`;
 
 const getColumnsOrder = (columns: Array<ColumnForConverter>) =>
     columns
@@ -204,7 +204,7 @@ export const convertToEventFilterEventQueryCriteria = ({
         () => typeConvertFilters(filters, columns),
         convertedFilters => structureFilters(convertedFilters, columns),
     )();
-    const displayColumnOrderCriteria = getColumnsOrder([...columns.values()])?.map(column => (column === 'occurredAt' ? 'occurredAt' : column));
+    const displayColumnOrderCriteria = getColumnsOrder([...columns.values()]);
 
     return {
         ...filtersCriteria,

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/helpers/eventFilters/clientConfigToApiEventFilterQueryCriteriaConverter/convertToEventFilterEventQueryCriteria.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/helpers/eventFilters/clientConfigToApiEventFilterQueryCriteriaConverter/convertToEventFilterEventQueryCriteria.js
@@ -181,7 +181,7 @@ const structureFilters = (apiFilters: Array<Object>, columns: ColumnsForConverte
         dataFilters: [],
     });
 
-const getSortOrder = (sortById: string, sortByDirection: string) => `${sortById === 'occurredAt' ? 'eventDate' : sortById}:${sortByDirection}`;
+const getSortOrder = (sortById: string, sortByDirection: string) => `${sortById === 'occurredAt' ? 'occurredAt' : sortById}:${sortByDirection}`;
 
 const getColumnsOrder = (columns: Array<ColumnForConverter>) =>
     columns
@@ -204,7 +204,7 @@ export const convertToEventFilterEventQueryCriteria = ({
         () => typeConvertFilters(filters, columns),
         convertedFilters => structureFilters(convertedFilters, columns),
     )();
-    const displayColumnOrderCriteria = getColumnsOrder([...columns.values()])?.map(column => (column === 'occurredAt' ? 'eventDate' : column));
+    const displayColumnOrderCriteria = getColumnsOrder([...columns.values()])?.map(column => (column === 'occurredAt' ? 'occurredAt' : column));
 
     return {
         ...filtersCriteria,


### PR DESCRIPTION
Hey all,

When upgrading to the new tracker endpoints in 2.38, for some reason, we ended up saving the occurredAt-column in the working lists as eventDate. Not sure if this was a bug in the API at the time, or if it was just a slip up from my side, but it lead to breaking tests now. The API, which would return a status code 200 until now, has changed to return a 400 bad request. 

This PR resolves that we solve both saving correct label in the `eventFilters`-endpoints and ensures correct order-label. 

Steps to reproduce bug:

1. Open `/#/?orgUnitId=DiszpKrYNg8&programId=eBAyeGv0exc`
2. Do any changes (for example changing sort order on the event date)
3. Try to save a working list view

The API should throw an error and the app will crash.