### PR TITLE
refactor: [DHIS2-17513] remove deprecated endpoints calls from cypress steps

### DIFF
--- a/cypress/e2e/EnrollmentAddEventPage/EnrollmentAddEventPageForm/index.js
+++ b/cypress/e2e/EnrollmentAddEventPage/EnrollmentAddEventPageForm/index.js
@@ -19,9 +19,9 @@ const changeEnrollmentAndEventsStatus = () => (
                 .then(enrollmentUrl => cy.request('POST', enrollmentUrl, { enrollments: [enrollmentToUpdate] }))
                 .then(() => {
                     if (eventToDelete) {
-                        cy.buildApiUrl('events', eventToDelete.event)
+                        cy.buildApiUrl('tracker?async=false&importStrategy=DELETE')
                             .then((eventUrl) => {
-                                cy.request('DELETE', eventUrl);
+                                cy.request('POST', eventUrl, { events: [{ event: eventToDelete.event }] });
                             }).then(() => {
                                 cy.reload();
                                 cy.get('[data-test="widget-enrollment"]').within(() => {

--- a/cypress/e2e/EnrollmentPage/BreakingTheGlass/index.js
+++ b/cypress/e2e/EnrollmentPage/BreakingTheGlass/index.js
@@ -9,8 +9,8 @@ Given('the tei created by this test is cleared from the database', () => {
             const apiTrackedEntities = body.trackedEntities || body.instances || [];
             return apiTrackedEntities.forEach(({ trackedEntity }) =>
                 cy
-                    .buildApiUrl('trackedEntityInstances', trackedEntity)
-                    .then(trackedEntityUrl => cy.request('DELETE', trackedEntityUrl)),
+                    .buildApiUrl('tracker?async=false&importStrategy=DELETE')
+                    .then(trackedEntityUrl => cy.request('POST', trackedEntityUrl, { trackedEntities: [{ trackedEntity }] })),
             );
         });
 });

--- a/cypress/e2e/EnrollmentPage/HiddenProgramStage/index.js
+++ b/cypress/e2e/EnrollmentPage/HiddenProgramStage/index.js
@@ -16,9 +16,9 @@ const cleanUpIfApplicable = () => {
             if (!event) {
                 return null;
             }
-            return cy.buildApiUrl('events', event.event)
+            return cy.buildApiUrl('tracker?async=false&importStrategy=DELETE')
                 .then(eventUrl =>
-                    cy.request('DELETE', eventUrl));
+                    cy.request('POST', eventUrl, { events: [{ event: event.event }] }));
         });
 };
 

--- a/cypress/e2e/NewEventThroughAddRelationship/index.js
+++ b/cypress/e2e/NewEventThroughAddRelationship/index.js
@@ -27,9 +27,9 @@ Then('the event should be sent to the server successfully', () => {
             expect(result.response.statusCode).to.equal(200);
             // clean up
             const id = result.response.body.bundleReport.typeReportMap.EVENT.objectReports[0].uid;
-            cy.buildApiUrl('events', id)
+            cy.buildApiUrl('tracker?async=false&importStrategy=DELETE')
                 .then((eventUrl) => {
-                    cy.request('DELETE', eventUrl);
+                    cy.request('POST', eventUrl, { events: [{ event: id }] });
                 });
         });
 });
@@ -87,9 +87,9 @@ Then('the data should be sent to the server successfully', () => {
         .then(({ response }) => {
             expect(response.statusCode).to.equal(200);
             const relationshipId = response.body.bundleReport.typeReportMap.RELATIONSHIP.objectReports[0].uid;
-            cy.buildApiUrl('relationships', relationshipId)
+            cy.buildApiUrl('tracker?async=false&importStrategy=DELETE')
                 .then((relationshipUrl) => {
-                    cy.request('DELETE', relationshipUrl);
+                    cy.request('POST', relationshipUrl, { relationships: [{ relationship: relationshipId }] });
                 });
         })
         .then(() => {
@@ -97,9 +97,9 @@ Then('the data should be sent to the server successfully', () => {
                 .then(({ response }) => {
                     expect(response.statusCode).to.equal(200);
                     const trackedEntityId = response.body.bundleReport.typeReportMap.TRACKED_ENTITY.objectReports[0].uid;
-                    cy.buildApiUrl('trackedEntityInstances', trackedEntityId)
+                    cy.buildApiUrl('tracker?async=false&importStrategy=DELETE')
                         .then((trackedEntityUrl) => {
-                            cy.request('DELETE', trackedEntityUrl);
+                            cy.request('POST', trackedEntityUrl, { trackedEntities: [{ trackedEntity: trackedEntityId }] });
                         });
                 });
 
@@ -107,9 +107,9 @@ Then('the data should be sent to the server successfully', () => {
                 .then(({ response }) => {
                     expect(response.statusCode).to.equal(200);
                     const eventId = response.body.bundleReport.typeReportMap.EVENT.objectReports[0].uid;
-                    cy.buildApiUrl('events', eventId)
+                    cy.buildApiUrl('tracker?async=false&importStrategy=DELETE')
                         .then((eventUrl) => {
-                            cy.request('DELETE', eventUrl);
+                            cy.request('POST', eventUrl, { events: [{ event: eventId }] });
                         });
                 });
         });
@@ -151,9 +151,9 @@ Then('the event and relationship should be sent to the server successfully', () 
         .then(({ response }) => {
             expect(response.statusCode).to.equal(200);
             const relationshipId = response.body.bundleReport.typeReportMap.RELATIONSHIP.objectReports[0].uid;
-            cy.buildApiUrl('relationships', relationshipId)
+            cy.buildApiUrl('tracker?async=false&importStrategy=DELETE')
                 .then((relationshipUrl) => {
-                    cy.request('DELETE', relationshipUrl);
+                    cy.request('POST', relationshipUrl, { relationships: [{ relationship: relationshipId }] });
                 });
         })
         .then(() => {
@@ -161,9 +161,9 @@ Then('the event and relationship should be sent to the server successfully', () 
                 .then(({ response }) => {
                     expect(response.statusCode).to.equal(200);
                     const eventId = response.body.bundleReport.typeReportMap.EVENT.objectReports[0].uid;
-                    cy.buildApiUrl('events', eventId)
+                    cy.buildApiUrl('tracker?async=false&importStrategy=DELETE')
                         .then((eventUrl) => {
-                            cy.request('DELETE', eventUrl);
+                            cy.request('POST', eventUrl, { events: [{ event: eventId }] });
                         });
                 });
         });


### PR DESCRIPTION
[DHIS2-17513](https://dhis2.atlassian.net/browse/DHIS2-17513)

**Tech summary**
This PR fixes these 7 scenarios in the dev instance:
- User interacts with event working lists > Show next page
- User interacts with event working lists > Show next page then previous page
- User interacts with event working lists > Show next page then first page
- User interacts with the Enrollment New Event Workspace > User can add a new event and complete the enrollment
- User adds events > User adds event in the malaria case registration program
- User adds events > User adds event with relationship to existing person in the malaria case registration program
- Hidden program stage > The user cannot add an event in a hidden program stage


The only remaining failure is related to adding event notes and it will be fixed in a separate bug ticket

[DHIS2-17513]: https://dhis2.atlassian.net/browse/DHIS2-17513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ