### PR TITLE
fix: [DHIS2-16394] use option set name in relationship table

### DIFF
--- a/src/core_modules/capture-core/components/Pages/common/TEIRelationshipsWidget/useTEIRelationshipsWidgetMetadata.js
+++ b/src/core_modules/capture-core/components/Pages/common/TEIRelationshipsWidget/useTEIRelationshipsWidgetMetadata.js
@@ -1,4 +1,5 @@
 // @flow
+import log from 'loglevel';
 import { useIndexedDBQuery } from '../../../../utils/reactQueryHelpers';
 import { getUserStorageController, userStores } from '../../../../storageControllers';
 import type { RelationshipTypes } from '../../../WidgetsRelationship';
@@ -6,6 +7,51 @@ import {
     extractElementIdsFromRelationshipTypes,
     formatRelationshipTypes,
 } from '../../../WidgetsRelationship';
+import { errorCreator } from '../../../../../capture-core-utils';
+
+// map through arrays of either dataElements or attributes and fetch optionSet values for each element if they have a optionSet
+const getOptionSetValuesForElement = async (elements: Array<Object>, userStorageController: Object) => {
+    // should be an object with keys of the element ids and value true
+    const optionSetIds = elements
+        .reduce((acc, { optionSet }) => {
+            if (optionSet) {
+                acc[optionSet.id] = true;
+            }
+            return acc;
+        }, {});
+
+    const optionSets = await userStorageController.getAll(userStores.OPTION_SETS, {
+        predicate: ({ id }) => optionSetIds[id],
+        project: ({ id, options }) => ({
+            id,
+            options: options
+                .map(({ code, displayName }) => ({ code, name: displayName })),
+        }),
+    });
+
+    if (!optionSets.length) {
+        return elements;
+    }
+
+    return elements.map((element) => {
+        if (element.optionSet) {
+            const optionSet = optionSets.find(({ id }) => id === element.optionSet.id);
+            if (!optionSet) {
+                log.error(
+                    errorCreator(`OptionSet with id ${element.optionSet.id} not found in indexedDB.`)({ element }));
+                return element;
+            }
+            return {
+                ...element,
+                optionSet: {
+                    ...element.optionSet,
+                    options: optionSet.options,
+                },
+            };
+        }
+        return element;
+    });
+};
 
 const getRelationshipTypes = async (): Promise<RelationshipTypes> => {
     const userStorageController = getUserStorageController();
@@ -15,18 +61,22 @@ const getRelationshipTypes = async (): Promise<RelationshipTypes> => {
 
     const attributes = (await userStorageController.getAll(userStores.TRACKED_ENTITY_ATTRIBUTES, {
         predicate: ({ id }) => attributeIds[id],
-        project: ({ id, valueType, displayName }) => ({ id, valueType, displayName }),
+        project: ({ id, valueType, displayName, optionSet }) => ({ id, valueType, displayName, optionSet }),
     }));
 
     const dataElements = (await userStorageController.getAll(userStores.DATA_ELEMENTS, {
         predicate: ({ id }) => dataElementIds[id],
-        project: ({ id, valueType, displayName }) => ({ id, valueType, displayName }),
+        project: ({ id, valueType, displayName, optionSet }) => ({ id, valueType, displayName, optionSet }),
     }));
+
+    const attributesWithPossibleOptionSet = await getOptionSetValuesForElement(attributes, userStorageController);
+
+    const dataElementsWithPossibleOptionSet = await getOptionSetValuesForElement(dataElements, userStorageController);
 
     return formatRelationshipTypes({
         relationshipTypes: cachedRelationshipTypes,
-        attributes,
-        dataElements,
+        attributes: attributesWithPossibleOptionSet,
+        dataElements: dataElementsWithPossibleOptionSet,
     });
 };
 

--- a/src/core_modules/capture-core/components/WidgetsRelationship/common/RelationshipsWidget/LinkedEntityTableBody.component.js
+++ b/src/core_modules/capture-core/components/WidgetsRelationship/common/RelationshipsWidget/LinkedEntityTableBody.component.js
@@ -8,7 +8,8 @@ import {
     Tooltip,
 } from '@dhis2/ui';
 import i18n from '@dhis2/d2-i18n';
-import { convertServerToClient, convertClientToList } from '../../../../converters';
+import { convertServerToClient } from '../../../../converters';
+import { convert as convertClientToList } from '../../../../converters/clientToList';
 import type { Props, StyledProps } from './linkedEntityTableBody.types';
 import { DeleteRelationship } from './DeleteRelationship';
 
@@ -43,9 +44,9 @@ const LinkedEntityTableBodyPlain = ({
                         >
                             {
                                 // $FlowFixMe flow doesn't like destructering
-                                columns.map(({ id, type, convertValue }) => {
+                                columns.map(({ id, type, options, convertValue }) => {
                                     const value = type ?
-                                        convertClientToList(convertServerToClient(values[id], type), type) :
+                                        convertClientToList(convertServerToClient(values[id], type), type, options) :
                                         convertValue(baseValues?.[id] ?? context.display[id]);
 
                                     return (

--- a/src/core_modules/capture-core/components/WidgetsRelationship/common/RelationshipsWidget/types/GroupedLinkedEntities.types.js
+++ b/src/core_modules/capture-core/components/WidgetsRelationship/common/RelationshipsWidget/types/GroupedLinkedEntities.types.js
@@ -5,12 +5,14 @@ export type MetadataBasedColumn = $ReadOnly<{|
     id: string,
     displayName: string,
     type: $Keys<typeof dataElementTypes>,
+    options?: Array<{ code: string, name: string }>,
 |}>;
 
 export type ManualColumn = $ReadOnly<{|
     id: string,
     displayName: string,
     convertValue: (value: any) => any,
+    options?: Array<{ code: string, name: string }>,
 |}>;
 
 export type TableColumn = MetadataBasedColumn | ManualColumn;

--- a/src/core_modules/capture-core/components/WidgetsRelationship/common/RelationshipsWidget/useRelationshipTypes.js
+++ b/src/core_modules/capture-core/components/WidgetsRelationship/common/RelationshipsWidget/useRelationshipTypes.js
@@ -8,6 +8,12 @@ type Element = {|
     id: string,
     displayName: string,
     valueType: string,
+    optionSet?: {|
+        options: Array<{
+            code: string,
+            name: string,
+        }>,
+    |},
 |};
 
 const relationshipTypesQuery = {
@@ -34,7 +40,7 @@ export const useRelationshipTypes = (cachedRelationshipTypes?: RelationshipTypes
         const filteredAttributeQuery = {
             resource: 'trackedEntityAttributes',
             params: {
-                fields: 'id,displayName,valueType',
+                fields: 'id,displayName,valueType,optionSet[id,options[code,name]]',
                 filter: `id:in:[${Object.keys(attributeIds).join(',')}]`,
                 paging: false,
             },
@@ -43,7 +49,7 @@ export const useRelationshipTypes = (cachedRelationshipTypes?: RelationshipTypes
         const filteredDataElementQuery = {
             resource: 'dataElements',
             params: {
-                fields: 'id,displayName,valueType',
+                fields: 'id,displayName,valueType,optionSet[id,options[code,name]]',
                 filter: `id:in:[${Object.keys(dataElementIds).join(',')}]`,
                 paging: false,
             },

--- a/src/core_modules/capture-core/components/WidgetsRelationship/common/Types/RelationshipTypes.types.js
+++ b/src/core_modules/capture-core/components/WidgetsRelationship/common/Types/RelationshipTypes.types.js
@@ -51,6 +51,7 @@ export type TrackerDataViewEntity = $ReadOnly<{|
     id: string,
     type: $Keys<typeof dataElementTypes>,
     displayName: string,
+    options?: Array<{ code: string, name: string }>,
 |}>;
 
 export type TrackerDataView = $ReadOnly<{|

--- a/src/core_modules/capture-core/components/WidgetsRelationship/common/utils/formatRelationshipTypes.js
+++ b/src/core_modules/capture-core/components/WidgetsRelationship/common/utils/formatRelationshipTypes.js
@@ -11,6 +11,12 @@ type Element = {|
     id: string,
     valueType: string,
     displayName: string,
+    optionSet?: {|
+        options: Array<{
+            code: string,
+            name: string,
+        }>,
+    |},
 |}
 
 type Props = {|
@@ -24,13 +30,21 @@ export const formatRelationshipTypes = ({
     attributes,
     dataElements,
 }: Props): RelationshipTypes => {
-    const attributesById = attributes.reduce((acc, { id, valueType, displayName }) => {
-        acc[id] = { valueType, displayName };
+    const attributesById = attributes.reduce((acc, { id, valueType, displayName, optionSet }) => {
+        acc[id] = {
+            valueType,
+            displayName,
+            options: optionSet?.options,
+        };
         return acc;
     }, {});
 
-    const dataElementsById = dataElements.reduce((acc, { id, valueType, displayName }) => {
-        acc[id] = { valueType, displayName };
+    const dataElementsById = dataElements.reduce((acc, { id, valueType, displayName, optionSet }) => {
+        acc[id] = {
+            valueType,
+            displayName,
+            options: optionSet?.options,
+        };
         return acc;
     }, {});
 

--- a/src/core_modules/capture-core/components/WidgetsRelationship/common/utils/replaceElementIdsWithElement.js
+++ b/src/core_modules/capture-core/components/WidgetsRelationship/common/utils/replaceElementIdsWithElement.js
@@ -16,6 +16,7 @@ type Elements = {|
         id: string,
         displayName: string,
         valueType: $Keys<typeof dataElementTypes>,
+        options?: Array<{ code: string, name: string }>,
     },
 |}
 
@@ -28,6 +29,7 @@ type ElementArray = $ReadOnlyArray<{|
     id: string,
     type: $Keys<typeof dataElementTypes>,
     displayName: string,
+    options?: Array<{ code: string, name: string }>,
 |}>;
 
 export const replaceElementIdsWithElement = (
@@ -64,6 +66,7 @@ export const replaceElementIdsWithElement = (
                 id: elementId,
                 type: element.valueType,
                 displayName: element.displayName,
+                options: element.options,
             };
         })
         .filter(element => element);

--- a/src/core_modules/capture-core/converters/clientToList.js
+++ b/src/core_modules/capture-core/converters/clientToList.js
@@ -142,7 +142,7 @@ export function convertValue(value: any, type: $Keys<typeof dataElementTypes>, d
 export function convert(
     value: any,
     type: $Keys<typeof dataElementTypes>,
-    options: ?Array<{ code: string, name: string}>,
+    options: ?Array<{ code: string, name: string }>,
 ) {
     if (!value && value !== 0 && value !== false) {
         return value;


### PR DESCRIPTION
Tech-summary:
- Use Option name instead of code in the relationships widget table


Before:
![image](https://github.com/dhis2/capture-app/assets/12842868/293842aa-23a7-4205-b603-8c9dfe80dd70)

After:
![image](https://github.com/dhis2/capture-app/assets/12842868/98a104e7-165d-4285-8af2-528b14d6f725)
