### PR TITLE
feat: [DHIS2-15299] escape value for attribute filter

### DIFF
--- a/cypress/integration/SearchPage.feature
+++ b/cypress/integration/SearchPage.feature
@@ -37,14 +37,6 @@ Feature: User interacts with Search page
     #     And you click search
     #     Then you should see no results found
 
-    Scenario: Searching using attributes in Tracker Program throws error
-        Given you are on the default search page
-        When you select the search domain Malaria Case diagnosis
-        And you expand the attributes search area
-        And you fill in the first name with values that will return an error
-        And you click search
-        Then there should be an generic error message
-
     Scenario: Searching using attributes in Tracker Program is invalid because no terms typed
         Given you are on the default search page
         When you select the search domain Malaria Case diagnosis

--- a/cypress/integration/SearchPage/index.js
+++ b/cypress/integration/SearchPage/index.js
@@ -151,19 +151,6 @@ When('for Person you fill in values that will return less than 5 results', () =>
         .blur();
 });
 
-When('you fill in the first name with values that will return an error', () => {
-    cy.get('[data-test="form-attributes"]')
-        .find('[data-test="capture-ui-input"]')
-        .first()
-        .type(',,,,')
-        .blur();
-});
-
-Then('there should be an generic error message', () => {
-    cy.get('[data-test="general-purpose-error-mesage"]')
-        .should('exist');
-});
-
 When('you dont fill in any of the values', () => {
     cy.get('[data-test="form-attributes"]')
         .find('[data-test="capture-ui-input"]')

--- a/src/core_modules/capture-core/components/PossibleDuplicatesDialog/possibleDuplicatesDialog.epics.js
+++ b/src/core_modules/capture-core/components/PossibleDuplicatesDialog/possibleDuplicatesDialog.epics.js
@@ -16,6 +16,7 @@ import { convertFormToClient, convertClientToServer } from '../../converters';
 import { getTrackedEntityInstances } from '../../trackedEntityInstances/trackedEntityInstanceRequests';
 import { getAttributesFromScopeId } from '../../metaData/helpers';
 import { searchGroupDuplicateActionTypes } from '../../components/Pages/NewRelationship/RegisterTei';
+import { escapeString } from '../../utils/escapeString';
 
 function getGroupElementsFromScopeId(scopeId: ?string) {
     if (!scopeId) {
@@ -65,7 +66,7 @@ export const loadSearchGroupDuplicatesForReviewEpic = (
                             return null;
                         }
                         const serverValue = element.convertValue(value, pipeD2(convertFormToClient, convertClientToServer));
-                        return `${element.id}:${element.optionSet ? 'eq' : 'like'}:${serverValue}`;
+                        return `${element.id}:${element.optionSet ? 'eq' : 'like'}:${escapeString(serverValue)}`;
                     })
                     .filter(f => f);
 

--- a/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchForm.epics.js
+++ b/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchForm.epics.js
@@ -29,11 +29,12 @@ import {
 } from '../../../actions/navigateToEnrollmentOverview/navigateToEnrollmentOverview.actions';
 import { dataElementConvertFunctions } from './SearchFormElementConverter/SearchFormElementConverter';
 import type { QuerySingleResource } from '../../../utils/api/api.types';
+import { escapeString } from '../../../utils/escapeString';
 
 
 const getFiltersForUniqueIdSearchQuery = (formValues) => {
     const fieldId = Object.keys(formValues)[0];
-    return [`${fieldId}:eq:${formValues[fieldId]}`];
+    return [`${fieldId}:eq:${escapeString(formValues[fieldId])}`];
 };
 
 const searchViaUniqueIdStream = ({

--- a/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchFormElementConverter/SearchFormElementConverter.js
+++ b/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchFormElementConverter/SearchFormElementConverter.js
@@ -2,6 +2,7 @@
 import { pipe as pipeD2 } from '../../../../../capture-core-utils';
 import { convertClientToServer, convertFormToClient } from '../../../../converters';
 import { type DataElement } from '../../../../metaData';
+import { escapeString } from '../../../../utils/escapeString';
 
 type FormValues = { [key: string]: any}
 
@@ -13,7 +14,7 @@ const derivedFilterKeyword = (dataElement) => {
 const convertString = (formValues: string, dataElement: DataElement) => {
     const sanitizedString = formValues.trim();
     const convertedString = (dataElement.convertValue(sanitizedString, pipeD2(convertFormToClient, convertClientToServer)));
-    return `${dataElement.id}:${derivedFilterKeyword(dataElement)}:${convertedString}`;
+    return `${dataElement.id}:${derivedFilterKeyword(dataElement)}:${escapeString(convertedString)}`;
 };
 
 const convertRange = (formValues: FormValues, dataElement: DataElement) => {
@@ -38,7 +39,7 @@ const convertAge = (formValues: FormValues, dataElement: DataElement) => {
 
 const convertFile = (formValues: FormValues, dataElement: DataElement) => {
     const convertedFileName = (dataElement.convertValue(formValues, pipeD2(convertFormToClient, convertClientToServer)));
-    return `${dataElement.id}:${derivedFilterKeyword(dataElement)}:${convertedFileName}`;
+    return `${dataElement.id}:${derivedFilterKeyword(dataElement)}:${escapeString(convertedFileName)}`;
 };
 
 const convertBoolean = (formValues: boolean, dataElement: DataElement) => {

--- a/src/core_modules/capture-core/components/TeiSearch/serverToFilters.js
+++ b/src/core_modules/capture-core/components/TeiSearch/serverToFilters.js
@@ -1,13 +1,14 @@
 // @flow
 import { type DataElement, dataElementTypes } from '../../metaData';
+import { escapeString } from '../../utils/escapeString';
 
 type RangeValue = {
     from: number,
     to: number,
 }
 
-const equals = (value: any, elementId: string) => `${elementId}:eq:${value}`;
-const like = (value: any, elementId: string) => `${elementId}:like:${value}`;
+const equals = (value: any, elementId: string) => `${elementId}:eq:${escapeString(value)}`;
+const like = (value: any, elementId: string) => `${elementId}:like:${escapeString(value)}`;
 
 
 function convertRange(value: RangeValue, elementId: string) {

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/DataElement.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/DataElement.js
@@ -19,7 +19,7 @@ import { convertFormToClient, convertClientToServer } from '../../../../converte
 import { convertOptionSetValue } from '../../../../converters/serverToClient';
 import { buildIcon } from '../../../../metaDataMemoryStoreBuilders/common/helpers';
 import { OptionGroup } from '../../../../metaData/OptionSet/OptionGroup';
-import { getFeatureType, getDataElement, getLabel, isNotValidOptionSet } from '../helpers';
+import { getFeatureType, getDataElement, getLabel, isNotValidOptionSet, escapeString } from '../helpers';
 import type { QuerySingleResource } from '../../../../utils/api/api.types';
 
 const OPTION_SET_NOT_FOUND = 'Optionset not found';
@@ -67,7 +67,7 @@ const buildDataElementUnique = (
                     params: {
                         program: contextProps.programId,
                         orgUnit: orgUnitId,
-                        filter: `${dataElement.id}:EQ:${serverValue}`,
+                        filter: `${dataElement.id}:EQ:${escapeString(serverValue)}`,
                     },
                 });
             } else {
@@ -76,7 +76,7 @@ const buildDataElementUnique = (
                     params: {
                         program: contextProps.programId,
                         ouMode: 'ACCESSIBLE',
-                        filter: `${dataElement.id}:EQ:${serverValue}`,
+                        filter: `${dataElement.id}:EQ:${escapeString(serverValue)}`,
                     },
                 });
             }

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/helpers/escapeString.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/helpers/escapeString.js
@@ -1,0 +1,14 @@
+// @flow
+
+const valueToEscape = Object.freeze({
+    COLON: ':',
+    COMMA: ',',
+    SLASH: '/',
+});
+const escape = '/';
+
+export const escapeString = (value: string): string =>
+    value
+        .replace(new RegExp(valueToEscape.SLASH, 'g'), `${escape}${valueToEscape.SLASH}`)
+        .replace(new RegExp(valueToEscape.COLON, 'g'), `${escape}${valueToEscape.COLON}`)
+        .replace(new RegExp(valueToEscape.COMMA, 'g'), `${escape}${valueToEscape.COMMA}`);

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/helpers/index.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/helpers/index.js
@@ -15,3 +15,4 @@ export {
 export { GEOMETRY, getFeatureType, getDataElement, getLabel } from './geometry';
 export { convertClientToView } from './convertClientToView';
 export { isNotValidOptionSet } from './isNotValidOptionSet';
+export { escapeString } from './escapeString';

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/optionSet/optionSetConverter.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/optionSet/optionSetConverter.js
@@ -3,13 +3,14 @@ import { pipe } from 'capture-core-utils';
 import { convertDataTypeValueToRequest } from './basicDataTypeConverters';
 import { typeof dataElementTypes } from '../../../../../../../metaData';
 import type { OptionSetFilterData } from '../../../../../../ListView';
+import { escapeString } from '../../../../../../../utils/escapeString';
 
 export function convertOptionSet(
     sourceValue: OptionSetFilterData,
     type: $Keys<dataElementTypes>,
 ) {
     return pipe(
-        values => values.map(filterValue => convertDataTypeValueToRequest(filterValue, type)),
+        values => values.map(filterValue => escapeString(convertDataTypeValueToRequest(filterValue, type))),
         values => values.join(';'),
         valueString => `in:${valueString}`,
     )(sourceValue.values);

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/textConverter.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/textConverter.js
@@ -1,6 +1,7 @@
 // @flow
 import type { TextFilterData } from '../../../../../ListView';
+import { escapeString } from '../../../../../../utils/escapeString';
 
 export function convertText(filter: TextFilterData) {
-    return `like:${filter.value}`;
+    return `like:${escapeString(filter.value)}`;
 }

--- a/src/core_modules/capture-core/converters/clientToServer.js
+++ b/src/core_modules/capture-core/converters/clientToServer.js
@@ -4,8 +4,8 @@ import { dataElementTypes } from '../metaData';
 import { stringifyNumber } from './common/stringifyNumber';
 
 type RangeValue = {
-    from: any,
-    to: any,
+    from: number,
+    to: number,
 }
 
 

--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/enrollment/DataElementFactory.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/enrollment/DataElementFactory.js
@@ -21,6 +21,7 @@ import { convertFormToClient, convertClientToServer } from '../../../../converte
 import type { ConstructorInput } from './dataElementFactory.types';
 import type { QuerySingleResource } from '../../../../utils/api/api.types';
 import { isNotValidOptionSet } from '../../../../utils/isNotValidOptionSet';
+import { escapeString } from '../../../../utils/escapeString';
 
 export class DataElementFactory {
     static translationPropertyNames = {
@@ -88,7 +89,7 @@ export class DataElementFactory {
                         params: {
                             program: contextProps.programId,
                             orgUnit: orgUnitId,
-                            filter: `${dataElement.id}:EQ:${serverValue}`,
+                            filter: `${dataElement.id}:EQ:${escapeString(serverValue)}`,
                         },
                     });
                 } else {
@@ -97,7 +98,7 @@ export class DataElementFactory {
                         params: {
                             program: contextProps.programId,
                             ouMode: 'ACCESSIBLE',
-                            filter: `${dataElement.id}:EQ:${serverValue}`,
+                            filter: `${dataElement.id}:EQ:${escapeString(serverValue)}`,
                         },
                     });
                 }

--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/trackedEntityTypes/factory/TrackedEntityType/DataElementFactory.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/trackedEntityTypes/factory/TrackedEntityType/DataElementFactory.js
@@ -19,6 +19,7 @@ import { convertFormToClient, convertClientToServer } from '../../../../converte
 import type { ConstructorInput } from './dataElementFactory.types';
 import type { QuerySingleResource } from '../../../../utils/api/api.types';
 import { isNotValidOptionSet } from '../../../../utils/isNotValidOptionSet';
+import { escapeString } from '../../../../utils/escapeString';
 
 export class DataElementFactory {
     static translationPropertyNames = {
@@ -151,7 +152,7 @@ export class DataElementFactory {
                             params: {
                                 trackedEntityType: contextProps.trackedEntityTypeId,
                                 orgUnit: orgUnitId,
-                                filter: `${dataElement.id}:EQ:${serverValue}`,
+                                filter: `${dataElement.id}:EQ:${escapeString(serverValue)}`,
                             },
                         });
                     } else {
@@ -160,7 +161,7 @@ export class DataElementFactory {
                             params: {
                                 trackedEntityType: contextProps.trackedEntityTypeId,
                                 ouMode: 'ACCESSIBLE',
-                                filter: `${dataElement.id}:EQ:${serverValue}`,
+                                filter: `${dataElement.id}:EQ:${escapeString(serverValue)}`,
                             },
                         });
                     }

--- a/src/core_modules/capture-core/utils/escapeString.js
+++ b/src/core_modules/capture-core/utils/escapeString.js
@@ -1,0 +1,15 @@
+// @flow
+
+const valueToEscape = Object.freeze({
+    COLON: ':',
+    COMMA: ',',
+    SLASH: '/',
+});
+const escape = '/';
+
+export const escapeString = (value: string): string =>
+    value
+        .replace(new RegExp(valueToEscape.SLASH, 'g'), `${escape}${valueToEscape.SLASH}`)
+        .replace(new RegExp(valueToEscape.COLON, 'g'), `${escape}${valueToEscape.COLON}`)
+        .replace(new RegExp(valueToEscape.COMMA, 'g'), `${escape}${valueToEscape.COMMA}`);
+


### PR DESCRIPTION
[DHIS2-15299](https://dhis2.atlassian.net/browse/DHIS2-15299)

**Tech summary**
Escape `,:/` in the value of the filter in the following places:
- working list - download events
- working lists (init and update) 
    - TEIs
    - program stage events
    - single events 
- search
    - by unique id
    - by attributes
    -  possible duplicate
    - from adding a relationship
- validate unique values
    - new enrolment
    - widget profile
    - new TET