### PR TITLE
fix: [DHIS2-17096] show/hide option groups in profile widget

### DIFF
--- a/src/core_modules/capture-core/components/WidgetProfile/WidgetProfile.component.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/WidgetProfile.component.js
@@ -88,7 +88,7 @@ const WidgetProfilePlain = ({
     const error = programsError || trackedEntityInstancesError || userRolesError;
     const clientAttributesWithSubvalues = useClientAttributesWithSubvalues(teiId, program, trackedEntityInstanceAttributes);
     const teiDisplayName = useTeiDisplayName(program, storedAttributeValues, clientAttributesWithSubvalues, teiId);
-    const displayChangelog = supportsChangelog && program.trackedEntityType?.changelogEnabled;
+    const displayChangelog = supportsChangelog && program && program.trackedEntityType?.changelogEnabled;
 
     const displayInListAttributes = useMemo(() => clientAttributesWithSubvalues
         .filter(item => item.displayInList)

--- a/src/core_modules/capture-core/components/WidgetProfile/hooks/useApiProgram.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/hooks/useApiProgram.js
@@ -1,0 +1,39 @@
+// @flow
+import { useMemo } from 'react';
+import { useDataQuery } from '@dhis2/app-runtime';
+
+const fields =
+    'id,version,displayName,displayShortName,description,programType,style,minAttributesRequiredToSearch,enrollmentDateLabel,incidentDateLabel,featureType,selectEnrollmentDatesInFuture,selectIncidentDatesInFuture,displayIncidentDate,' +
+    'access[*],' +
+    'dataEntryForm[id,htmlCode],' +
+    'categoryCombo[id,displayName,isDefault,categories[id,displayName]],' +
+    'programIndicators[id,displayName,code,shortName,style,displayInForm,expression,displayDescription,description,filter,program[id]],' +
+    'programSections[id, displayFormName, sortOrder, trackedEntityAttributes],' +
+    'programRuleVariables[id,displayName,programRuleVariableSourceType,valueType,program[id],programStage[id],dataElement[id],trackedEntityAttribute[id],useCodeForOptionSet],' +
+    'programStages[id,access,autoGenerateEvent,openAfterEnrollment,generatedByEnrollmentDate,reportDateToUse,minDaysFromStart,displayName,description,executionDateLabel,formType,featureType,validationStrategy,enableUserAssignment,style,' +
+        'dataEntryForm[id,htmlCode],' +
+        'programStageSections[id,displayName,displayDescription,sortOrder,dataElements[id]],' +
+        'programStageDataElements[compulsory,displayInReports,renderOptionsAsRadio,allowFutureDate,renderType[*],dataElement[id,displayName,displayShortName,displayFormName,valueType,translations[*],description,optionSetValue,style,optionSet[id,displayName,version,valueType,options[id,displayName,code,style, translations]]]]' +
+    '],' +
+    'programTrackedEntityAttributes[trackedEntityAttribute[id,displayName,displayShortName,displayFormName,description,valueType,optionSetValue,unique,orgunitScope,pattern,translations[property,locale,value],optionSet[id,displayName,version,valueType,options[id,displayName,name,code,style,translations]]],displayInList,searchable,mandatory,renderOptionsAsRadio,allowFutureDate],' +
+    'trackedEntityType[id,access,displayName,allowAuditLog,minAttributesRequiredToSearch,featureType,trackedEntityTypeAttributes[trackedEntityAttribute[id],displayInList,mandatory,searchable],translations[property,locale,value]],' +
+    'userRoles[id,displayName]';
+
+export const useApiProgram = (programId: string) => {
+    const { error, loading, data } = useDataQuery(
+        useMemo(
+            () => ({
+                programs: {
+                    resource: 'programs',
+                    id: programId,
+                    params: {
+                        fields,
+                    },
+                },
+            }),
+            [programId],
+        ),
+    );
+
+    return { error, loading, program: data?.programs };
+};

--- a/src/core_modules/capture-core/components/WidgetProfile/hooks/useOptionGroups.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/hooks/useOptionGroups.js
@@ -1,0 +1,58 @@
+// @flow
+import { useMemo } from 'react';
+import { useApiMetadataQuery } from 'capture-core/utils/reactQueryHelpers';
+
+const createOptionSetToOptionGroupDictionary = ({ optionGroups }) => optionGroups.reduce(
+    (acc, optionGroup) => {
+        const optionSetId = optionGroup.optionSet.id;
+        const transformedOptionGroup = {
+            id: optionGroup.id,
+            options: optionGroup.options.map(option => option.id),
+        };
+        if (acc[optionSetId]) {
+            acc[optionSetId].push(transformedOptionGroup);
+        } else {
+            acc[optionSetId] = [transformedOptionGroup];
+        }
+        return acc;
+    },
+    {},
+);
+
+export const useOptionGroups = (program: any) => {
+    const params = useMemo(() => {
+        if (!program) {
+            return {};
+        }
+
+        const attributes = program.programTrackedEntityAttributes.reduce(
+            (acc, attribute) => {
+                const optionSet = attribute.trackedEntityAttribute.optionSet;
+                if (optionSet) {
+                    acc.push(optionSet.id);
+                }
+                return acc;
+            },
+            [],
+        );
+
+        return {
+            fields: 'id,optionSet,options',
+            filter: `optionSet.id:in:[${attributes.join(',')}]`,
+        };
+    }, [program]);
+
+    const queryKey = ['optionGroups', 'programAttributes', ...(program?.id ? [program.id] : [])];
+    const queryFn = { resource: 'optionGroups', params };
+    const queryOptions = {
+        enabled: Boolean(program),
+        select: createOptionSetToOptionGroupDictionary,
+    };
+    const { data, isLoading, error } = useApiMetadataQuery<any>(queryKey, queryFn, queryOptions);
+
+    return {
+        optionGroups: program ? data : null,
+        loading: isLoading,
+        error,
+    };
+};


### PR DESCRIPTION
[DHIS2-17096](https://dhis2.atlassian.net/browse/DHIS2-17096)
The program object downloaded for the profile widget is missing option group data.

This pull request
1. Downloads the missing data
2. Transforms this data to the expected format
3. Adds the transformed data to the `program` object.

[DHIS2-17096]: https://dhis2.atlassian.net/browse/DHIS2-17096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ