### PR TITLE
fix: [DHIS2-11345] support newline in program rule expressions

### DIFF
--- a/packages/rules-engine/src/d2Functions/getD2Functions.js
+++ b/packages/rules-engine/src/d2Functions/getD2Functions.js
@@ -186,7 +186,7 @@ export const getD2Functions = ({
     },
     length: {
         parameters: 1,
-        execute: (params: any) => String(params[0]).length,
+        execute: (params: any) => String(params[0]).replace(/\n/g, '').length,
     },
     inOrgUnitGroup: {
         parameters: 1,

--- a/packages/rules-engine/src/services/expressionService/executeExpression.js
+++ b/packages/rules-engine/src/services/expressionService/executeExpression.js
@@ -10,8 +10,9 @@ import type { ExecuteExpressionInput, ErrorHandler, ExpressionSet, DhisFunctions
  * @returns {*}
  */
 function evaluate(code) {
+    const codeWithNewline = code.replace(/\n/g, '\\n');
     // eslint-disable-next-line no-new-func
-    const func = new Function(`"use strict";return ${code}`);
+    const func = new Function(`"use strict";return ${codeWithNewline}`);
     return func();
 }
 


### PR DESCRIPTION
Jira issue: [DHIS2-11345](https://dhis2.atlassian.net/browse/DHIS2-11345)

Replaces `\n` with `\\n` in expression string before evaluating it.
Also not counting newline characters when getting string length with `d2:length`.