### PR TITLE
fix: [DHIS2-15687] display translated options in profile widget

### DIFF
--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/helpers/convertClientToView.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/helpers/convertClientToView.js
@@ -6,7 +6,7 @@ type Attribute = {
     attribute: string,
     value: string,
     valueType: $Keys<typeof dataElementTypes>,
-    optionSet: { options: Array<{ name: string, code: string }> },
+    optionSet: { options: Array<{ name: string, code: string, displayName: string }> },
 }
 
 export const convertClientToView = (clientAttribute: Attribute) => {
@@ -20,7 +20,7 @@ export const convertClientToView = (clientAttribute: Attribute) => {
         const options = optionSet.options.map(
             option =>
                 new Option((o) => {
-                    o.text = option.name;
+                    o.text = option.displayName;
                     o.value = option.code;
                 }),
         );


### PR DESCRIPTION
[DHIS2-15687](https://dhis2.atlassian.net/browse/DHIS2-15687)

**Tech summary**
- use the translated displayName
- the fix works for both `TEXT` and `MULTI_TEXT` options sets.

[DHIS2-15687]: https://dhis2.atlassian.net/browse/DHIS2-15687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ