### PR TITLE
fix: [DHIS2-16393] Use option name in Stages&Events

### DIFF
--- a/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/hooks/useProgramMetadata.js
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/hooks/useProgramMetadata.js
@@ -48,12 +48,10 @@ export const useProgramMetadata = (programId: string) => {
         () => (optionSets ? optionSets.reduce(
             (acc, optionSet) => {
                 acc[optionSet.id] = {
-                    optionSet: {
-                        options: optionSet.options.map(option => ({
-                            name: option.displayName,
-                            code: option.code,
-                        })),
-                    },
+                    options: optionSet.options.map(option => ({
+                        name: option.displayName,
+                        code: option.code,
+                    })),
                 };
                 return acc;
             }, {}) : undefined),

--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/hooks/useEventList.js
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/hooks/useEventList.js
@@ -49,22 +49,11 @@ const getAllFieldsWithValue = (
     dataElements: Array<StageDataElement>,
     dataElementsByType: Array<{type: string, eventId: string, ids: Object}>,
 ) => dataElements
-    .reduce((acc, { id, type, options }) => {
+    .reduce((acc, { id, type }) => {
         const value = dataElementsByType
             .find(item => item.type === type && item.eventId === eventId)?.ids?.[id];
         if (type && value) {
-            if (options) {
-                if (options[value]) {
-                    acc[id] = options[value];
-                } else {
-                    log.error(
-                        errorCreator('Missing value in options')({ id, value, options }),
-                    );
-                    acc[id] = convertServerToClient(value, type);
-                }
-            } else {
-                acc[id] = convertServerToClient(value, type);
-            }
+            acc[id] = convertServerToClient(value, type);
         } else {
             acc[id] = undefined;
         }


### PR DESCRIPTION
Tech-summary:
- Use the option set displayName instead of option set codes in the stages&events tables.

Before:
<img width="1728" alt="image" src="https://github.com/dhis2/capture-app/assets/12842868/65e5dc80-642e-41e7-81d8-c29138242f56">

After:
<img width="1728" alt="image" src="https://github.com/dhis2/capture-app/assets/12842868/e6fb023d-94c4-48b4-bd5d-723d9cae5ffc">
