### PR TITLE
fix: [DHIS2-17291][DHIS2-16597] skip trackedEntites request when no events match the WL filters

### DIFF
--- a/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsUser.feature
+++ b/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsUser.feature
@@ -195,6 +195,13 @@ When you open an enrollment event from the working list
 And you go back using the browser button
 Then the program stage working list is loaded
 
+@v>=39
+Scenario: The user can open a program stage list without events
+Given you open the main page with Ngelehun and WHO RMNCH Tracker context and configure a program stage working list
+And you set the event visit date to Today
+And you apply the current filter
+Then the working list is empty
+
 @v>=40
 Scenario: The user creates, updates and deletes a Program stage custom working list
 Given you open the main page with Ngelehun and Malaria case diagnosis and Household investigation context

--- a/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/index.js
+++ b/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/index.js
@@ -806,3 +806,19 @@ Then('the JSON button exists', () => {
                 .should('have.attr', 'href').and('include', `/trackedEntities.json?${params}`);
         });
 });
+
+When('you set the event visit date to Today', () => {
+    cy.get('[data-test="tei-working-lists"]')
+        .contains('Date of visit')
+        .click();
+
+    cy.get('[data-test="list-view-filter-contents"]')
+        .contains('Today')
+        .click();
+});
+
+Then('the working list is empty', () => {
+    cy.get('[data-test="tei-working-lists"]')
+        .contains('No items to display')
+        .click();
+});

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getEventListData/getEventListData.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/helpers/getEventListData/getEventListData.js
@@ -70,6 +70,16 @@ export const getEventListData = async (
     });
     const apiEvents = handleAPIResponse(REQUESTED_ENTITIES.events, apiEventsResponse);
 
+    if (apiEvents.length === 0) {
+        return {
+            recordContainers: [],
+            request: {
+                url: urlEvents,
+                queryParams: queryParamsEvents,
+            },
+        };
+    }
+
     const trackedEntityIds = apiEvents
         .reduce((acc, { trackedEntity }) => (acc.includes(trackedEntity) ? acc : [...acc, trackedEntity]), [])
         .join(';');


### PR DESCRIPTION
[DHIS2-17291](https://dhis2.atlassian.net/browse/DHIS2-17291) and [DHIS2-16597](https://dhis2.atlassian.net/browse/DHIS2-16597)

**Tech summary**
- do not query for trackedEntities if there are no events matching the working lists filters


[DHIS2-17291]: https://dhis2.atlassian.net/browse/DHIS2-17291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-16597]: https://dhis2.atlassian.net/browse/DHIS2-16597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ