### PR TITLE
fix: [DHIS2-17531] use new image endpoint in search tracked entity results

### DIFF
--- a/src/core_modules/capture-core/components/Pages/common/TEIRelationshipsWidget/TeiSearch/epics/teiSearch.epics.js
+++ b/src/core_modules/capture-core/components/Pages/common/TEIRelationshipsWidget/TeiSearch/epics/teiSearch.epics.js
@@ -100,7 +100,9 @@ const searchTei = ({
         getTrackerProgram(selectedProgramId).attributes :
         getTrackedEntityType(selectedTrackedEntityTypeId).attributes;
 
-    return from(getTrackedEntityInstances(queryArgs, attributes, absoluteApiPath, querySingleResource)).pipe(
+    return from(
+        getTrackedEntityInstances(queryArgs, attributes, absoluteApiPath, querySingleResource, selectedProgramId),
+    ).pipe(
         map(({ trackedEntityInstanceContainers, pagingData }) =>
             searchTeiResultRetrieved(
                 { trackedEntityInstanceContainers, currentPage: pagingData.currentPage },

--- a/src/core_modules/capture-core/components/PossibleDuplicatesDialog/possibleDuplicatesDialog.epics.js
+++ b/src/core_modules/capture-core/components/PossibleDuplicatesDialog/possibleDuplicatesDialog.epics.js
@@ -84,9 +84,10 @@ export const loadSearchGroupDuplicatesForReviewEpic = (
                     ...contextParam,
                 };
                 const attributes = getAttributesFromScopeId(selectedScopeId);
+                const programId = scopeType === scopeTypes.TRACKER_PROGRAM ? selectedScopeId : null;
 
                 const stream$: Stream = from(
-                    getTrackedEntityInstances(queryArgs, attributes, absoluteApiPath, querySingleResource),
+                    getTrackedEntityInstances(queryArgs, attributes, absoluteApiPath, querySingleResource, programId),
                 );
                 return stream$.pipe(
                     map(({ trackedEntityInstanceContainers: searchResults, pagingData }) =>

--- a/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchForm.epics.js
+++ b/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchForm.epics.js
@@ -49,7 +49,7 @@ const searchViaUniqueIdStream = ({
     absoluteApiPath: string,
     querySingleResource: QuerySingleResource,
 }) =>
-    from(getTrackedEntityInstances(queryArgs, attributes, absoluteApiPath, querySingleResource)).pipe(
+    from(getTrackedEntityInstances(queryArgs, attributes, absoluteApiPath, querySingleResource, programId)).pipe(
         flatMap(({ trackedEntityInstanceContainers }) => {
             const searchResults = trackedEntityInstanceContainers;
             if (searchResults.length > 0) {
@@ -92,8 +92,22 @@ const handleErrors = ({ httpStatusCode, message }) => {
     return of(showErrorViewOnSearchBox());
 };
 
-const searchViaAttributesStream = ({ queryArgs, attributes, triggeredFrom, absoluteApiPath, querySingleResource }) =>
-    from(getTrackedEntityInstances(queryArgs, attributes, absoluteApiPath, querySingleResource)).pipe(
+const searchViaAttributesStream = ({
+    queryArgs,
+    attributes,
+    triggeredFrom,
+    absoluteApiPath,
+    querySingleResource,
+    programId,
+}: {
+    queryArgs: any,
+    attributes: any,
+    triggeredFrom: string,
+    absoluteApiPath: string,
+    querySingleResource: QuerySingleResource,
+    programId?: string,
+}) =>
+    from(getTrackedEntityInstances(queryArgs, attributes, absoluteApiPath, querySingleResource, programId)).pipe(
         map(({ trackedEntityInstanceContainers: searchResults, pagingData }) => {
             if (searchResults.length > 0) {
                 return showSuccessResultsViewOnSearchBox(
@@ -204,6 +218,7 @@ export const searchViaAttributesOnScopeProgramEpic = (
                 triggeredFrom,
                 absoluteApiPath,
                 querySingleResource,
+                programId,
             });
         }),
     );

--- a/src/core_modules/capture-core/components/TeiSearch/epics/teiSearch.epics.js
+++ b/src/core_modules/capture-core/components/TeiSearch/epics/teiSearch.epics.js
@@ -100,7 +100,9 @@ const searchTei = ({
         getTrackerProgram(selectedProgramId).attributes :
         getTrackedEntityType(selectedTrackedEntityTypeId).attributes;
 
-    return from(getTrackedEntityInstances(queryArgs, attributes, absoluteApiPath, querySingleResource)).pipe(
+    return from(
+        getTrackedEntityInstances(queryArgs, attributes, absoluteApiPath, querySingleResource, selectedProgramId),
+    ).pipe(
         map(({ trackedEntityInstanceContainers, pagingData }) =>
             searchTeiResultRetrieved(
                 { trackedEntityInstanceContainers, currentPage: pagingData.currentPage },

--- a/src/core_modules/capture-core/trackedEntityInstances/getSubValues.js
+++ b/src/core_modules/capture-core/trackedEntityInstances/getSubValues.js
@@ -1,7 +1,7 @@
 // @flow
 import log from 'loglevel';
 import isDefined from 'd2-utilizr/lib/isDefined';
-import { errorCreator } from 'capture-core-utils';
+import { errorCreator, featureAvailable, FEATURES } from 'capture-core-utils';
 import { type DataElement, dataElementTypes } from '../metaData';
 import type { QuerySingleResource } from '../utils/api/api.types';
 
@@ -14,20 +14,35 @@ const subValueGetterByElementType = {
         attributeId,
         absoluteApiPath,
         querySingleResource,
+        programId,
     }: {
         value: any,
         teiId: string,
         attributeId: string,
         absoluteApiPath: string,
         querySingleResource: QuerySingleResource,
+        programId: ?string,
     }) =>
         querySingleResource({ resource: `fileResources/${value}` })
-            .then(res =>
-                ({
+            .then((res) => {
+                const buildUrl = () => {
+                    if (featureAvailable(FEATURES.trackerImageEndpoint)) {
+                        if (programId) {
+                            return `${absoluteApiPath}/tracker/trackedEntities/${teiId}/attributes/${attributeId}/image?program=${programId}&dimension=small`;
+                        }
+                        return `${absoluteApiPath}/tracker/trackedEntities/${teiId}/attributes/${attributeId}/image?dimension=small`;
+                    }
+                    return `${absoluteApiPath}/trackedEntityInstances/${teiId}/${attributeId}/image`;
+                };
+                const previewUrl = buildUrl();
+
+                return {
                     name: res.name,
                     value: res.id,
-                    url: `${absoluteApiPath}/trackedEntityInstances/${teiId}/${attributeId}/image`,
-                }))
+                    previewUrl,
+                    url: previewUrl,
+                };
+            })
             .catch((error) => {
                 log.warn(errorCreator(GET_SUBVALUE_ERROR)({ value, teiId, attributeId, error }));
                 return null;
@@ -40,12 +55,14 @@ export async function getSubValues({
     values,
     absoluteApiPath,
     querySingleResource,
+    programId,
 }: {
     teiId: string,
     attributes: Array<DataElement>,
     values?: ?Object,
     absoluteApiPath: string,
     querySingleResource: QuerySingleResource,
+    programId: ?string,
 }) {
     if (!values) {
         return null;
@@ -67,6 +84,7 @@ export async function getSubValues({
                     attributeId,
                     absoluteApiPath,
                     querySingleResource,
+                    programId,
                 });
                 accValues[attributeId] = subValue;
             }

--- a/src/core_modules/capture-core/trackedEntityInstances/getSubValues.js
+++ b/src/core_modules/capture-core/trackedEntityInstances/getSubValues.js
@@ -1,53 +1,38 @@
 // @flow
-import log from 'loglevel';
 import isDefined from 'd2-utilizr/lib/isDefined';
-import { errorCreator, featureAvailable, FEATURES } from 'capture-core-utils';
+import { featureAvailable, FEATURES } from 'capture-core-utils';
 import { type DataElement, dataElementTypes } from '../metaData';
 import type { QuerySingleResource } from '../utils/api/api.types';
 
-const GET_SUBVALUE_ERROR = 'Could not get subvalue';
-
 const subValueGetterByElementType = {
     [dataElementTypes.IMAGE]: ({
-        value,
         teiId,
         attributeId,
         absoluteApiPath,
-        querySingleResource,
         programId,
     }: {
-        value: any,
         teiId: string,
         attributeId: string,
         absoluteApiPath: string,
-        querySingleResource: QuerySingleResource,
         programId: ?string,
-    }) =>
-        querySingleResource({ resource: `fileResources/${value}` })
-            .then((res) => {
-                const buildUrl = () => {
-                    if (featureAvailable(FEATURES.trackerImageEndpoint)) {
-                        if (programId) {
-                            return `${absoluteApiPath}/tracker/trackedEntities/${teiId}/attributes/${attributeId}/image?program=${programId}&dimension=small`;
-                        }
-                        return `${absoluteApiPath}/tracker/trackedEntities/${teiId}/attributes/${attributeId}/image?dimension=small`;
-                    }
-                    return `${absoluteApiPath}/trackedEntityInstances/${teiId}/${attributeId}/image`;
-                };
-                const previewUrl = buildUrl();
+    }) => {
+        const buildUrl = () => {
+            if (featureAvailable(FEATURES.trackerImageEndpoint)) {
+                if (programId) {
+                    return `${absoluteApiPath}/tracker/trackedEntities/${teiId}/attributes/${attributeId}/image?program=${programId}&dimension=small`;
+                }
+                return `${absoluteApiPath}/tracker/trackedEntities/${teiId}/attributes/${attributeId}/image?dimension=small`;
+            }
+            return `${absoluteApiPath}/trackedEntityInstances/${teiId}/${attributeId}/image`;
+        };
+        const previewUrl = buildUrl();
 
-                return {
-                    name: res.name,
-                    value: res.id,
-                    previewUrl,
-                    url: previewUrl,
-                };
-            })
-            .catch((error) => {
-                log.warn(errorCreator(GET_SUBVALUE_ERROR)({ value, teiId, attributeId, error }));
-                return null;
-            }) };
-
+        return {
+            previewUrl,
+            url: previewUrl,
+        };
+    },
+};
 
 export async function getSubValues({
     teiId,

--- a/src/core_modules/capture-core/trackedEntityInstances/trackedEntityInstanceRequests.js
+++ b/src/core_modules/capture-core/trackedEntityInstances/trackedEntityInstanceRequests.js
@@ -34,6 +34,7 @@ async function convertToClientTei(
     attributes: Array<DataElement>,
     absoluteApiPath: string,
     querySingleResource: QuerySingleResource,
+    programId: ?string,
 ) {
     const attributeValuesById = getValuesById(apiTei.attributes);
     const convertedAttributeValues = convertDataElementsValues(attributeValuesById, attributes, convertValue);
@@ -44,6 +45,7 @@ async function convertToClientTei(
         values: convertedAttributeValues,
         absoluteApiPath,
         querySingleResource,
+        programId,
     });
 
     return {
@@ -63,6 +65,7 @@ export async function getTrackedEntityInstances(
     attributes: Array<DataElement>,
     absoluteApiPath: string,
     querySingleResource: QuerySingleResource,
+    selectedProgramId: ?string,
 ): TrackedEntityInstancesPromise {
     const apiResponse = await querySingleResource({
         resource: 'tracker/trackedEntities',
@@ -72,7 +75,13 @@ export async function getTrackedEntityInstances(
 
     const trackedEntityInstanceContainers = await apiTrackedEntities.reduce(async (accTeiPromise, apiTei) => {
         const accTeis = await accTeiPromise;
-        const teiContainer = await convertToClientTei(apiTei, attributes, absoluteApiPath, querySingleResource);
+        const teiContainer = await convertToClientTei(
+            apiTei,
+            attributes,
+            absoluteApiPath,
+            querySingleResource,
+            selectedProgramId,
+        );
         if (teiContainer) {
             accTeis.push(teiContainer);
         }


### PR DESCRIPTION
[DHIS2-17531](https://dhis2.atlassian.net/browse/DHIS2-17531)

Tech summary:
-  when `FEATURES.trackerImageEndpoint` is true, use the new image endpoint in the search tracked entity results card. For versions below 2.41, the old endpoints are kept. 
-  add the programId when the search is done within a program context. Used to build the image URL


[DHIS2-17531]: https://dhis2.atlassian.net/browse/DHIS2-17531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ