### PR TITLE
fix: [DHIS2-17161] Do not update attribute values from enrollment Widget

### DIFF
--- a/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/useCommonEnrollmentDomainData/useCommonEnrollmentDomainData.js
+++ b/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/useCommonEnrollmentDomainData/useCommonEnrollmentDomainData.js
@@ -23,7 +23,7 @@ export const useCommonEnrollmentDomainData = (teiId: string, enrollmentId: strin
                     id: ({ variables: { teiId: updatedTeiId } }) => updatedTeiId,
                     params: ({ variables: { programId: updatedProgramId } }) => ({
                         program: updatedProgramId,
-                        fields: ['enrollments[*],attributes'],
+                        fields: ['enrollments[*,!attributes],attributes'],
                     }),
                 },
             }),

--- a/src/core_modules/capture-core/components/WidgetEnrollment/hooks/useEnrollment.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollment/hooks/useEnrollment.js
@@ -27,7 +27,7 @@ export const useEnrollment = ({
                     resource: 'tracker/enrollments/',
                     id: ({ variables: { enrollmentId: updatedEnrollmentId } }) => updatedEnrollmentId,
                     params: {
-                        fields: 'enrollment,trackedEntity,program,status,orgUnit,enrolledAt,occurredAt,followUp,deleted,createdBy,updatedBy,attributes,geometry',
+                        fields: 'enrollment,trackedEntity,program,status,orgUnit,enrolledAt,occurredAt,followUp,deleted,createdBy,updatedBy,geometry',
                     },
                 },
             }),


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-17161

Skip attribute values in the api GET request in the enrollment Widget as it should not be needed. 
This way, we don't potentially post stale attribute values to the api.

Also, stopped retrieving enrollment.attributes for the EnrollmentDomain in the Redux store (we use EnrollmentDomain.attributeValues)