### PR TITLE
fix: [DHIS2-15888] multi text element in program rules

### DIFF
--- a/packages/rules-engine/src/commonUtils/normalizeRuleVariable.js
+++ b/packages/rules-engine/src/commonUtils/normalizeRuleVariable.js
@@ -39,6 +39,7 @@ export const normalizeRuleVariable = (data: any, valueType: string) => {
         [typeKeys.AGE]: convertString,
         [typeKeys.TEXT]: convertString,
         [typeKeys.LONG_TEXT]: convertString,
+        [typeKeys.MULTI_TEXT]: convertString,
     };
 
     if (!data && data !== 0 && data !== false) {

--- a/packages/rules-engine/src/constants/typeKeys.const.js
+++ b/packages/rules-engine/src/constants/typeKeys.const.js
@@ -1,6 +1,7 @@
 // @flow
 export const typeKeys = {
     TEXT: 'TEXT',
+    MULTI_TEXT: 'MULTI_TEXT',
     LONG_TEXT: 'LONG_TEXT',
     LETTER: 'LETTER',
     PHONE_NUMBER: 'PHONE_NUMBER',

--- a/packages/rules-engine/src/constants/typeToInterfaceFnName.const.js
+++ b/packages/rules-engine/src/constants/typeToInterfaceFnName.const.js
@@ -3,6 +3,7 @@ import { typeKeys } from './typeKeys.const';
 
 export const mapTypeToInterfaceFnName = {
     [typeKeys.TEXT]: 'convertText',
+    [typeKeys.MULTI_TEXT]: 'convertMultiText',
     [typeKeys.LONG_TEXT]: 'convertLongText',
     [typeKeys.LETTER]: 'convertLetter',
     [typeKeys.PHONE_NUMBER]: 'convertPhoneNumber',

--- a/packages/rules-engine/src/d2Functions/getD2Functions.js
+++ b/packages/rules-engine/src/d2Functions/getD2Functions.js
@@ -296,4 +296,11 @@ export const getD2Functions = ({
             return params[0];
         },
     },
+    multiTextContains: {
+        parameters: 2,
+        execute: (params: any) => {
+            log.warn('multiTextContains not implemented yet');
+            return params[0];
+        },
+    },
 });

--- a/packages/rules-engine/src/d2Functions/getD2Functions.types.js
+++ b/packages/rules-engine/src/d2Functions/getD2Functions.types.js
@@ -55,4 +55,5 @@ export type D2Functions = $ReadOnly<{|
     lastEventDate: D2FunctionConfig,
     addControlDigits: D2FunctionConfig,
     checkControlDigits: D2FunctionConfig,
+    multiTextContains: D2FunctionConfig,
 |}>;

--- a/packages/rules-engine/src/helpers/OptionSetHelper.js
+++ b/packages/rules-engine/src/helpers/OptionSetHelper.js
@@ -1,6 +1,19 @@
+// @flow
+import { typeKeys } from '../constants';
+import type { Option } from '../services/VariableService';
+
 export class OptionSetHelper {
-    static getName(options, key) {
+    static getName(options: Array<Option>, key: any, dataElementValueType: string) {
         if (options) {
+            if (dataElementValueType === typeKeys.MULTI_TEXT) {
+                const values = key.split(',');
+                const optionsName = options.reduce(
+                    (acc, option) => (values.includes(option.code) ? acc.concat(option.displayName) : acc),
+                    [],
+                );
+                return optionsName.length !== 0 ? optionsName.join(',') : key;
+            }
+
             const option = options.find(o => o.code === key);
             return (option && option.displayName) || key;
         }

--- a/packages/rules-engine/src/rulesEngine.types.js
+++ b/packages/rules-engine/src/rulesEngine.types.js
@@ -175,6 +175,7 @@ export type IDateUtils = {|
 
 export type IConvertInputRulesValue = {|
     convertText(value: any): ?string,
+    convertMultiText(value: any): ?string,
     convertLongText(value: any): ?string,
     convertLetter(value: any): ?string,
     convertPhoneNumber(value: any): ?string,
@@ -203,6 +204,7 @@ export type IConvertInputRulesValue = {|
 
 export type IConvertOutputRulesEffectsValue = {|
     convertText(value: string): any,
+    convertMultiText(value: string): any,
     convertLongText(value: string): any,
     convertLetter(value: string): any,
     convertPhoneNumber(value: string): any,

--- a/packages/rules-engine/src/services/VariableService/VariableService.js
+++ b/packages/rules-engine/src/services/VariableService/VariableService.js
@@ -274,7 +274,7 @@ export class VariableService {
     ) {
         const value = this.onProcessValue(rawValue, valueType);
         return (value !== null && useNameForOptionSet && dataElements && dataElements[dataElementId] && dataElements[dataElementId].optionSetId) ?
-            OptionSetHelper.getName(optionSets[dataElements[dataElementId].optionSetId].options, value) :
+            OptionSetHelper.getName(optionSets[dataElements[dataElementId].optionSetId].options, value, dataElements[dataElementId].valueType) :
             value;
     }
 

--- a/packages/rules-engine/src/services/VariableService/index.js
+++ b/packages/rules-engine/src/services/VariableService/index.js
@@ -6,6 +6,7 @@ export type {
     EventsData,
     TEIValues,
     Enrollment,
+    Option,
     OptionSet,
     OptionSets,
     CompareDates,

--- a/packages/rules-engine/src/services/VariableService/variableService.types.js
+++ b/packages/rules-engine/src/services/VariableService/variableService.types.js
@@ -51,7 +51,7 @@ export type Enrollment = {
     +enrollmentId?: string,
 };
 
-type Option = {
+export type Option = {
     id: string,
     code: string,
     displayName: string,

--- a/src/core_modules/capture-core/components/FormFields/New/Fields/MultiSelectField/MultiSelectField.component.js
+++ b/src/core_modules/capture-core/components/FormFields/New/Fields/MultiSelectField/MultiSelectField.component.js
@@ -24,7 +24,7 @@ const styles = theme => ({
 const MULTI_TEXT_SEPARATOR = ',';
 
 const MultiSelectFieldComponentPlain = (props: Props) => {
-    const { onSelect, options, value = '', translations, onFocus, onBlur } = props;
+    const { onSelect, options, value = '', translations, onFocus, onBlur, disabled } = props;
     const [selected, setSelected] = useState([]);
 
     useEffect(() => {
@@ -54,6 +54,7 @@ const MultiSelectFieldComponentPlain = (props: Props) => {
                 filterable
                 filterPlaceholder={translations.filterPlaceholder}
                 noMatchText={translations.noMatchText}
+                disabled={disabled}
             >
                 {options.map(option => (
                     <MultiSelectOption key={option.id} label={option.label} value={option.value} />

--- a/src/core_modules/capture-core/components/FormFields/New/Fields/MultiSelectField/MultiSelectField.types.js
+++ b/src/core_modules/capture-core/components/FormFields/New/Fields/MultiSelectField/MultiSelectField.types.js
@@ -14,6 +14,7 @@ export type Props = {
     onBlur: (value: ?string) => void,
     options: Array<MultiSelectOptionConfig>,
     value?: string,
+    disabled: boolean,
     translations: {
         filterPlaceholder: string,
         noMatchText: string,

--- a/src/core_modules/capture-core/rules/__tests__/postProcessRulesEffects.test.js
+++ b/src/core_modules/capture-core/rules/__tests__/postProcessRulesEffects.test.js
@@ -11,8 +11,10 @@ test('Post process rules effects', () => {
         },
         { type: 'HIDEPROGRAMSTAGE', id: 'PUZaKR0Jh2k' },
         { id: 'SWfdBhglX0fk', type: 'HIDESECTION' },
-        { id: 'w75KJ2mc4zz', type: 'ASSIGN', value: 'true' },
+        { id: 'w75KJ2mc4zz', type: 'ASSIGN', value: 'value1' },
         { id: 'wasdJ2mc4zz', type: 'ASSIGN', value: 'true' },
+        { id: 'pjsdJ2mc4zz', type: 'ASSIGN', value: 'value1,value2' },
+        { id: 'ky6dJ2mc4zz', type: 'ASSIGN', value: 'value1,value2' },
         {
             id: 'w75KJ2mc4zz',
             message: ' true',
@@ -63,7 +65,8 @@ test('Post process rules effects', () => {
                 id: 'optionSet',
                 name: 'optionSet',
                 code: 'optionSet',
-                options: [{ option: { value: false } }],
+                options: [{ value: 'value1' }],
+                dataElement: { type: dataElementTypes.TEXT },
             };
         });
 
@@ -73,8 +76,37 @@ test('Post process rules effects', () => {
             o.type = dataElementTypes.NUMBER;
             o.compulsory = true;
         });
+
+        const dataElement3 = new DataElement((o) => {
+            o.id = 'pjsdJ2mc4zz';
+            o.name = 'dataElement3';
+            o.type = dataElementTypes.MULTI_TEXT;
+            o.optionSet = {
+                id: 'optionSet3',
+                name: 'optionSet3',
+                code: 'optionSet3',
+                options: [{ value: 'value1' }, { value: 'value2' }],
+                dataElement: { type: dataElementTypes.MULTI_TEXT },
+            };
+        });
+
+        const dataElement4 = new DataElement((o) => {
+            o.id = 'ky6dJ2mc4zz';
+            o.name = 'dataElement4';
+            o.type = dataElementTypes.MULTI_TEXT;
+            o.optionSet = {
+                id: 'optionSet4',
+                name: 'optionSet4',
+                code: 'optionSet4',
+                options: [{ value: 'value1' }, { value: 'notAMatch' }],
+                dataElement: { type: dataElementTypes.MULTI_TEXT },
+                useNameForOptionSet: true,
+            };
+        });
         initSection.addElement(dataElement1);
         initSection.addElement(dataElement2);
+        initSection.addElement(dataElement3);
+        initSection.addElement(dataElement4);
     });
 
     const section2 = new Section((initSection) => {
@@ -149,12 +181,22 @@ test('Post process rules effects', () => {
         {
             id: 'w75KJ2mc4zz',
             type: 'ASSIGN',
-            value: null,
+            value: 'value1',
         },
         {
             id: 'wasdJ2mc4zz',
             type: 'ASSIGN',
-            value: 'true',
+            value: null,
+        },
+        {
+            id: 'pjsdJ2mc4zz',
+            type: 'ASSIGN',
+            value: 'value1,value2',
+        },
+        {
+            id: 'ky6dJ2mc4zz',
+            type: 'ASSIGN',
+            value: null,
         },
     ]);
 });

--- a/src/core_modules/capture-core/rules/__tests__/postProcessRulesEffects.test.js
+++ b/src/core_modules/capture-core/rules/__tests__/postProcessRulesEffects.test.js
@@ -12,7 +12,7 @@ test('Post process rules effects', () => {
         { type: 'HIDEPROGRAMSTAGE', id: 'PUZaKR0Jh2k' },
         { id: 'SWfdBhglX0fk', type: 'HIDESECTION' },
         { id: 'w75KJ2mc4zz', type: 'ASSIGN', value: 'value1' },
-        { id: 'wasdJ2mc4zz', type: 'ASSIGN', value: 'true' },
+        { id: 'wasdJ2mc4zz', type: 'ASSIGN', value: 32 },
         { id: 'pjsdJ2mc4zz', type: 'ASSIGN', value: 'value1,value2' },
         { id: 'ky6dJ2mc4zz', type: 'ASSIGN', value: 'value1,value2' },
         {
@@ -186,7 +186,7 @@ test('Post process rules effects', () => {
         {
             id: 'wasdJ2mc4zz',
             type: 'ASSIGN',
-            value: null,
+            value: 32,
         },
         {
             id: 'pjsdJ2mc4zz',

--- a/src/core_modules/capture-core/rules/__tests__/ruleEffectsForEventProgram.test.js
+++ b/src/core_modules/capture-core/rules/__tests__/ruleEffectsForEventProgram.test.js
@@ -426,6 +426,7 @@ describe('Event rules engine', () => {
         ovY6E8BSdto: { id: 'ovY6E8BSdto', valueType: 'TEXT', optionSetId: 'dsgBmIZ0Yrq' },
         Z5z8vFQy0w0: { id: 'Z5z8vFQy0w0', valueType: 'TEXT' },
         TzqawmlPkI5: { id: 'TzqawmlPkI5', valueType: 'TEXT', optionSetId: 'L6eMZDJkCwX' },
+        leqawmlPkI5: { id: 'leqawmlPkI5', valueType: 'MULTI_TEXT', optionSetId: 'Jy0pZDJkCwX' },
         f8j4XDEozvj: { id: 'f8j4XDEozvj', valueType: 'TEXT', optionSetId: 'xD9QOIvNAjw' },
         jBBkFuPKctq: { id: 'jBBkFuPKctq', valueType: 'TEXT', optionSetId: 'T9zjyaIkRqH' },
         A4Fg6jgWauf: { id: 'A4Fg6jgWauf', valueType: 'TEXT', optionSetId: 'w1vUkxq8IOl' },
@@ -716,6 +717,14 @@ describe('Event rules engine', () => {
             useNameForOptionSet: true,
         },
         {
+            id: 'rapvdmYrwLb',
+            dataElementId: 'leqawmlPkI5',
+            displayName: 'HISTORY',
+            programId: 'PNClHaZARtz',
+            programRuleVariableSourceType: variableSourceTypes.DATAELEMENT_CURRENT_EVENT,
+            useNameForOptionSet: true,
+        },
+        {
             id: 'JPIyrAmJapV',
             dataElementId: 'CUbZcLm9LyN',
             displayName: 'HOSPITALISED',
@@ -820,6 +829,31 @@ describe('Event rules engine', () => {
                         { property: 'NAME', locale: 'pt', value: 'Desconhecido' },
                         { property: 'NAME', locale: 'ru', value: 'Неизвестно' },
                     ],
+                },
+            ],
+        },
+        Jy0pZDJkCwX: {
+            id: 'Jy0pZDJkCwX',
+            displayName: 'Yes/No/Unknown',
+            version: 3,
+            valueType: 'MULTI_TEXT',
+            options: [
+                {
+                    id: 'x9yVKkv9koc',
+                    displayName: 'Yes',
+                    code: 'Yes',
+                    translations: [],
+                },
+                {
+                    id: 'R98tI2c6rF5',
+                    displayName: 'No',
+                    code: 'No',
+                    translations: [],
+                },
+                {
+                    id: 'pqxvAQU1z9W',
+                    code: 'Unknown',
+                    translations: [],
                 },
             ],
         },
@@ -984,7 +1018,7 @@ describe('Event rules engine', () => {
             ],
         ],
         [
-            { QQLXTXVidW2: 'Yes' },
+            { QQLXTXVidW2: 'Yes', leqawmlPkI5: 'Yes,No' },
             [
                 {
                     type: 'ASSIGN',
@@ -1059,7 +1093,7 @@ describe('Event rules engine', () => {
             ],
         ],
         [
-            { QQLXTXVidW2: 'No' },
+            { QQLXTXVidW2: 'No', leqawmlPkI5: 'Yes,No' },
             [
                 {
                     type: 'ASSIGN',
@@ -2561,9 +2595,21 @@ describe('Assign effects', () => {
         mjus9Dvnyt5: { id: 'mjus9Dvnyt5', valueType: 'FILE_RESOURCE' },
         fgrr9Dvnyt5: { id: 'fgrr9Dvnyt5', valueType: 'IMAGE' },
         oZ3fhkd9taw: { id: 'oZ3fhkd9taw', valueType: 'UNKNOWN' },
+        hyur9Dvnyt5: { id: 'hyur9Dvnyt5', valueType: 'MULTI_TEXT', optionSetId: 'pC3N9N77UmT' },
     };
     const orgUnit = { id: 'DiszpKrYNg8', name: 'Ngelehun CHC' };
-    const optionSets = {};
+    const optionSets = {
+        pC3N9N77UmT: {
+            id: 'pC3N9N77UmT',
+            displayName: 'Gender',
+            version: 0,
+            valueType: 'MULTI_TEXT',
+            options: [
+                { id: 'rBvjJYbMCVx', displayName: 'Male', code: 'Male', translations: [] },
+                { id: 'Mnp3oXrpAbK', displayName: 'Female', code: 'Female', translations: [] },
+            ],
+            dataElement: { type: 'MULTI_TEXT' },
+        } };
     const currentEvent = {};
 
     test('Assign effect corner cases', () => {
@@ -2675,6 +2721,12 @@ describe('Assign effects', () => {
                         id: 'hjyur9Dvnyt5',
                         data: '-30',
                         dataElementId: 'jhrr9Dvnyt5',
+                        programRuleActionType: 'ASSIGN',
+                    },
+                    {
+                        id: 'juyur9Dvnyt5',
+                        data: "'Male,Female'",
+                        dataElementId: 'hyur9Dvnyt5',
                         programRuleActionType: 'ASSIGN',
                     },
                     {
@@ -2825,6 +2877,12 @@ describe('Assign effects', () => {
                 targetDataType: 'dataElement',
                 type: 'ASSIGN',
                 value: '-30',
+            },
+            {
+                id: 'hyur9Dvnyt5',
+                targetDataType: 'dataElement',
+                type: 'ASSIGN',
+                value: 'Male,Female',
             },
             {
                 id: 'plor9Dvnyt5',

--- a/src/core_modules/capture-core/rules/__tests__/ruleEffectsForEventProgram.test.js
+++ b/src/core_modules/capture-core/rules/__tests__/ruleEffectsForEventProgram.test.js
@@ -2596,6 +2596,7 @@ describe('Assign effects', () => {
         fgrr9Dvnyt5: { id: 'fgrr9Dvnyt5', valueType: 'IMAGE' },
         oZ3fhkd9taw: { id: 'oZ3fhkd9taw', valueType: 'UNKNOWN' },
         hyur9Dvnyt5: { id: 'hyur9Dvnyt5', valueType: 'MULTI_TEXT', optionSetId: 'pC3N9N77UmT' },
+        ght5r9Dnyt5: { id: 'ght5r9Dnyt5', valueType: 'MULTI_TEXT', optionSetId: 'pC3N9N77UmT' },
     };
     const orgUnit = { id: 'DiszpKrYNg8', name: 'Ngelehun CHC' };
     const optionSets = {
@@ -2727,6 +2728,12 @@ describe('Assign effects', () => {
                         id: 'juyur9Dvnyt5',
                         data: "'Male,Female'",
                         dataElementId: 'hyur9Dvnyt5',
+                        programRuleActionType: 'ASSIGN',
+                    },
+                    {
+                        id: 'gty5r9Dvnyt5',
+                        data: "'Female,Male,Female'",
+                        dataElementId: 'ght5r9Dnyt5',
                         programRuleActionType: 'ASSIGN',
                     },
                     {
@@ -2883,6 +2890,12 @@ describe('Assign effects', () => {
                 targetDataType: 'dataElement',
                 type: 'ASSIGN',
                 value: 'Male,Female',
+            },
+            {
+                id: 'ght5r9Dnyt5',
+                targetDataType: 'dataElement',
+                type: 'ASSIGN',
+                value: 'Female,Male',
             },
             {
                 id: 'plor9Dvnyt5',

--- a/src/core_modules/capture-core/rules/__tests__/rulesEffectsForTrackerProgram.test.js
+++ b/src/core_modules/capture-core/rules/__tests__/rulesEffectsForTrackerProgram.test.js
@@ -12,6 +12,7 @@ test('expressions with d2Functions in tracker program', () => {
         Z5z8vFQy0w0: { id: 'Z5z8vFQy0w0', valueType: 'URL' },
         TzqawmlPkI5: { id: 'TzqawmlPkI5', valueType: 'AGE' },
         f8j4XDEozvj: { id: 'f8j4XDEozvj', valueType: 'FILE_RESOURCE' },
+        g6yEXDEozvj: { id: 'g6yEXDEozvj', valueType: 'MULTI_TEXT', optionSetId: 'pC3N9N77UmT' },
         jBBkFuPKctq: { id: 'jBBkFuPKctq', valueType: 'ORGANISATION_UNIT' },
         A4Fg6jgWauf: { id: 'A4Fg6jgWauf', valueType: 'IMAGE' },
         CUbZcLm9LyN: { id: 'CUbZcLm9LyN', valueType: 'USERNAME' },
@@ -242,6 +243,14 @@ test('expressions with d2Functions in tracker program', () => {
                     programRuleActionType: 'DISPLAYTEXT',
                 },
                 {
+                    id: 'ghy5rwfRAVr',
+                    displayContent:
+                        "d2:multiTextContains('multiTextValues', 'searchString')",
+                    data: "d2:multiTextContains('multiTextValues', 'searchString')",
+                    location: 'feedback',
+                    programRuleActionType: 'DISPLAYTEXT',
+                },
+                {
                     id: 'AFkfzcDf4Fs',
                     displayContent: "d2:inOrgUnitGroup('CHC') = ",
                     data: "d2:inOrgUnitGroup('CHC')",
@@ -414,6 +423,7 @@ test('expressions with d2Functions in tracker program', () => {
                 { id: 'khtgyO5SSxu', trackedEntityAttributeId: 'Z5z8vFQy0w0', programRuleActionType: 'HIDEFIELD' },
                 { id: 'hwgyOgy4Sxu', trackedEntityAttributeId: 'TzqawmlPkI5', programRuleActionType: 'HIDEFIELD' },
                 { id: 'hwgyloeSSxu', trackedEntityAttributeId: 'f8j4XDEozvj', programRuleActionType: 'HIDEFIELD' },
+                { id: 'ghyjloeSSxu', trackedEntityAttributeId: 'g6yEXDEozvj', programRuleActionType: 'HIDEFIELD' },
                 { id: 'lkoeO59SSxu', trackedEntityAttributeId: 'jBBkFuPKctq', programRuleActionType: 'HIDEFIELD' },
                 { id: 'poe4O59SSxu', trackedEntityAttributeId: 'A4Fg6jgWauf', programRuleActionType: 'HIDEFIELD' },
                 { id: 'gtyyO59SSxu', trackedEntityAttributeId: 'CUbZcLm9LyN', programRuleActionType: 'HIDEFIELD' },
@@ -454,12 +464,24 @@ test('expressions with d2Functions in tracker program', () => {
             programId: 'IpHINAT79UW',
         },
     ];
-    const optionSets = {};
+    const optionSets = {
+        pC3N9N77UmT: {
+            id: 'pC3N9N77UmT',
+            displayName: 'Gender',
+            version: 0,
+            valueType: 'MULTI_TEXT',
+            options: [
+                { id: 'rBvjJYbMCVx', displayName: 'Male', code: 'Male', translations: [] },
+                { id: 'Mnp3oXrpAbK', displayName: 'Female', code: 'Female', translations: [] },
+            ],
+            dataElement: { type: 'MULTI_TEXT' },
+        } };
     const teiValues = {
         zDhUuAYrxNC: 'value',
         Z5z8vFQy0w0: 'https://www.google.com/',
         TzqawmlPkI5: '30',
         f8j4XDEozvj: 'FILE_RESOURCE',
+        g6yEXDEozvj: 'Male',
         jBBkFuPKctq: 'ORGANISATION_UNIT',
         A4Fg6jgWauf: 'IMAGE',
         CUbZcLm9LyN: 'USERNAME',
@@ -684,6 +706,15 @@ test('expressions with d2Functions in tracker program', () => {
         {
             type: 'DISPLAYTEXT',
             id: 'feedback',
+            displayText: {
+                id: 'ghy5rwfRAVr',
+                message:
+                    "d2:multiTextContains('multiTextValues', 'searchString') multiTextValues",
+            },
+        },
+        {
+            type: 'DISPLAYTEXT',
+            id: 'feedback',
             displayText: { id: 'AFkfzcDf4Fs', message: "d2:inOrgUnitGroup('CHC') =  " },
         },
         {
@@ -817,6 +848,14 @@ test('expressions with d2Functions in tracker program', () => {
             id: 'f8j4XDEozvj',
             targetDataType: 'trackedEntityAttribute',
             type: 'HIDEFIELD',
+        },
+        {
+            content: undefined,
+            type: 'HIDEFIELD',
+            id: 'g6yEXDEozvj',
+            hadValue: true,
+            name: undefined,
+            targetDataType: 'trackedEntityAttribute',
         },
         {
             content: undefined,

--- a/src/core_modules/capture-core/rules/converters/inputConverter.js
+++ b/src/core_modules/capture-core/rules/converters/inputConverter.js
@@ -12,6 +12,7 @@ const convertObjectToString = (value: ?{ name: string }) => (value ? value.name 
 
 export const inputConverter: IConvertInputRulesValue = {
     convertText: convertStringValue,
+    convertMultiText: convertStringValue,
     convertLongText: convertStringValue,
     convertLetter: convertStringValue,
     convertPhoneNumber: convertStringValue,

--- a/src/core_modules/capture-core/rules/converters/outputConverter.js
+++ b/src/core_modules/capture-core/rules/converters/outputConverter.js
@@ -12,7 +12,7 @@ const dateMomentFormat = 'YYYY-MM-DD';
 
 export const outputConverter: IConvertOutputRulesEffectsValue = {
     convertText: (value: string): string => value,
-
+    convertMultiText: (value: string): string => value,
     convertLongText: (value: string): string => value,
     convertLetter: (value: string): string => value,
     convertPhoneNumber: (value: string): string => value,

--- a/src/core_modules/capture-core/rules/converters/outputConverter.js
+++ b/src/core_modules/capture-core/rules/converters/outputConverter.js
@@ -12,7 +12,7 @@ const dateMomentFormat = 'YYYY-MM-DD';
 
 export const outputConverter: IConvertOutputRulesEffectsValue = {
     convertText: (value: string): string => value,
-    convertMultiText: (value: string): string => value,
+    convertMultiText: (value: string): string => [...new Set(value.split(','))].join(','),
     convertLongText: (value: string): string => value,
     convertLetter: (value: string): string => value,
     convertPhoneNumber: (value: string): string => value,

--- a/src/core_modules/capture-core/rules/postProcessRulesEffects.js
+++ b/src/core_modules/capture-core/rules/postProcessRulesEffects.js
@@ -3,15 +3,15 @@ import { effectActions } from '@dhis2/rules-engine-javascript';
 import type { OutputEffect, HideOutputEffect, AssignOutputEffect, OutputEffects } from '@dhis2/rules-engine-javascript';
 import { type RenderFoundation, dataElementTypes } from '../metaData';
 
-const isValidOptionSet = (optionSets, effectValue) => {
-    if (!optionSets.options || effectValue === null || effectValue === '') {
+const isValidOptionSet = (optionSet, effectValue) => {
+    if (!optionSet.options || effectValue === null || effectValue === '') {
         return false;
     }
     // Using == because effect.value is always a string whereas option.value can be a number
-    if (optionSets.dataElementType === dataElementTypes.MULTI_TEXT) {
-        return effectValue.split(',').every(value => optionSets.options.some(option => option.value == value));
+    if (optionSet.dataElementType === dataElementTypes.MULTI_TEXT) {
+        return effectValue.split(',').every(value => optionSet.options.some(option => option.value == value));
     }
-    return optionSets.options.some(option => option.value == effectValue);
+    return optionSet.options.some(option => option.value == effectValue);
 };
 
 const getAssignEffectsBasedOnHideField = (hideEffects: Array<HideOutputEffect>) =>

--- a/src/core_modules/capture-core/rules/postProcessRulesEffects.js
+++ b/src/core_modules/capture-core/rules/postProcessRulesEffects.js
@@ -4,7 +4,7 @@ import type { OutputEffect, HideOutputEffect, AssignOutputEffect, OutputEffects 
 import { type RenderFoundation, dataElementTypes } from '../metaData';
 
 const isValidOptionSet = (optionSets, effectValue) => {
-    if (!optionSets || !optionSets.options || effectValue === null || effectValue === '') {
+    if (!optionSets.options || effectValue === null || effectValue === '') {
         return false;
     }
     // Using == because effect.value is always a string whereas option.value can be a number
@@ -44,7 +44,7 @@ const postProcessAssignEffects = ({
 
     // If a value gets assigned to an option set it must match one of its available options
     assignValueEffects.map((effect) => {
-        if (!isValidOptionSet(optionSets[effect.id], effect.value)) {
+        if (optionSets[effect.id] && !isValidOptionSet(optionSets[effect.id], effect.value)) {
             effect.value = null;
         }
         return effect;

--- a/src/core_modules/capture-core/rules/postProcessRulesEffects.js
+++ b/src/core_modules/capture-core/rules/postProcessRulesEffects.js
@@ -1,7 +1,18 @@
 // @flow
 import { effectActions } from '@dhis2/rules-engine-javascript';
 import type { OutputEffect, HideOutputEffect, AssignOutputEffect, OutputEffects } from '@dhis2/rules-engine-javascript';
-import type { RenderFoundation } from '.././metaData';
+import { type RenderFoundation, dataElementTypes } from '../metaData';
+
+const isValidOptionSet = (optionSets, effectValue) => {
+    if (!optionSets || !optionSets.options || effectValue === null || effectValue === '') {
+        return false;
+    }
+    // Using == because effect.value is always a string whereas option.value can be a number
+    if (optionSets.dataElementType === dataElementTypes.MULTI_TEXT) {
+        return effectValue.split(',').every(value => optionSets.options.some(option => option.value == value));
+    }
+    return optionSets.options.some(option => option.value == effectValue);
+};
 
 const getAssignEffectsBasedOnHideField = (hideEffects: Array<HideOutputEffect>) =>
     hideEffects
@@ -27,14 +38,13 @@ const postProcessAssignEffects = ({
 }) => {
     const optionSets = foundation.getElements().filter(({ optionSet }) => optionSet).reduce((acc, { id, optionSet }) => {
         // $FlowFixMe
-        acc[id] = optionSet.options;
+        acc[id] = { options: optionSet.options, dataElementType: optionSet.dataElement.type };
         return acc;
     }, {});
 
     // If a value gets assigned to an option set it must match one of its available options
     assignValueEffects.map((effect) => {
-        // Using == because effect.value is always a string whereas option.value can be a number
-        if (optionSets[effect.id] && !optionSets[effect.id].some(option => option.value == effect.value)) {
+        if (!isValidOptionSet(optionSets[effect.id], effect.value)) {
             effect.value = null;
         }
         return effect;


### PR DESCRIPTION
[DHIS2-15888](https://dhis2.atlassian.net/browse/DHIS2-15888)

**Tech summary**
- Right now, it is not possible to check specific multi-text values. [DHIS2-16211](https://dhis2.atlassian.net/browse/DHIS2-16211) and [DHIS2-13436](https://dhis2.atlassian.net/browse/DHIS2-13436) must be implemented first.
- I added logic to check that a multi-text field has a value, therefore rules like the one mentioned in the ticket description `A{AllergiesMulti} != ""` should work correctly.
- The same rule actions that can be applied to an element with a single value option can also be applied to an element with multiple value options (Hide, Hide option, Show error, Show warning, Make filed mandatory, Assign a value, etc.).
- To assign multiple values, the expression to be evaluated and assigned must contain valid options codes separated by `,` (for example, a valid expression for the rule mentioned in the ticket is `'Penicillin,Other,Anticonvulsants'`)
- added some unit tests for the new logic

[DHIS2-15888]: https://dhis2.atlassian.net/browse/DHIS2-15888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-16211]: https://dhis2.atlassian.net/browse/DHIS2-16211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-13436]: https://dhis2.atlassian.net/browse/DHIS2-13436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ