### PR TITLE
fix: [DHIS2-15342] program stage WL trackedEntities request

### DIFF
--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getEventListData/getEventListData.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getEventListData/getEventListData.js
@@ -70,10 +70,9 @@ export const getEventListData = async (
         params: queryArgsEvents,
     });
 
-    const trackedEntityIds = apiEvents.reduce(
-        (acc, apiEvent) => (acc.includes(apiEvent.trackedEntity) ? acc : `${acc};${apiEvent.trackedEntity}`),
-        '',
-    );
+    const trackedEntityIds = apiEvents
+        .reduce((acc, { trackedEntity }) => (acc.includes(trackedEntity) ? acc : [...acc, trackedEntity]), [])
+        .join(';');
 
     const { resource: resourceTEIs, queryArgs: queryArgsTEIs } = {
         resource: 'tracker/trackedEntities',


### PR DESCRIPTION
The solution was to sanitize the `trackedEntityIds` by removing the first `;`. The PR also fixed the [Cypress tests](https://github.com/dhis2/capture-app/wiki/Pull-Request-Guidelines#cypress-tests-to-follow-up-on-the-tests-are-commented-out-from-our-code-base) related to the Program stage WL