### PR TITLE
fix: [DHIS2-8814] Table in custom form overflows container with no scrollbar

### DIFF
--- a/src/core_modules/capture-core/components/D2Form/D2Section.component.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Section.component.js
@@ -112,6 +112,7 @@ class D2SectionPlain extends React.PureComponent<Props> {
 
         return (<div
             data-test="d2-section"
+            style={{ overflowX: 'scroll' }}
             className={applyCustomFormClass ? this.props.classes.containerCustomForm : ''}
         >
             {


### PR DESCRIPTION
[DHIS2-8814](https://dhis2.atlassian.net/browse/DHIS2-8814?atlOrigin=eyJpIjoiN2M3OGE3YThlMzI3NDMyMGIyNTI1NTNkMmM2YjFiZTgiLCJwIjoiaiJ9)

- Add overflow to `d2-section`

[DHIS2-8814]: https://dhis2.atlassian.net/browse/DHIS2-8814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ