### PR TITLE
ci: skip cypress for translations

### DIFF
--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -95,7 +95,7 @@ jobs:
   instance-version:
     runs-on: ubuntu-latest
     needs: [lint, flow, unit-tests]
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: "!(startsWith(github.event.head_commit.message, 'fix(translations)') && github.actor == 'dhis2-bot') && !contains(github.event.head_commit.message, '[skip ci]')"
     outputs:
       version: ${{ steps.instance-version.outputs.version }}
     steps:
@@ -109,7 +109,6 @@ jobs:
   cypress-dev:
     runs-on: ubuntu-latest
     needs: instance-version
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     container: cypress/browsers:node14.7.0-chrome84
     strategy:
       # when one test fails, DO NOT cancel the other


### PR DESCRIPTION
Translation-PRs from Transifex are automatically closed when our cypress tests (dev-instance) fails. See: https://github.com/dhis2/capture-app/pulls?q=fix%28translations%29

Until we have a reliable setup I suggest we disable the Cypress tests for these PRs.