### PR TITLE
fix: [DHIS2-17736] Dropdown Regression in Registration Form

### DIFF
--- a/src/core_modules/capture-core/components/D2Form/D2Section.component.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Section.component.js
@@ -15,7 +15,6 @@ const getStyles = theme => ({
     containerCustomForm: {
         paddingTop: 10,
         paddingBottom: 10,
-        overflowX: 'auto',
     },
 });
 

--- a/src/core_modules/capture-core/components/D2Form/D2Section.component.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Section.component.js
@@ -15,7 +15,7 @@ const getStyles = theme => ({
     containerCustomForm: {
         paddingTop: 10,
         paddingBottom: 10,
-        overflowX: 'scroll',
+        overflowX: 'auto',
     },
 });
 

--- a/src/core_modules/capture-core/components/D2Form/D2Section.component.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Section.component.js
@@ -15,6 +15,7 @@ const getStyles = theme => ({
     containerCustomForm: {
         paddingTop: 10,
         paddingBottom: 10,
+        overflowX: 'scroll',
     },
 });
 
@@ -112,7 +113,6 @@ class D2SectionPlain extends React.PureComponent<Props> {
 
         return (<div
             data-test="d2-section"
-            style={{ overflowX: 'scroll' }}
             className={applyCustomFormClass ? this.props.classes.containerCustomForm : ''}
         >
             {


### PR DESCRIPTION
[DHIS2-17736](https://dhis2.atlassian.net/browse/DHIS2-17736?atlOrigin=eyJpIjoiZmMwZjBkMWJkNGQ1NGQxYThkZjAxMGY1MTQ0NmFmNDQiLCJwIjoiaiJ9)

- Removed overflowx prop implemented in [DHIS2-8814](https://github.com/dhis2/capture-app/pull/3655)

[DHIS2-17736]: https://dhis2.atlassian.net/browse/DHIS2-17736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-8814]: https://dhis2.atlassian.net/browse/DHIS2-8814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ