### PR TITLE
ci: reduce cypress containers

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,7 +29,7 @@ env:
     BASE_URL_INSTANCES: ${{ secrets.CYPRESS_DHIS2_INSTANCES_BASE_URL }}
     NAME_PATTERN_LEGACY_INSTANCES: ca-test-{version}
     NAME_PATTERN_DEV_INSTANCE: ca-test-dev
-    CYPRESS_CONTAINERS: 8
+    CYPRESS_CONTAINERS: 5
     TRIGGER_LABELS: e2e-tests, testing
 
 defaults:

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -117,7 +117,7 @@ jobs:
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4, 5, 6, 7, 8]
+        containers: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Reduce the number of Cypress containers running in CI. Sometimes we see that there are no runners available and it can cause the execution to timeout. By reducing it we should see a higher success rate.