### PR TITLE
fix: search form padding, spacing, borders

### DIFF
--- a/src/core_modules/capture-core/components/IncompleteSelectionsMessage/index.js
+++ b/src/core_modules/capture-core/components/IncompleteSelectionsMessage/index.js
@@ -9,7 +9,7 @@ const StyledPaper = withStyles({
         display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',
-        background: colors.grey300,
+        background: colors.grey200,
         color: colors.grey700,
         padding: '12px 16px',
     },

--- a/src/core_modules/capture-core/components/Pages/MainPage/MainPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/MainPage/MainPage.component.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { useMemo } from 'react';
 import { compose } from 'redux';
-import { spacers } from '@dhis2/ui';
+import { colors, spacers } from '@dhis2/ui';
 import { withStyles } from '@material-ui/core/styles';
 import { WorkingListsType } from './WorkingListsType';
 import type { Props, PlainProps } from './mainPage.types';
@@ -21,13 +21,20 @@ const getStyles = () => ({
         display: 'flex',
         flexWrap: 'wrap',
         gap: spacers.dp16,
+        padding: spacers.dp16,
     },
     half: {
         flex: 1,
     },
     quarter: {
         flex: 0.4,
-        padding: `${spacers.dp12} ${spacers.dp24} ${spacers.dp24} 0`,
+    },
+    searchBoxWrapper: {
+        padding: spacers.dp16,
+        background: colors.white,
+        border: '1px solid',
+        borderColor: colors.grey400,
+        borderRadius: 3,
     },
 });
 
@@ -61,7 +68,7 @@ const MainPageBody = compose(
             </>
         ) : (
             <div className={classes.container}>
-                <div className={classes.half}>
+                <div className={`${classes.half} ${classes.searchBoxWrapper}`}>
                     <SearchBox programId={programId} />
                 </div>
                 <div className={classes.quarter}>

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
@@ -22,14 +22,16 @@ const getStyles = () => ({
     },
     half: {
         flex: 1,
+    },
+    quarter: {
+        flex: 0.4,
+    },
+    searchBoxWrapper: {
         padding: spacers.dp16,
         background: colors.white,
         border: '1px solid',
         borderColor: colors.grey400,
         borderRadius: 3,
-    },
-    quarter: {
-        flex: 0.4,
     },
 });
 
@@ -41,7 +43,7 @@ const SearchPagePlain = ({ programId, orgUnitId, onNavigateToMainPage, classes }
         </Button>
 
         <div className={classes.container}>
-            <div className={classes.half}>
+            <div className={`${classes.half} ${classes.searchBoxWrapper}`}>
                 <SearchBox programId={programId} />
             </div>
             <div className={classes.quarter}>

--- a/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/Search/SearchPage.component.js
@@ -11,15 +11,18 @@ import { TemplateSelector } from '../../TemplateSelector';
 
 const getStyles = () => ({
     backButton: {
-        margin: `${spacers.dp12} 0 0 ${spacers.dp24}`,
+        margin: spacers.dp16,
+        padding: '0',
     },
     container: {
         display: 'flex',
         flexWrap: 'wrap',
+        margin: `0 ${spacers.dp16} 0`,
         gap: spacers.dp16,
     },
     half: {
         flex: 1,
+        padding: spacers.dp16,
         background: colors.white,
         border: '1px solid',
         borderColor: colors.grey400,
@@ -27,15 +30,13 @@ const getStyles = () => ({
     },
     quarter: {
         flex: 0.4,
-        padding: `${spacers.dp12} ${spacers.dp24} ${spacers.dp24} 0`,
     },
 });
 
 const SearchPagePlain = ({ programId, orgUnitId, onNavigateToMainPage, classes }: PlainProps) => (
     <>
         <TopBar programId={programId} orgUnitId={orgUnitId} />
-        <Button dataTest="back-button" className={classes.backButton} onClick={onNavigateToMainPage}>
-            <IconChevronLeft24 />
+        <Button icon={<IconChevronLeft24 />} dataTest="back-button" className={classes.backButton} onClick={onNavigateToMainPage}>
             {i18n.t('Back')}
         </Button>
 

--- a/src/core_modules/capture-core/components/SearchBox/SearchBox.component.js
+++ b/src/core_modules/capture-core/components/SearchBox/SearchBox.component.js
@@ -24,11 +24,10 @@ const getStyles = () => ({
     },
     title: {
         fontWeight: 500,
-        marginBottom: spacers.dp24,
+        marginBottom: spacers.dp16,
     },
     container: {
         color: colors.grey900,
-        padding: '8px 24px 24px 24px',
     },
     innerContainer: {
         display: 'flex',
@@ -36,12 +35,7 @@ const getStyles = () => ({
         gap: spacers.dp16,
     },
     searchFormContainer: {
-        padding: spacers.dp16,
         flex: 1,
-        background: colors.white,
-        border: '1px solid',
-        borderColor: colors.grey400,
-        borderRadius: 3,
     },
     emptySelectionPaperContent: {
         display: 'flex',

--- a/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchForm.component.js
+++ b/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchForm.component.js
@@ -11,8 +11,10 @@ import { searchBoxStatus } from '../../../reducers/descriptions/searchDomain.red
 import { ResultsPageSizeContext } from '../../Pages/shared-contexts';
 
 const getStyles = () => ({
-    searchDomainSelectorSection: {
-        marginBottom: spacers.dp8,
+    searchDomainsContainer: {
+        display: 'flex',
+        flexDirection: 'column',
+        gap: spacers.dp16,
     },
     searchRow: {
         display: 'flex',
@@ -208,6 +210,7 @@ const SearchFormIndex = ({
             tabIndex={-1}
             onKeyPress={handleKeyPress}
             role={'none'}
+            className={classes.searchDomainsContainer}
         >
             {
                 searchGroupsForSelectedScope
@@ -220,7 +223,6 @@ const SearchFormIndex = ({
                             <div key={formId} data-test="form-unique">
                                 <Section
                                     isCollapsed={isSearchSectionCollapsed}
-                                    className={classes.searchDomainSelectorSection}
                                     header={
                                         <SectionHeaderSimple
                                             containerStyle={{ alignItems: 'center' }}
@@ -282,7 +284,6 @@ const SearchFormIndex = ({
                             <div key={formId} data-test="form-attributes">
                                 <Section
                                     isCollapsed={isSearchSectionCollapsed}
-                                    className={classes.searchDomainSelectorSection}
                                     header={
                                         <SectionHeaderSimple
                                             containerStyle={{ alignItems: 'center' }}

--- a/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchForm.component.js
+++ b/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchForm.component.js
@@ -337,7 +337,7 @@ const SearchFormIndex = ({
     },
     [
         classes.searchButtonContainer,
-        classes.searchDomainSelectorSection,
+        classes.searchDomainsContainer,
         classes.searchRowSelectElement,
         classes.searchRow,
         classes.textInfo,


### PR DESCRIPTION
Fixes [DHIS2-16257](https://dhis2.atlassian.net/browse/DHIS2-16257).

This PR adjusts the padding, spacing, and border usage on the search form page. There are multiple instances of the search form / search box, this PR standardises the design.

### Screenshots

Before:

![SCR-20231206-dvm](https://github.com/dhis2/capture-app/assets/33054985/f5a3665c-e04a-45d8-a258-fd1d3e2a934d)
![SCR-20231206-dvu](https://github.com/dhis2/capture-app/assets/33054985/d27f9f0a-903c-4d90-bdd9-2281fcef7931)

![SCR-20231206-dw3](https://github.com/dhis2/capture-app/assets/33054985/215ec8c5-b3d4-43f2-8b6c-6f4978bdbbde)

After:

![SCR-20231206-e6z](https://github.com/dhis2/capture-app/assets/33054985/49b0caad-923d-4915-ba20-cf905ffacf6f)

![SCR-20231206-e7d](https://github.com/dhis2/capture-app/assets/33054985/c86e3dc8-93d5-4538-aa82-31c01b681211)

![SCR-20231206-e6s](https://github.com/dhis2/capture-app/assets/33054985/e69c555a-2a1c-4fe5-92b5-96de014f6974)


[DHIS2-16257]: https://dhis2.atlassian.net/browse/DHIS2-16257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ