### PR TITLE
chore: [DHIS2-17372] optimize Cypress recordings with conditional triggers

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -105,9 +105,9 @@ jobs:
               with:
                   record: ${{ env.SHOULD_RECORD }}
                   parallel: ${{ env.SHOULD_RECORD }}
-                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}-{2}', matrix.versions, github.run_number, matrix.spec-group.id) || '' }}
+                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}-{2}', matrix.versions, github.run_number, matrix.spec-group) || '' }}
                   ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
-                  spec: ${{ matrix.spec_group.tests }}
+                  spec: ${{ join(matrix.spec-group, ',') }}
                   browser: chrome
                   start: yarn start:forCypress
                   wait-on: http://localhost:3000

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -78,6 +78,7 @@ jobs:
                   password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }} # can be removed if maxDHIS2Version has been specified
 
     cypress:
+        if: contains(fromJson(needs.prerequisites.outputs.json-labels), github.event.label.name)
         needs: [prerequisites, setup-matrix]
         runs-on: ubuntu-latest
         strategy:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -103,8 +103,8 @@ jobs:
               with:
                   record: ${{ env.SHOULD_RECORD }}
                   parallel: ${{ env.SHOULD_RECORD }}
-                  group: ${{ env.SHOULD_RECORD && format('e2e-chrome-parallel-{0}', matrix.versions) || '' }}
-                  ci-build-id: ${{ env.SHOULD_RECORD && github.run_id || '' }}
+                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}', matrix.versions) || '' }}
+                  ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
                   browser: chrome
                   start: yarn start:forCypress
                   wait-on: http://localhost:3000

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -78,8 +78,8 @@ jobs:
                   password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }} # can be removed if maxDHIS2Version has been specified
 
     cypress:
-        if: contains(fromJson(needs.prerequisites.outputs.json-labels), github.event.label.name)
         needs: [prerequisites, setup-matrix]
+        if: contains(fromJson(needs.prerequisites.outputs.json-labels), github.event.label.name)
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -103,8 +103,8 @@ jobs:
               with:
                   record: ${{ env.SHOULD_RECORD }}
                   parallel: ${{ env.SHOULD_RECORD }}
-                  group: ${{ env.SHOULD_RECORD && format('e2e-chrome-parallel-{0}', matrix.versions) }}
-                  ci-build-id: ${{ env.SHOULD_RECORD && github.run_id }}
+                  group: ${{ env.SHOULD_RECORD && format('e2e-chrome-parallel-{0}', matrix.versions) || '' }}
+                  ci-build-id: ${{ env.SHOULD_RECORD && github.run_id || '' }}
                   browser: chrome
                   start: yarn start:forCypress
                   wait-on: http://localhost:3000

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -105,9 +105,9 @@ jobs:
               with:
                   record: ${{ env.SHOULD_RECORD }}
                   parallel: ${{ env.SHOULD_RECORD }}
-                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}', matrix.versions, matrix.spec-group.id) || '' }}
+                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}-{2}', matrix.versions, github.run_number, matrix.spec-group.id) || '' }}
                   ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
-                  spec: ${{ join(matrix.spec-group, ',') }}
+                  spec: ${{ matrix.spec_group.tests }}
                   browser: chrome
                   start: yarn start:forCypress
                   wait-on: http://localhost:3000

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -105,7 +105,7 @@ jobs:
               with:
                   record: ${{ env.SHOULD_RECORD }}
                   parallel: ${{ env.SHOULD_RECORD }}
-                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}-{2}', matrix.versions, github.run_number, matrix.spec-group) || '' }}
+                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}', matrix.versions, matrix.spec-group) || '' }}
                   ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
                   spec: ${{ join(matrix.spec-group, ',') }}
                   browser: chrome

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,11 +37,21 @@ defaults:
         shell: bash
 
 jobs:
-    prerequisites:
+    setup-matrix:
         runs-on: ubuntu-latest
         outputs:
+            matrix: ${{ steps.set-matrix.outputs.specs }}
+        steps:
+        - uses: actions/checkout@v3
+        - name: Generate test matrix
+          id: set-matrix
+          run: echo "::set-output name=specs::$(node cypress/support/generateTestMatrix.js)"
+
+    prerequisites:
+        runs-on: ubuntu-latest
+        needs: setup-matrix
+        outputs:
             json-labels: ${{ steps.json-labels.outputs.labels }}
-            matrix-containers: ${{ steps.matrix-containers.outputs.containers }}
             versions: ${{ steps.legacy-versions.outputs.versions }}
         steps:
             - name: compute-json-labels
@@ -50,13 +60,6 @@ jobs:
                   arrLabels=(${TRIGGER_LABELS//,/ })
                   for item in ${arrLabels[@]}; do labels+=\"$item\",; done
                   echo "::set-output name=labels::[ ${labels%,} ]"
-
-            - name: compute-matrix-containers
-              id: matrix-containers
-              if: contains(fromJson(steps.json-labels.outputs.labels), github.event.label.name)
-              run: |
-                  for (( cnt = 1; cnt <= $CYPRESS_CONTAINERS; cnt++)); do containers+=$cnt,; done
-                  echo "::set-output name=containers::[ ${containers%,} ]"
 
             - if: contains(fromJson(steps.json-labels.outputs.labels), github.event.label.name)
               uses: actions/checkout@v2
@@ -75,14 +78,13 @@ jobs:
                   password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }} # can be removed if maxDHIS2Version has been specified
 
     cypress:
-        needs: prerequisites
-        if: contains(fromJson(needs.prerequisites.outputs.json-labels), github.event.label.name)
+        needs: [prerequisites, setup-matrix]
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
                 versions: ${{ fromJSON(needs.prerequisites.outputs.versions) }}
-                containers: ${{ fromJSON(needs.prerequisites.outputs.matrix-containers) }}
+                spec: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
         env:
             SHOULD_RECORD: ${{ contains(github.event.head_commit.message, '[e2e record]') || contains(join(github.event.pull_request.labels.*.name), 'e2e record') }}
         steps:
@@ -103,8 +105,9 @@ jobs:
               with:
                   record: ${{ env.SHOULD_RECORD }}
                   parallel: ${{ env.SHOULD_RECORD }}
-                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}', matrix.versions) || '' }}
+                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}', matrix.versions, matrix.spec) || '' }}
                   ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
+                  spec: ${{ matrix.spec }}
                   browser: chrome
                   start: yarn start:forCypress
                   wait-on: http://localhost:3000

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -105,7 +105,7 @@ jobs:
               with:
                   record: ${{ env.SHOULD_RECORD }}
                   parallel: ${{ env.SHOULD_RECORD }}
-                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}-{2}', matrix.versions, github.run_number, matrix.spec-group) || '' }}
+                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}', matrix.versions, matrix.spec-group.id) || '' }}
                   ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
                   spec: ${{ join(matrix.spec-group, ',') }}
                   browser: chrome

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -105,9 +105,9 @@ jobs:
               with:
                   record: ${{ env.SHOULD_RECORD }}
                   parallel: ${{ env.SHOULD_RECORD }}
-                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}', matrix.versions, matrix.spec-group) || '' }}
+                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}', matrix.versions, matrix.spec-group.id) || '' }}
                   ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
-                  spec: ${{ join(matrix.spec-group, ',') }}
+                  spec: ${{ join(matrix.spec-group.tests, ',') }}
                   browser: chrome
                   start: yarn start:forCypress
                   wait-on: http://localhost:3000

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -84,7 +84,7 @@ jobs:
             fail-fast: false
             matrix:
                 versions: ${{ fromJSON(needs.prerequisites.outputs.versions) }}
-                spec: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+                spec-group: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
         env:
             SHOULD_RECORD: ${{ contains(github.event.head_commit.message, '[e2e record]') || contains(join(github.event.pull_request.labels.*.name), 'e2e record') }}
         steps:
@@ -105,9 +105,9 @@ jobs:
               with:
                   record: ${{ env.SHOULD_RECORD }}
                   parallel: ${{ env.SHOULD_RECORD }}
-                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}', matrix.versions, matrix.spec) || '' }}
+                  group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-{0}-{1}-{2}', matrix.versions, github.run_number, matrix.spec-group) || '' }}
                   ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
-                  spec: ${{ matrix.spec }}
+                  spec: ${{ join(matrix.spec-group, ',') }}
                   browser: chrome
                   start: yarn start:forCypress
                   wait-on: http://localhost:3000

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -83,6 +83,8 @@ jobs:
             matrix:
                 versions: ${{ fromJSON(needs.prerequisites.outputs.versions) }}
                 containers: ${{ fromJSON(needs.prerequisites.outputs.matrix-containers) }}
+        env:
+            SHOULD_RECORD: ${{ contains(github.event.head_commit.message, '[e2e record]') || contains(join(github.event.pull_request.labels.*.name), 'e2e record') }}
         steps:
             - uses: actions/checkout@v3
 
@@ -99,16 +101,17 @@ jobs:
             - name: Cypress run
               uses: cypress-io/github-action@v6
               with:
-                  record: true
-                  parallel: true
-                  group: e2e-chrome-parallel-${{ matrix.versions }}
+                  record: ${{ env.SHOULD_RECORD }}
+                  parallel: ${{ env.SHOULD_RECORD }}
+                  group: ${{ env.SHOULD_RECORD && format('e2e-chrome-parallel-{0}', matrix.versions) }}
+                  ci-build-id: ${{ env.SHOULD_RECORD && github.run_id }}
                   browser: chrome
                   start: yarn start:forCypress
                   wait-on: http://localhost:3000
                   wait-on-timeout: 300
               env:
                   CI: true
-                  CYPRESS_RECORD_KEY: '6b0bce0d-a4e8-417b-bbee-9157cbe9a999'
+                  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   CYPRESS_dhis2BaseUrl: ${{ steps.instance-url.outputs.url }}
                   CYPRESS_dhis2InstanceVersion: ${{matrix.versions}}

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -136,9 +136,9 @@ jobs:
         with:
           record: ${{ env.SHOULD_RECORD }}
           parallel: ${{ env.SHOULD_RECORD }}
-          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}', matrix.spec-group.id) || '' }}
+          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}-{1}', github.run_number, matrix.spec-group.id) || '' }}
           ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
-          spec: ${{ join(matrix.spec-group, ',') }}
+          spec: ${{ matrix.spec_group.tests }}
           browser: chrome
           start: yarn start:forCypress
           wait-on: http://localhost:3000

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -122,7 +122,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        spec: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+        spec-group: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     env:
       SHOULD_RECORD: ${{ contains(github.event.head_commit.message, '[e2e record]') || contains(join(github.event.pull_request.labels.*.name), 'e2e record') }}
     steps:
@@ -136,9 +136,9 @@ jobs:
         with:
           record: ${{ env.SHOULD_RECORD }}
           parallel: ${{ env.SHOULD_RECORD }}
-          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}', matrix.spec) || '' }}
+          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}-{1}', github.run_number, matrix.spec-group) || '' }}
           ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
-          spec: ${{ matrix.spec }}
+          spec: ${{ join(matrix.spec-group, ',') }}
           browser: chrome
           start: yarn start:forCypress
           wait-on: http://localhost:3000

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -106,17 +106,23 @@ jobs:
           username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}
           password: ${{ secrets.CYPRESS_DHIS2_PASSWORD }}
 
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.specs }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate test matrix
+        id: set-matrix
+        run: echo "::set-output name=specs::$(node cypress/support/generateTestMatrix.js)"
+
   cypress-dev:
     runs-on: ubuntu-latest
-    needs: instance-version
+    needs: [instance-version, setup-matrix]
     strategy:
-      # when one test fails, DO NOT cancel the other
-      # containers, because this will kill Cypress processes
-      # leaving the Dashboard hanging ...
-      # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4, 5]
+        spec: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     env:
       SHOULD_RECORD: ${{ contains(github.event.head_commit.message, '[e2e record]') || contains(join(github.event.pull_request.labels.*.name), 'e2e record') }}
     steps:
@@ -130,8 +136,9 @@ jobs:
         with:
           record: ${{ env.SHOULD_RECORD }}
           parallel: ${{ env.SHOULD_RECORD }}
-          group: ${{ env.SHOULD_RECORD == 'true' && 'e2e-chrome-parallel-dev' || '' }}
-          ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
+          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev{0}', matrix.spec) }}
+          ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id }}
+          spec: ${{ matrix.spec }}
           browser: chrome
           start: yarn start:forCypress
           wait-on: http://localhost:3000

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -130,8 +130,8 @@ jobs:
         with:
           record: ${{ env.SHOULD_RECORD }}
           parallel: ${{ env.SHOULD_RECORD }}
-          group: ${{ env.SHOULD_RECORD && 'e2e-chrome-parallel-dev' || '' }}
-          ci-build-id: ${{ env.SHOULD_RECORD && github.run_id || '' }}
+          group: ${{ env.SHOULD_RECORD == 'true' && 'e2e-chrome-parallel-dev' || '' }}
+          ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
           browser: chrome
           start: yarn start:forCypress
           wait-on: http://localhost:3000

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -136,9 +136,9 @@ jobs:
         with:
           record: ${{ env.SHOULD_RECORD }}
           parallel: ${{ env.SHOULD_RECORD }}
-          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}', matrix.spec-group) || '' }}
+          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}', matrix.spec-group.id) || '' }}
           ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
-          spec: ${{ join(matrix.spec-group, ',') }}
+          spec: ${{ join(matrix.spec-group.tests, ',') }}
           browser: chrome
           start: yarn start:forCypress
           wait-on: http://localhost:3000

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           record: ${{ env.SHOULD_RECORD }}
           parallel: ${{ env.SHOULD_RECORD }}
-          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}-{1}', github.run_number, matrix.spec-group) || '' }}
+          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}', matrix.spec-group.id) || '' }}
           ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
           spec: ${{ join(matrix.spec-group, ',') }}
           browser: chrome

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -136,8 +136,8 @@ jobs:
         with:
           record: ${{ env.SHOULD_RECORD }}
           parallel: ${{ env.SHOULD_RECORD }}
-          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev{0}', matrix.spec) }}
-          ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id }}
+          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev{0}', matrix.spec) || '' }}
+          ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
           spec: ${{ matrix.spec }}
           browser: chrome
           start: yarn start:forCypress

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -117,6 +117,8 @@ jobs:
       fail-fast: false
       matrix:
         containers: [1, 2, 3, 4, 5]
+    env:
+      SHOULD_RECORD: ${{ contains(github.event.head_commit.message, '[e2e record]') || contains(join(github.event.pull_request.labels.*.name), 'e2e record') }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -126,16 +128,17 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v6
         with:
-          record: true
-          parallel: true
-          group: e2e-chrome-parallel-dev
+          record: ${{ env.SHOULD_RECORD }}
+          parallel: ${{ env.SHOULD_RECORD }}
+          group: ${{ env.SHOULD_RECORD && 'e2e-chrome-parallel-dev' }}
+          ci-build-id: ${{ env.SHOULD_RECORD && github.run_id }}
           browser: chrome
           start: yarn start:forCypress
           wait-on: http://localhost:3000
           wait-on-timeout: 300
         env:
           CI: true
-          CYPRESS_RECORD_KEY: '6b0bce0d-a4e8-417b-bbee-9157cbe9a999'
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_dhis2BaseUrl: ${{ secrets.CYPRESS_DHIS2_INSTANCES_BASE_URL }}/ca-test-dev
           CYPRESS_dhis2InstanceVersion: ${{ needs.instance-version.outputs.version }}

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -136,9 +136,9 @@ jobs:
         with:
           record: ${{ env.SHOULD_RECORD }}
           parallel: ${{ env.SHOULD_RECORD }}
-          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}-{1}', github.run_number, matrix.spec-group.id) || '' }}
+          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}-{1}', github.run_number, matrix.spec-group) || '' }}
           ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
-          spec: ${{ matrix.spec_group.tests }}
+          spec: ${{ join(matrix.spec-group, ',') }}
           browser: chrome
           start: yarn start:forCypress
           wait-on: http://localhost:3000

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           record: ${{ env.SHOULD_RECORD }}
           parallel: ${{ env.SHOULD_RECORD }}
-          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev{0}', matrix.spec) || '' }}
+          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}', matrix.spec) || '' }}
           ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
           spec: ${{ matrix.spec }}
           browser: chrome

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -130,8 +130,8 @@ jobs:
         with:
           record: ${{ env.SHOULD_RECORD }}
           parallel: ${{ env.SHOULD_RECORD }}
-          group: ${{ env.SHOULD_RECORD && 'e2e-chrome-parallel-dev' }}
-          ci-build-id: ${{ env.SHOULD_RECORD && github.run_id }}
+          group: ${{ env.SHOULD_RECORD && 'e2e-chrome-parallel-dev' || '' }}
+          ci-build-id: ${{ env.SHOULD_RECORD && github.run_id || '' }}
           browser: chrome
           start: yarn start:forCypress
           wait-on: http://localhost:3000

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -136,7 +136,7 @@ jobs:
         with:
           record: ${{ env.SHOULD_RECORD }}
           parallel: ${{ env.SHOULD_RECORD }}
-          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}-{1}', github.run_number, matrix.spec-group) || '' }}
+          group: ${{ env.SHOULD_RECORD == 'true' && format('e2e-chrome-parallel-dev-{0}', matrix.spec-group) || '' }}
           ci-build-id: ${{ env.SHOULD_RECORD == 'true' && github.run_id || '' }}
           spec: ${{ join(matrix.spec-group, ',') }}
           browser: chrome

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ REACT_APP_DHIS2_BASE_URL="http://localhost:8080"
 
 To run Cypress tests locally on your own machine, follow the instructions [here](https://github.com/dhis2/capture-app/wiki/Cypress#run-cypress-tests-locally).
 
+## Conditional E2E Test Recording
+
+To record tests in Cypress Cloud, you can use one of the following methods based on your needs:
+
+-   **Commit Message**: Include `[e2e record]` in your commit messages to activate recording.
+-   **GitHub Labels**: Apply the `e2e record` label to your pull request to trigger recording.
+
+This setup helps in managing Cypress Cloud credits more efficiently, ensuring recordings are only made when explicitly required.
+
 ## Built With
 
 This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -15,7 +15,21 @@ const getAllFiles = (dirPath, arrayOfFiles = []) => {
     return arrayOfFiles;
 };
 
+const createGroups = (files, numberOfGroups = 10) => {
+    const groups = [];
+    for (let i = 0; i < numberOfGroups; i++) {
+        groups.push([]);
+    }
+
+    files.forEach((file, index) => {
+        groups[index % numberOfGroups].push(file);
+    });
+
+    return groups;
+};
+
 const cypressSpecsPath = './cypress/e2e';
 const specs = getAllFiles(cypressSpecsPath);
+const groupedSpecs = createGroups(specs);
 
-console.log(JSON.stringify(specs));
+console.log(JSON.stringify(groupedSpecs));

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const path = require("path");
+
+const getAllFiles = (dirPath, arrayOfFiles = []) => {
+  const files = fs.readdirSync(dirPath);
+
+  files.forEach((file) => {
+    if (fs.statSync(path.join(dirPath, file)).isDirectory()) {
+      arrayOfFiles = getAllFiles(path.join(dirPath, file), arrayOfFiles);
+    } else {
+      if (path.extname(file) === ".feature") {
+        arrayOfFiles.push(path.join(dirPath, file));
+      }
+    }
+  });
+
+  return arrayOfFiles;
+};
+
+const cypressSpecsPath = "./cypress/e2e";
+const specs = getAllFiles(cypressSpecsPath);
+
+console.log(JSON.stringify(specs));

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -25,7 +25,7 @@ const createGroups = (files, numberOfGroups = 10) => {
         groups[index % numberOfGroups].push(file);
     });
 
-    return groups;
+    return groups.map((group, index) => ({ id: index + 1, tests: group }));
 };
 
 const cypressSpecsPath = './cypress/e2e';

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -25,7 +25,7 @@ const createGroups = (files, numberOfGroups = 10) => {
         groups[index % numberOfGroups].push(file);
     });
 
-    return groups.map((group, index) => ({ id: index + 1, tests: group }));
+    return groups;
 };
 
 const cypressSpecsPath = './cypress/e2e';

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -7,10 +7,8 @@ const getAllFiles = (dirPath, arrayOfFiles = []) => {
     files.forEach((file) => {
         if (fs.statSync(path.join(dirPath, file)).isDirectory()) {
             arrayOfFiles = getAllFiles(path.join(dirPath, file), arrayOfFiles);
-        } else {
-            if (path.extname(file) === '.feature') {
-                arrayOfFiles.push(path.join(dirPath, file));
-            }
+        } else if (path.extname(file) === '.feature') {
+            arrayOfFiles.push(path.join(dirPath, file));
         }
     });
 

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -1,23 +1,23 @@
-const fs = require("fs");
-const path = require("path");
+const fs = require('fs');
+const path = require('path');
 
 const getAllFiles = (dirPath, arrayOfFiles = []) => {
-  const files = fs.readdirSync(dirPath);
+    const files = fs.readdirSync(dirPath);
 
-  files.forEach((file) => {
-    if (fs.statSync(path.join(dirPath, file)).isDirectory()) {
-      arrayOfFiles = getAllFiles(path.join(dirPath, file), arrayOfFiles);
-    } else {
-      if (path.extname(file) === ".feature") {
-        arrayOfFiles.push(path.join(dirPath, file));
-      }
-    }
-  });
+    files.forEach((file) => {
+        if (fs.statSync(path.join(dirPath, file)).isDirectory()) {
+            arrayOfFiles = getAllFiles(path.join(dirPath, file), arrayOfFiles);
+        } else {
+            if (path.extname(file) === '.feature') {
+                arrayOfFiles.push(path.join(dirPath, file));
+            }
+        }
+    });
 
-  return arrayOfFiles;
+    return arrayOfFiles;
 };
 
-const cypressSpecsPath = "./cypress/e2e";
+const cypressSpecsPath = './cypress/e2e';
 const specs = getAllFiles(cypressSpecsPath);
 
 console.log(JSON.stringify(specs));


### PR DESCRIPTION
JIRA ticket: [DHIS2-17372](https://dhis2.atlassian.net/browse/DHIS2-17372)

This PR enhances our Cypress test execution setup by improving how tests are run in parallel both locally and in Cypress Cloud, and optimises the triggering mechanisms for test recordings and executions in Cypress Cloud.

### Key Updates:


- **Conditional Recording**: Introduced logic to activate recordings via commit messages ([e2e record]) or GitHub labels (e2e record), offering flexible control over when recordings are initiated in Cypress Cloud.
- **Parallel Test Execution**: Redefined how tests are grouped and executed in parallel, reducing redundancy and improving runtime efficiency.
- **Security Improvement**: Ensured the Cypress record key is used securely throughout our CI configurations.
- **Documentation Update**: Revised the README to include the latest instructions on how to activate test recordings.

#### Impact:

These improvements streamline our testing process, ensuring efficient resource utilisation and precise control over test recordings and executions in Cypress Cloud. This helps in effectively managing Cypress Cloud credits and minimises unnecessary usage.

[DHIS2-17372]: https://dhis2.atlassian.net/browse/DHIS2-17372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ