### PR TITLE
feat: [DHIS2-15830] Add orgUnitId and programId to plugin context

### DIFF
--- a/src/core_modules/capture-core/components/D2Form/FormFieldPlugin/FormFieldPlugin.container.js
+++ b/src/core_modules/capture-core/components/D2Form/FormFieldPlugin/FormFieldPlugin.container.js
@@ -6,11 +6,13 @@ import { usePluginMessages } from './hooks/usePluginMessages';
 import { usePluginCallbacks } from './hooks/usePluginCallbacks';
 import { usePluginValues } from './hooks/usePluginValues';
 import { formatPluginConfig } from './formatPluginConfig';
+import { useLocationQuery } from '../../../utils/routing';
 
 export const FormFieldPlugin = (props: ContainerProps) => {
     const { pluginSource, fieldsMetadata, formId, onUpdateField, pluginContext } = props;
     const metadataByPluginId = useMemo(() => Object.fromEntries(fieldsMetadata), [fieldsMetadata]);
     const configuredPluginIds = useMemo(() => Object.keys(metadataByPluginId), [metadataByPluginId]);
+    const { programId, orgUnitId } = useLocationQuery();
 
     // Plugin related functionality and feedback
     const { pluginValues } = usePluginValues(formId, metadataByPluginId, pluginContext);
@@ -39,6 +41,8 @@ export const FormFieldPlugin = (props: ContainerProps) => {
 
     return (
         <FormFieldPluginComponent
+            orgUnitId={orgUnitId}
+            programId={programId}
             pluginSource={pluginSource}
             fieldsMetadata={formattedMetadata}
             values={pluginValues}
@@ -50,3 +54,4 @@ export const FormFieldPlugin = (props: ContainerProps) => {
         />
     );
 };
+

--- a/src/core_modules/capture-core/components/D2Form/FormFieldPlugin/FormFieldPlugin.container.js
+++ b/src/core_modules/capture-core/components/D2Form/FormFieldPlugin/FormFieldPlugin.container.js
@@ -12,7 +12,7 @@ export const FormFieldPlugin = (props: ContainerProps) => {
     const { pluginSource, fieldsMetadata, formId, onUpdateField, pluginContext } = props;
     const metadataByPluginId = useMemo(() => Object.fromEntries(fieldsMetadata), [fieldsMetadata]);
     const configuredPluginIds = useMemo(() => Object.keys(metadataByPluginId), [metadataByPluginId]);
-    const { programId, orgUnitId } = useLocationQuery();
+    const { orgUnitId } = useLocationQuery();
 
     // Plugin related functionality and feedback
     const { pluginValues } = usePluginValues(formId, metadataByPluginId, pluginContext);
@@ -42,7 +42,6 @@ export const FormFieldPlugin = (props: ContainerProps) => {
     return (
         <FormFieldPluginComponent
             orgUnitId={orgUnitId}
-            programId={programId}
             pluginSource={pluginSource}
             fieldsMetadata={formattedMetadata}
             values={pluginValues}

--- a/src/core_modules/capture-core/components/D2Form/FormFieldPlugin/FormFieldPlugin.types.js
+++ b/src/core_modules/capture-core/components/D2Form/FormFieldPlugin/FormFieldPlugin.types.js
@@ -64,6 +64,8 @@ export type ComponentProps = {|
     fieldsMetadata: MetadataByPluginId,
     formSubmitted: boolean,
     values: { [id: string]: any },
+    orgUnitId: string,
+    programId: string,
     setFieldValue: (SetFieldValueProps) => void,
     errors: { [id: string]: Array<string> },
     warnings: { [id: string]: Array<string> },

--- a/src/core_modules/capture-core/components/D2Form/FormFieldPlugin/FormFieldPlugin.types.js
+++ b/src/core_modules/capture-core/components/D2Form/FormFieldPlugin/FormFieldPlugin.types.js
@@ -65,7 +65,6 @@ export type ComponentProps = {|
     formSubmitted: boolean,
     values: { [id: string]: any },
     orgUnitId: string,
-    programId: string,
     setFieldValue: (SetFieldValueProps) => void,
     errors: { [id: string]: Array<string> },
     warnings: { [id: string]: Array<string> },


### PR DESCRIPTION
Tech summary:
We need to pass in ProgramId and orgUnitId as part of the context for the form field plugin.