### PR TITLE
fix: [DHIS2-17072] Improve verbose rules engine message

### DIFF
--- a/packages/rules-engine/src/RulesEngine.js
+++ b/packages/rules-engine/src/RulesEngine.js
@@ -119,14 +119,17 @@ export class RulesEngine {
                         dhisFunctions,
                         variablesHash,
                         flags: this.flags,
-                        onError: (error, injectedExpression) => log.warn(
-                            `Expression with id rule:${rule.id} could not be run. ` +
+                        onError: (error, injectedExpression, evalutationResult) => log.error(
+                            `Expression with rule id: ${rule.id} could not be run. ` +
                             `Original condition was: ${expression} - ` +
-                            `Evaluation ended up as:${injectedExpression} - error message:${error}`),
-                        onVerboseLog: injectedExpression => console.log(
-                            `Expression with id rule:${rule.id} was run. ` +
+                            `Evaluation ended up as: ${injectedExpression} - ` +
+                            `Result of evaluation was: ${evalutationResult.toString()} - ` +
+                            `error message: ${error}`),
+                        onVerboseLog: (injectedExpression, evalutationResult) => console.log(
+                            `Expression with rule id: ${rule.id} was run. ` +
                             `Original condition was: ${expression} - ` +
-                            `Evaluation ended up as:${injectedExpression}`),
+                            `Evaluation ended up as: ${injectedExpression} - ` +
+                            `Result of evaluation was: ${evalutationResult.toString()}`),
                     });
                 } else {
                     log.warn(`Rule id:'${rule.id}' and name:'${rule.displayName}' ` +
@@ -159,14 +162,17 @@ export class RulesEngine {
                                 dhisFunctions,
                                 variablesHash,
                                 flags: this.flags,
-                                onError: (error, injectedExpression) => log.warn(
-                                    `Expression with id rule: action:${id} could not be run. ` +
+                                onError: (error, injectedExpression, evalutationResult) => log.error(
+                                    `Expression with action id: action:${id} could not be run. ` +
                                     `Original condition was: ${actionExpression} - ` +
-                                    `Evaluation ended up as:${injectedExpression} - error message:${error}`),
-                                onVerboseLog: injectedExpression => log.info(
-                                    `Expression with id rule: action:${id} was run. ` +
+                                    `Evaluation ended up as:${injectedExpression} - ` +
+                                    `Result of evaluation was: ${evalutationResult.toString()} - ` +
+                                    `Error message:${error}`),
+                                onVerboseLog: (injectedExpression, evalutationResult) => console.log(
+                                    `Expression with action id: action:${id} was run. ` +
                                     `Original condition was: ${actionExpression} - ` +
-                                    `Evaluation ended up as: ${injectedExpression}`),
+                                    `Evaluation ended up as: ${injectedExpression} - ` +
+                                    `Result of evaluation was: ${evalutationResult.toString()}`),
                             });
                         }
 

--- a/packages/rules-engine/src/RulesEngine.js
+++ b/packages/rules-engine/src/RulesEngine.js
@@ -123,13 +123,13 @@ export class RulesEngine {
                             `Expression with rule id: ${rule.id} could not be run. ` +
                             `Original condition was: ${expression} - ` +
                             `Evaluation ended up as: ${injectedExpression} - ` +
-                            `Result of evaluation was: ${evalutationResult.toString()} - ` +
+                            `Result of evaluation was: ${evalutationResult?.toString()} - ` +
                             `error message: ${error}`),
                         onVerboseLog: (injectedExpression, evalutationResult) => console.log(
                             `Expression with rule id: ${rule.id} was run. ` +
                             `Original condition was: ${expression} - ` +
                             `Evaluation ended up as: ${injectedExpression} - ` +
-                            `Result of evaluation was: ${evalutationResult.toString()}`),
+                            `Result of evaluation was: ${evalutationResult?.toString()}`),
                     });
                 } else {
                     log.warn(`Rule id:'${rule.id}' and name:'${rule.displayName}' ` +
@@ -166,13 +166,13 @@ export class RulesEngine {
                                     `Expression with action id: action:${id} could not be run. ` +
                                     `Original condition was: ${actionExpression} - ` +
                                     `Evaluation ended up as:${injectedExpression} - ` +
-                                    `Result of evaluation was: ${evalutationResult.toString()} - ` +
+                                    `Result of evaluation was: ${evalutationResult?.toString()} - ` +
                                     `Error message:${error}`),
                                 onVerboseLog: (injectedExpression, evalutationResult) => console.log(
                                     `Expression with action id: action:${id} was run. ` +
                                     `Original condition was: ${actionExpression} - ` +
                                     `Evaluation ended up as: ${injectedExpression} - ` +
-                                    `Result of evaluation was: ${evalutationResult.toString()}`),
+                                    `Result of evaluation was: ${evalutationResult?.toString()}`),
                             });
                         }
 

--- a/packages/rules-engine/src/services/expressionService/executeExpression.js
+++ b/packages/rules-engine/src/services/expressionService/executeExpression.js
@@ -195,10 +195,10 @@ export const executeExpression = ({
         );
 
         if (flags.verbose) {
-            onVerboseLog(expressionWithInjectedVariableValues);
+            onVerboseLog(expressionWithInjectedVariableValues, answer);
         }
     } catch (error) {
-        onError(error.message, expressionWithInjectedVariableValues);
+        onError(error.message, expressionWithInjectedVariableValues, answer);
     }
     return answer;
 };

--- a/packages/rules-engine/src/services/expressionService/executeExpression.types.js
+++ b/packages/rules-engine/src/services/expressionService/executeExpression.types.js
@@ -17,7 +17,7 @@ export type DhisFunctionsInfo = $ReadOnly<{|
     applicableDhisFunctions: Array<InternalD2FunctionConfig>,
 |}>;
 
-export type ErrorHandler = (error: string, expressionWithInjectedVariableValues: string) => void;
+export type ErrorHandler = (error: string, expressionWithInjectedVariableValues: string, evaluationResult: any) => void;
 
 export type ExecuteExpressionInput = $ReadOnly<{|
     expression: string,
@@ -25,5 +25,5 @@ export type ExecuteExpressionInput = $ReadOnly<{|
     variablesHash: RuleVariables,
     flags?: Flag,
     onError: ErrorHandler,
-    onVerboseLog: (expressionWithInjectedVariableValues: string) => void,
+    onVerboseLog: (expressionWithInjectedVariableValues: string, evaluationResult: any) => void,
 |}>;


### PR DESCRIPTION
Improve program rules verbose logging for feature parity.

- Use console.log for both rules expressions and action expressions.

- Print the actual evaluation result.

- Change errors from log.warn to log.error