### PR TITLE
chore: non-mandatory dev-tests

### DIFF
--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -146,7 +146,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [cypress-dev]
+    needs: [lint, flow, unit-tests]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
As discussed: change the verify workflow to continue even though the dev-tests fail