### PR TITLE
fix: [DHIS2-16931] Working list hides delete button

### DIFF
--- a/src/core_modules/capture-core/components/ListView/withEndColumnMenu/RowMenu.component.js
+++ b/src/core_modules/capture-core/components/ListView/withEndColumnMenu/RowMenu.component.js
@@ -127,6 +127,7 @@ class Index extends React.Component<Props, State> {
                 {this.state.menuOpen &&
                 <Popper
                     placement="bottom-end"
+                    strategy={'fixed'}
                 >
                     {
                         ({ ref, style, placement }) => (


### PR DESCRIPTION
Tech-summary:
- The button was actually rendered, but it was hidden behind the pagination component. Change strategy to be fixed instead of absolute