### PR TITLE
fix: [DHIS2-13884] remove padding caused by hidden sections

### DIFF
--- a/src/core_modules/capture-core/components/D2Form/D2Form.component.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Form.component.js
@@ -1,18 +1,10 @@
 // @flow
-import React, { type ComponentType } from 'react';
-import { withStyles } from '@material-ui/core';
+import React from 'react';
 import log from 'loglevel';
 import { errorCreator } from 'capture-core-utils';
 import { D2SectionContainer } from './D2Section.container';
 import type { Props, PropsForPureComponent } from './D2Form.types';
 import { type Section } from '../../metaData';
-
-export const styles = () => ({
-    containerCustomForm: {
-        paddingTop: 10,
-        paddingBottom: 10,
-    },
-});
 
 class D2Form extends React.PureComponent<PropsForPureComponent> {
     name: string;
@@ -95,32 +87,28 @@ class D2Form extends React.PureComponent<PropsForPureComponent> {
             key={section.id}
             innerRef={(sectionInstance) => { this.setSectionInstance(sectionInstance, section.id); }}
             sectionMetaData={section}
-            customForm={section.customForm}
             validationStrategy={this.props.formFoundation.validationStrategy}
             formId={this.getFormId()}
             formBuilderId={this.getFormBuilderId(section.id)}
             sectionId={section.id}
+            customForm={section.customForm}
+            applyCustomFormClass={false}
             {...passOnProps}
         />
     )
-    renderVertical = (section: Section, passOnProps: any, classes: Object) => (
-        <div
-            data-test="d2-form-component"
-            className={section.customForm ? classes.containerCustomForm : ''}
+
+    renderVertical = (section: Section, passOnProps: any) => (
+        <D2SectionContainer
             key={section.id}
-        >
-            <D2SectionContainer
-                innerRef={(sectionInstance) => {
-                    this.setSectionInstance(sectionInstance, section.id);
-                }}
-                sectionMetaData={section}
-                validationStrategy={this.props.formFoundation.validationStrategy}
-                formId={this.getFormId()}
-                formBuilderId={this.getFormBuilderId(section.id)}
-                sectionId={section.id}
-                {...passOnProps}
-            />
-        </div>
+            innerRef={(sectionInstance) => { this.setSectionInstance(sectionInstance, section.id); }}
+            sectionMetaData={section}
+            validationStrategy={this.props.formFoundation.validationStrategy}
+            formId={this.getFormId()}
+            formBuilderId={this.getFormBuilderId(section.id)}
+            sectionId={section.id}
+            applyCustomFormClass={!!section.customForm}
+            {...passOnProps}
+        />
     )
 
     render() {
@@ -133,7 +121,7 @@ class D2Form extends React.PureComponent<PropsForPureComponent> {
         } = this.props;
         const metaDataSectionsAsArray = Array.from(formFoundation.sections.entries()).map(entry => entry[1]);
 
-        const sections = metaDataSectionsAsArray.map(section => (passOnProps.formHorizontal ? this.renderHorizontal(section, passOnProps) : this.renderVertical(section, passOnProps, classes)));
+        const sections = metaDataSectionsAsArray.map(section => (passOnProps.formHorizontal ? this.renderHorizontal(section, passOnProps) : this.renderVertical(section, passOnProps)));
 
         return (
             <>
@@ -157,7 +145,7 @@ class D2Form extends React.PureComponent<PropsForPureComponent> {
     }
 }
 
-const D2FormWithRef = (props: Props) => {
+export const D2FormComponent = (props: Props) => {
     const { formRef, ...passOnProps } = props;
 
     const handleRef = (instance) => {
@@ -173,5 +161,3 @@ const D2FormWithRef = (props: Props) => {
         />
     );
 };
-
-export const D2FormComponent: ComponentType<Props> = withStyles(styles)(D2FormWithRef);

--- a/src/core_modules/capture-core/components/D2Form/D2Form.component.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Form.component.js
@@ -91,7 +91,6 @@ class D2Form extends React.PureComponent<PropsForPureComponent> {
             formId={this.getFormId()}
             formBuilderId={this.getFormBuilderId(section.id)}
             sectionId={section.id}
-            customForm={section.customForm}
             applyCustomFormClass={false}
             {...passOnProps}
         />

--- a/src/core_modules/capture-core/components/D2Form/D2Section.component.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Section.component.js
@@ -12,6 +12,10 @@ const getStyles = theme => ({
         backgroundColor: 'white',
         maxWidth: theme.typography.pxToRem(892),
     },
+    containerCustomForm: {
+        paddingTop: 10,
+        paddingBottom: 10,
+    },
 });
 
 type Props = {
@@ -19,8 +23,10 @@ type Props = {
     isHidden?: ?boolean,
     classes: {
         section: string,
+        containerCustomForm: string,
     },
     formHorizontal: ?boolean,
+    applyCustomFormClass: boolean,
     sectionId: string,
     formBuilderId: string,
     formId: string,
@@ -66,12 +72,8 @@ class D2SectionPlain extends React.PureComponent<Props> {
         );
     }
 
-    render() {
-        const { sectionMetaData, isHidden, classes, sectionId, ...passOnProps } = this.props;
-
-        if (isHidden) {
-            return null;
-        }
+    renderSection(sectionProps) {
+        const { sectionMetaData, classes, sectionId, ...passOnProps } = sectionProps;
 
         if (!sectionMetaData.showContainer || this.props.formHorizontal) {
             return (
@@ -104,6 +106,23 @@ class D2SectionPlain extends React.PureComponent<Props> {
                 </Section>
             </div>
         );
+    }
+
+    render() {
+        const { isHidden, applyCustomFormClass, ...passOnProps } = this.props;
+
+        if (isHidden) {
+            return null;
+        }
+
+        return (<div
+            data-test="d2-form-component"
+            className={applyCustomFormClass ? this.props.classes.containerCustomForm : ''}
+        >
+            {
+                this.renderSection(passOnProps)
+            }
+        </div>);
     }
 }
 


### PR DESCRIPTION
Issue: [DHIS2-13884](https://dhis2.atlassian.net/browse/DHIS2-13884)
The padding occurs because every section, hidden or not, is wrapped inside a div.

This pull request solves the problem by moving the enclosing div down the component tree, to the point right after the sections' check for emptiness is made.

[DHIS2-13884]: https://dhis2.atlassian.net/browse/DHIS2-13884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ