### PR TITLE
fix: [DHIS2-15525] show formNames in the enrollment dashboard

### DIFF
--- a/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/hooks/useProgramMetadata.js
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/hooks/useProgramMetadata.js
@@ -8,7 +8,7 @@ const query = {
         id: ({ id }) => id,
         params: {
             fields:
-            ['programStages[id,repeatable,hideDueDate,programStageDataElements[displayInReports,dataElement[id,valueType,displayName,optionSet[options[code,name]]]'],
+            ['programStages[id,repeatable,hideDueDate,programStageDataElements[displayInReports,dataElement[id,valueType,displayName,displayFormName,optionSet[options[code,name]]]'],
         },
     },
 };

--- a/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/hooks/useProgramStages.js
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/hooks/useProgramStages.js
@@ -32,6 +32,7 @@ export const useProgramStages = (program: Program, programStages?: Array<apiProg
                             acc.push({
                                 id: dataElement.id,
                                 name: dataElement.displayName,
+                                formName: dataElement.displayFormName,
                                 type: dataElement.valueType,
                                 options,
                                 optionSet: dataElement.optionSet,

--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/hooks/useEventList.js
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/hooks/useEventList.js
@@ -113,13 +113,13 @@ const useComputeDataFromEvent = (dataElements: Array<StageDataElement>, events: 
 const useComputeHeaderColumn = (dataElements: Array<StageDataElement>, hideDueDate: boolean, formFoundation: Object) => {
     const headerColumns = useMemo(() => {
         const dataElementHeaders = dataElements.reduce((acc, currDataElement) => {
-            const { id, name, type, optionSet } = currDataElement;
+            const { id, name, formName, type, optionSet } = currDataElement;
             if (!acc.find(item => item.id === id)) {
                 if (isNotValidOptionSet(type, optionSet)) {
                     log.error(errorCreator(MULIT_TEXT_WITH_NO_OPTIONS_SET)({ currDataElement }));
                     return acc;
                 }
-                acc.push({ id, header: name, type, sortDirection: SORT_DIRECTION.DEFAULT });
+                acc.push({ id, header: formName || name, type, sortDirection: SORT_DIRECTION.DEFAULT });
             }
             return acc;
         }, []);

--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/types/common.types.js
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/types/common.types.js
@@ -8,6 +8,7 @@ type StageOptions = {
 export type StageDataElement = {
     id: string,
     name: string,
+    formName: string,
     type: $Keys<typeof dataElementTypes>,
     options?: StageOptions,
     optionSet?: { options: Array<Option> },


### PR DESCRIPTION
[DHIS2-15525](https://dhis2.atlassian.net/browse/DHIS2-15525)

**Tech summary**
- use the dataElement `formNames` in the StagesAndEvents widget. 
- fallback to `name` if`formNames` is undefined
