### PR TITLE
fix: [DHIS2-17131] schedule dates with format DD-MM-YYYY

### DIFF
--- a/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/helpers/deriveAutoGenerateEvents.js
+++ b/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/helpers/deriveAutoGenerateEvents.js
@@ -1,6 +1,7 @@
 // @flow
 import moment from 'moment';
-import { ProgramStage } from '../../../../../metaData';
+import { dataElementTypes, ProgramStage } from '../../../../../metaData';
+import { convertClientToServer } from '../../../../../converters';
 import { convertCategoryOptionsToServer } from '../../../../../converters/clientToServer';
 
 const ignoreAutoGenerateIfApplicable = (stage, firstStageDuringRegistrationEvent) =>
@@ -58,9 +59,11 @@ export const deriveAutoGenerateEvents = ({
                     : {
                         status: 'SCHEDULE',
                         // for schedule type of events we want to add the standard interval days to the date
-                        scheduledAt: moment(dateToUseInScheduleStatus)
-                            .add(minDaysFromStart, 'days')
-                            .format('YYYY-MM-DD'),
+                        scheduledAt: convertClientToServer(
+                            moment(dateToUseInScheduleStatus)
+                                .add(minDaysFromStart, 'days')
+                                .format('YYYY-MM-DD'),
+                            dataElementTypes.DATE),
                     };
 
                 return {

--- a/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/helpers/deriveAutoGenerateEvents.js
+++ b/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/helpers/deriveAutoGenerateEvents.js
@@ -1,7 +1,6 @@
 // @flow
 import moment from 'moment';
-import { dataElementTypes, ProgramStage } from '../../../../../metaData';
-import { convertClientToServer } from '../../../../../converters';
+import { ProgramStage } from '../../../../../metaData';
 import { convertCategoryOptionsToServer } from '../../../../../converters/clientToServer';
 
 const ignoreAutoGenerateIfApplicable = (stage, firstStageDuringRegistrationEvent) =>
@@ -53,13 +52,13 @@ export const deriveAutoGenerateEvents = ({
                 const eventInfo = openAfterEnrollment
                     ? {
                         status: 'ACTIVE',
-                        occurredAt: convertClientToServer(dateToUseInActiveStatus, dataElementTypes.DATE),
-                        scheduledAt: convertClientToServer(dateToUseInActiveStatus, dataElementTypes.DATE),
+                        occurredAt: dateToUseInActiveStatus,
+                        scheduledAt: dateToUseInActiveStatus,
                     }
                     : {
                         status: 'SCHEDULE',
                         // for schedule type of events we want to add the standard interval days to the date
-                        scheduledAt: moment(convertClientToServer(dateToUseInScheduleStatus, dataElementTypes.DATE))
+                        scheduledAt: moment(dateToUseInScheduleStatus)
                             .add(minDaysFromStart, 'days')
                             .format('YYYY-MM-DD'),
                     };

--- a/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/helpers/deriveAutoGenerateEvents.js
+++ b/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/helpers/deriveAutoGenerateEvents.js
@@ -1,11 +1,8 @@
 // @flow
-import { pipe } from 'capture-core-utils';
 import moment from 'moment';
 import { dataElementTypes, ProgramStage } from '../../../../../metaData';
-import { convertFormToClient, convertClientToServer } from '../../../../../converters';
+import { convertClientToServer } from '../../../../../converters';
 import { convertCategoryOptionsToServer } from '../../../../../converters/clientToServer';
-
-const convertFn = pipe(convertFormToClient, convertClientToServer);
 
 const ignoreAutoGenerateIfApplicable = (stage, firstStageDuringRegistrationEvent) =>
     !firstStageDuringRegistrationEvent || firstStageDuringRegistrationEvent.id !== stage.id;
@@ -56,13 +53,13 @@ export const deriveAutoGenerateEvents = ({
                 const eventInfo = openAfterEnrollment
                     ? {
                         status: 'ACTIVE',
-                        occurredAt: convertFn(dateToUseInActiveStatus, dataElementTypes.DATE),
-                        scheduledAt: convertFn(dateToUseInActiveStatus, dataElementTypes.DATE),
+                        occurredAt: convertClientToServer(dateToUseInActiveStatus, dataElementTypes.DATE),
+                        scheduledAt: convertClientToServer(dateToUseInActiveStatus, dataElementTypes.DATE),
                     }
                     : {
                         status: 'SCHEDULE',
                         // for schedule type of events we want to add the standard interval days to the date
-                        scheduledAt: moment(convertFn(dateToUseInScheduleStatus, dataElementTypes.DATE))
+                        scheduledAt: moment(convertClientToServer(dateToUseInScheduleStatus, dataElementTypes.DATE))
                             .add(minDaysFromStart, 'days')
                             .format('YYYY-MM-DD'),
                     };


### PR DESCRIPTION
[DHIS2-17131](https://dhis2.atlassian.net/browse/DHIS2-17131)

The dates appears to already be on standard system format (yyyy-mm-dd) in `deriveAutoGenerateEvents()`.

[DHIS2-17131]: https://dhis2.atlassian.net/browse/DHIS2-17131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ