### PR TITLE
fix: [TECH-1642] adapt order scenario

### DIFF
--- a/cypress/integration/WorkingLists/TeiWorkingLists/TeiWorkingListsUser.feature
+++ b/cypress/integration/WorkingLists/TeiWorkingLists/TeiWorkingListsUser.feature
@@ -159,9 +159,9 @@ And you apply the current filter
 When you click the last name column header
 Then the sort arrow should indicate ascending order
 And the list should display data ordered ascendingly by last name
-When you click the WHOMCH Smoking column header
+When you click the WHOMCH Hemoglobin value column header
 Then the sort arrow should indicate descending order
-And the list should display data ordered ascendingly by WHOMCH Smoking
+And the list should display data ordered descending by WHOMCH Hemoglobin
 
 @v>=39
 Scenario: The user can remove the program stage filter

--- a/cypress/integration/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/index.js
+++ b/cypress/integration/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/index.js
@@ -345,7 +345,7 @@ When('you click the last name column header', () => {
 
 When('you click the WHOMCH Hemoglobin value column header', () => {
     cy.get('[data-test="dhis2-uicore-tableheadercellaction"]')
-        .eq(9)
+        .last()
         .click()
         .click();
 });

--- a/cypress/integration/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/index.js
+++ b/cypress/integration/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/index.js
@@ -343,9 +343,9 @@ When('you click the last name column header', () => {
         .click();
 });
 
-When('you click the WHOMCH Smoking column header', () => {
+When('you click the WHOMCH Hemoglobin value column header', () => {
     cy.get('[data-test="dhis2-uicore-tableheadercellaction"]')
-        .eq(6)
+        .eq(9)
         .click()
         .click();
 });
@@ -400,10 +400,10 @@ Then('the list should display data ordered ascendingly by last name', () => {
         });
 });
 
-Then('the list should display data ordered ascendingly by WHOMCH Smoking', () => {
+Then('the list should display data ordered descending by WHOMCH Hemoglobin', () => {
     const names = [
-        'Siren',
         'Hertz',
+        'Siren',
     ];
 
     cy.get('[data-test="tei-working-lists"]')


### PR DESCRIPTION
[TECH-1642](https://dhis2.atlassian.net/browse/TECH-1642)

**Tech summary**
Small change to fix the `While in a program stage working list, the user can sort by both TEA and data elements` cypress test. The rest of the failures on dev are [known errors](https://github.com/dhis2/capture-app/wiki/Pull-Request-Guidelines#cypress-tests-to-follow-up-on-the-tests-are-commented-out-from-our-code-base) and will be fixed by [DHIS2-15814](https://dhis2.atlassian.net/browse/DHIS2-15814).

[TECH-1642]: https://dhis2.atlassian.net/browse/TECH-1642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15814]: https://dhis2.atlassian.net/browse/DHIS2-15814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ