### PR TITLE
refactor: [DHIS2-17750] replace material ui Card for Widget

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-06-28T11:23:02.970Z\n"
-"PO-Revision-Date: 2024-06-28T11:23:02.970Z\n"
+"POT-Creation-Date: 2024-07-18T08:06:52.377Z\n"
+"PO-Revision-Date: 2024-07-18T08:06:52.377Z\n"
 
 msgid "Choose one or more dates..."
 msgstr "Choose one or more dates..."
@@ -366,17 +366,11 @@ msgstr "Registered person"
 msgid "validation failed"
 msgstr "validation failed"
 
-msgid "Errors"
-msgstr "Errors"
+msgid "No feedback"
+msgstr "No feedback"
 
-msgid "Feedback"
-msgstr "Feedback"
-
-msgid "Indicators"
-msgstr "Indicators"
-
-msgid "Warnings"
-msgstr "Warnings"
+msgid "No indicator output"
+msgstr "No indicator output"
 
 msgid "Generate new event"
 msgstr "Generate new event"
@@ -940,6 +934,18 @@ msgid ""
 msgstr ""
 "Leaving this page will discard any selections you made for a new "
 "relationship"
+
+msgid "Errors"
+msgstr "Errors"
+
+msgid "Feedback"
+msgstr "Feedback"
+
+msgid "Indicators"
+msgstr "Indicators"
+
+msgid "Warnings"
+msgstr "Warnings"
 
 msgid "Show all events"
 msgstr "Show all events"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-07-18T08:06:52.377Z\n"
-"PO-Revision-Date: 2024-07-18T08:06:52.377Z\n"
+"POT-Creation-Date: 2024-07-30T08:56:19.469Z\n"
+"PO-Revision-Date: 2024-07-30T08:56:19.469Z\n"
 
 msgid "Choose one or more dates..."
 msgstr "Choose one or more dates..."
@@ -366,11 +366,11 @@ msgstr "Registered person"
 msgid "validation failed"
 msgstr "validation failed"
 
-msgid "No feedback"
-msgstr "No feedback"
+msgid "No feedback for this event yet"
+msgstr "No feedback for this event yet"
 
-msgid "No indicator output"
-msgstr "No indicator output"
+msgid "No indicator output for this event yet"
+msgstr "No indicator output for this event yet"
 
 msgid "Generate new event"
 msgstr "Generate new event"
@@ -782,12 +782,6 @@ msgstr "There was an error loading the page"
 
 msgid "Choose an organisation unit to start reporting"
 msgstr "Choose an organisation unit to start reporting"
-
-msgid "No feedback for this event yet"
-msgstr "No feedback for this event yet"
-
-msgid "No indicator output for this event yet"
-msgstr "No indicator output for this event yet"
 
 msgid "Program stage is invalid"
 msgstr "Program stage is invalid"

--- a/src/core_modules/capture-core/components/DataEntry/DataEntry.component.js
+++ b/src/core_modules/capture-core/components/DataEntry/DataEntry.component.js
@@ -62,10 +62,15 @@ const styles = theme => ({
         position: 'relative',
         flexGrow: 1,
         width: theme.typography.pxToRem(300),
-        margin: theme.typography.pxToRem(10),
+        '& > div > div > *:not(:first-child)': {
+            marginTop: '10px',
+        },
         marginRight: 0,
     },
     verticalOutputsContainer: {
+        '& > *': {
+            marginTop: '10px',
+        },
         marginBottom: theme.typography.pxToRem(10),
     },
     dataEntrySectionContainer: {

--- a/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withDataEntryOutput.js
+++ b/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withDataEntryOutput.js
@@ -21,7 +21,7 @@ const getDataEntryOutput = (InnerComponent: React.ComponentType<any>, Output: Re
             return dataEntryOutputs ? [...dataEntryOutputs, output] : [output];
         };
         getOutput = (key: any) => (
-            <div style={{ marginTop: 10 }} key={key}>
+            <div key={key}>
                 {/* $FlowFixMe[cannot-spread-inexact] automated comment */}
                 <Output
                     key={key}

--- a/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withErrorOutput.js
+++ b/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withErrorOutput.js
@@ -1,66 +1,19 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
-import Card from '@material-ui/core/Card';
-import { IconErrorFilled16 } from '@dhis2/ui';
-import { withStyles } from '@material-ui/core/styles';
-import i18n from '@dhis2/d2-i18n';
 import { getDataEntryKey } from '../common/getDataEntryKey';
 import { withDataEntryOutput } from './withDataEntryOutput';
+import { WidgetError } from '../../WidgetErrorAndWarning/WidgetError';
 
 
 type Props = {
     errorItems: ?Array<any>,
     errorOnCompleteItems: ?Array<any>,
     saveAttempted: boolean,
-    classes: {
-        list: string,
-        listItem: string,
-        card: string,
-        header: string,
-        headerText: string,
-    },
 };
-
-const styles = (theme: Theme) => ({
-    card: {
-        padding: theme.typography.pxToRem(10),
-        backgroundColor: theme.palette.error.red200,
-        borderRadius: theme.typography.pxToRem(5),
-    },
-    list: {
-        margin: 0,
-    },
-    listItem: {
-        paddingLeft: theme.typography.pxToRem(10),
-        marginTop: theme.typography.pxToRem(8),
-    },
-    header: {
-        color: '#902c02',
-        display: 'flex',
-        alignItems: 'center',
-    },
-    headerText: {
-        marginLeft: theme.typography.pxToRem(10),
-    },
-});
 
 const getErrorOutput = () =>
     class ErrorOutputBuilder extends React.Component<Props> {
-        static renderErrorItems = (errorItems: any, classes: any) =>
-            (<div>
-                {errorItems
-                    .map(item => (
-                        <li
-                            key={item.id}
-                            className={classes.listItem}
-                        >
-                            <p>{item.message}</p>
-                        </li>
-                    ))
-                }
-            </div>)
-
         name: string;
         constructor(props) {
             super(props);
@@ -82,27 +35,8 @@ const getErrorOutput = () =>
         }
 
         render = () => {
-            const { classes } = this.props;
             const visibleItems = this.getVisibleErrorItems();
-            return (
-                <div>
-                    {visibleItems && visibleItems.length > 0 &&
-                    <Card className={classes.card}>
-                        <div className={classes.header}>
-                            <IconErrorFilled16 />
-                            <div className={classes.headerText}>
-                                {i18n.t('Errors')}
-                            </div>
-                        </div>
-                        <ul className={classes.list}>
-                            {ErrorOutputBuilder.renderErrorItems(visibleItems, classes)}
-                        </ul>
-
-                    </Card>
-                    }
-                </div>
-
-            );
+            return <WidgetError error={visibleItems} />;
         }
     };
 
@@ -124,5 +58,4 @@ export const withErrorOutput = () =>
     (InnerComponent: React.ComponentType<any>) =>
         withDataEntryOutput()(
             InnerComponent,
-            withStyles(styles)(
-                connect(mapStateToProps, mapDispatchToProps)(getErrorOutput())));
+            connect(mapStateToProps, mapDispatchToProps)(getErrorOutput()));

--- a/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withFeedbackOutput.js
+++ b/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withFeedbackOutput.js
@@ -25,7 +25,14 @@ const getFeedbackOutput = () =>
 
         render = () => {
             const feedback = this.getItems();
-            return <WidgetFeedback feedback={feedback} emptyText={i18n.t('No feedback')} />;
+            const hasItems = feedback.length > 0;
+            return (
+                <div>
+                    {hasItems &&
+                        <WidgetFeedback feedback={feedback} emptyText={i18n.t('No feedback for this event yet')} />
+                    }
+                </div>
+            );
         }
     };
 

--- a/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withFeedbackOutput.js
+++ b/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withFeedbackOutput.js
@@ -1,98 +1,31 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
-import Card from '@material-ui/core/Card';
-import { Menu, MenuItem } from '@dhis2/ui';
-import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
 import { getDataEntryKey } from '../common/getDataEntryKey';
 import { withDataEntryOutput } from './withDataEntryOutput';
-
+import { WidgetFeedback } from '../../WidgetFeedback';
+import type { FilteredText, FilteredKeyValue } from '../../WidgetFeedback';
 
 type Props = {
     feedbackItems: {
-        displayTexts: [{ key: string, value: string}],
-        displayKeyValuePairs: [{ key: string, value: string}],
-    },
-    classes: {
-        listItem: string,
-        card: string,
-        keyValuePairKey: string,
+        displayTexts: Array<FilteredText>,
+        displayKeyValuePairs: Array<FilteredKeyValue>,
     },
 };
 
-const styles = (theme: Theme) => ({
-    listItem: {
-        display: 'flex',
-        backgroundColor: '#f5f5f5 !important',
-        paddingLeft: theme.typography.pxToRem(10),
-        marginTop: theme.typography.pxToRem(8),
-    },
-    keyValuePairKey: {
-        flexGrow: 1,
-        margin: 0,
-    },
-    keyValue: {
-        margin: 0,
-        fontSize: '0.875rem',
-    },
-    card: {
-        padding: theme.typography.pxToRem(10),
-        borderRadius: theme.typography.pxToRem(5),
-    },
-    labelContainer: {
-        display: 'flex',
-    },
-});
-
 const getFeedbackOutput = () =>
     class FeedbackOutputBuilder extends React.Component<Props> {
-        renderFeedbackItems = (feedbackItems: any, classes: any) =>
-            (<div>
-                {feedbackItems.displayTexts &&
-                    feedbackItems.displayTexts.map(item => (
-                        <MenuItem
-                            dense
-                            key={item.id}
-                            className={classes.listItem}
-                            button={false}
-                            label={<p className={classes.keyValuePairKey}> {item.message} </p>}
-                        />
-                    ),
-                    )}
-                {feedbackItems.displayKeyValuePairs &&
-                    feedbackItems.displayKeyValuePairs.map(item => (
-                        <MenuItem
-                            key={item.id}
-                            button={false}
-                            className={classes.listItem}
-                            dense
-                            label={
-                                <div className={classes.labelContainer}>
-                                    <p className={classes.keyValuePairKey}> {item.key} </p>
-                                    <p className={classes.keyValue}> {item.value} </p>
-                                </div>
-                            }
-                        />
-                    ),
-                    )}
-            </div>)
+        getItems = () => {
+            const { feedbackItems } = this.props;
+            const displayTexts = feedbackItems?.displayTexts || [];
+            const displayKeyValuePairs = feedbackItems?.displayKeyValuePairs || [];
+            return [...displayTexts, ...displayKeyValuePairs];
+        }
 
         render = () => {
-            const { feedbackItems, classes } = this.props;
-            const hasItems = feedbackItems && (feedbackItems.displayTexts || feedbackItems.displayKeyValuePairs);
-            return (
-                <div>
-                    {hasItems &&
-                        <Card className={classes.card}>
-                            {i18n.t('Feedback')}
-                            <Menu dense>
-                                {feedbackItems && this.renderFeedbackItems(feedbackItems, classes)}
-                            </Menu>
-                        </Card>
-                    }
-                </div>
-            );
+            const feedback = this.getItems();
+            return <WidgetFeedback feedback={feedback} emptyText={i18n.t('No feedback')} />;
         }
     };
 
@@ -113,4 +46,4 @@ export const withFeedbackOutput = () =>
 
         withDataEntryOutput()(
             InnerComponent,
-            withStyles(styles)(connect(mapStateToProps, mapDispatchToProps)(getFeedbackOutput())));
+            connect(mapStateToProps, mapDispatchToProps)(getFeedbackOutput()));

--- a/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withIndicatorOutput.js
+++ b/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withIndicatorOutput.js
@@ -1,98 +1,31 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
-import Card from '@material-ui/core/Card';
-import { Menu, MenuItem } from '@dhis2/ui';
-import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
 import { getDataEntryKey } from '../common/getDataEntryKey';
 import { withDataEntryOutput } from './withDataEntryOutput';
-
+import { WidgetIndicator } from '../../WidgetIndicator';
+import type { FilteredText, FilteredKeyValue } from '../../WidgetFeedback';
 
 type Props = {
     indicatorItems: {
-        displayTexts: [{ key: string, value: string}],
-        displayKeyValuePairs: [{ key: string, value: string}],
-    },
-    classes: {
-        listItem: string,
-        card: string,
+        displayTexts: Array<FilteredText>,
+        displayKeyValuePairs: Array<FilteredKeyValue>,
     },
 };
 
-const styles = (theme: Theme) => ({
-    listItem: {
-        display: 'flex',
-        backgroundColor: '#f5f5f5 !important',
-        paddingLeft: theme.typography.pxToRem(10),
-        marginTop: theme.typography.pxToRem(8),
-    },
-    keyValuePairKey: {
-        flexGrow: 1,
-        margin: 0,
-    },
-    keyValue: {
-        margin: 0,
-        fontSize: '0.875rem',
-    },
-    card: {
-        padding: theme.typography.pxToRem(10),
-        borderRadius: theme.typography.pxToRem(5),
-    },
-    labelContainer: {
-        display: 'flex',
-    },
-});
-
 const getIndicatorOutput = () =>
     class IndicatorkOutputBuilder extends React.Component<Props> {
-        renderIndicatorItems = (indicatorItems: any, classes: any) =>
-            (<div>
-                {indicatorItems.displayTexts &&
-                    indicatorItems.displayTexts.map(item => (
-                        <MenuItem
-                            key={item.id}
-                            className={classes.listItem}
-                            button={false}
-                            dense
-                            label={<p className={classes.keyValuePairKey}>{item.message}</p>}
-                        />
-                    ),
-                    )}
-                {indicatorItems.displayKeyValuePairs &&
-                    indicatorItems.displayKeyValuePairs.map(item => (
-                        <MenuItem
-                            key={item.id}
-                            className={classes.listItem}
-                            button={false}
-                            dense
-                            label={
-                                <div className={classes.labelContainer}>
-                                    <p className={classes.keyValuePairKey}> {item.key} </p>
-                                    <p className={classes.keyValue}> {item.value} </p>
-                                </div>
-                            }
-                        />
-                    ),
-                    )}
-            </div>)
+        getItems = () => {
+            const { indicatorItems } = this.props;
+            const displayTexts = indicatorItems?.displayTexts || [];
+            const displayKeyValuePairs = indicatorItems?.displayKeyValuePairs || [];
+            return [...displayTexts, ...displayKeyValuePairs];
+        }
 
         render = () => {
-            const { indicatorItems, classes } = this.props;
-            const hasItems = indicatorItems && (indicatorItems.displayTexts || indicatorItems.displayKeyValuePairs);
-            return (
-                <div>
-                    {hasItems &&
-                        <Card className={classes.card}>
-                            {i18n.t('Indicators')}
-                            <Menu dense>
-                                {indicatorItems && this.renderIndicatorItems(indicatorItems, classes)}
-                            </Menu>
-                        </Card>
-                    }
-                </div>
-
-            );
+            const indicators = this.getItems();
+            return <WidgetIndicator indicators={indicators} emptyText={i18n.t('No indicator output')} />;
         }
     };
 
@@ -113,4 +46,4 @@ export const withIndicatorOutput = () =>
 
         withDataEntryOutput()(
             InnerComponent,
-            withStyles(styles)(connect(mapStateToProps, mapDispatchToProps)(getIndicatorOutput())));
+            connect(mapStateToProps, mapDispatchToProps)(getIndicatorOutput()));

--- a/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withIndicatorOutput.js
+++ b/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withIndicatorOutput.js
@@ -25,7 +25,15 @@ const getIndicatorOutput = () =>
 
         render = () => {
             const indicators = this.getItems();
-            return <WidgetIndicator indicators={indicators} emptyText={i18n.t('No indicator output')} />;
+            const hasItems = indicators.length > 0;
+            return (
+                <div>
+                    {hasItems &&
+                        <WidgetIndicator indicators={indicators} emptyText={i18n.t('No indicator output for this event yet')} />
+                    }
+                </div>
+
+            );
         }
     };
 

--- a/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withWarningOutput.js
+++ b/src/core_modules/capture-core/components/DataEntry/dataEntryOutput/withWarningOutput.js
@@ -1,66 +1,19 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
-import Card from '@material-ui/core/Card';
-import { IconWarningFilled16 } from '@dhis2/ui';
-import { withStyles } from '@material-ui/core/styles';
-import i18n from '@dhis2/d2-i18n';
 import { getDataEntryKey } from '../common/getDataEntryKey';
 import { withDataEntryOutput } from './withDataEntryOutput';
+import { WidgetWarning } from '../../WidgetErrorAndWarning/WidgetWarning';
 
 
 type Props = {
     warningItems: ?Array<any>,
     warningOnCompleteItems: ?Array<any>,
     saveAttempted: boolean,
-    classes: {
-        list: string,
-        listItem: string,
-        card: string,
-        header: string,
-        headerText: string,
-    },
 };
-
-const styles = theme => ({
-    list: {
-        margin: 0,
-    },
-    listItem: {
-        paddingLeft: theme.typography.pxToRem(10),
-        marginTop: theme.typography.pxToRem(8),
-    },
-    header: {
-        display: 'flex',
-        alignItems: 'center',
-    },
-    headerText: {
-        marginLeft: theme.typography.pxToRem(10),
-    },
-    card: {
-        borderRadius: theme.typography.pxToRem(5),
-        padding: theme.typography.pxToRem(10),
-        backgroundColor: theme.palette.warning.lighter,
-    },
-
-});
 
 const getWarningOutput = () =>
     class WarningOutputBuilder extends React.Component<Props> {
-        static renderWarningItems = (warningItems: any, classes: any) =>
-            (<div>
-                {warningItems &&
-                    warningItems.map(item => (
-                        <li
-                            key={item.id}
-                            className={classes.listItem}
-                        >
-                            <p>{item.message}</p>
-                        </li>
-                    ),
-                    )}
-            </div>)
-
         getVisibleWarningItems() {
             const { warningItems, warningOnCompleteItems, saveAttempted } = this.props;
             if (saveAttempted) {
@@ -76,26 +29,8 @@ const getWarningOutput = () =>
         }
 
         render = () => {
-            const { classes } = this.props;
             const visibleItems = this.getVisibleWarningItems();
-            return (
-                <div>
-                    {visibleItems && visibleItems.length > 0 &&
-                    <Card className={classes.card}>
-                        <div className={classes.header}>
-                            <IconWarningFilled16 />
-                            <div className={classes.headerText}>
-                                {i18n.t('Warnings')}
-                            </div>
-                        </div>
-                        <ul className={classes.list}>
-                            {WarningOutputBuilder.renderWarningItems(visibleItems, classes)}
-                        </ul>
-                    </Card>
-                    }
-                </div>
-
-            );
+            return <WidgetWarning warning={visibleItems} />;
         }
     };
 
@@ -117,4 +52,4 @@ export const withWarningOutput = () =>
     (InnerComponent: React.ComponentType<any>) =>
         withDataEntryOutput()(
             InnerComponent,
-            withStyles(styles)(connect(mapStateToProps, mapDispatchToProps)(getWarningOutput())));
+            connect(mapStateToProps, mapDispatchToProps)(getWarningOutput()));

--- a/src/core_modules/capture-core/components/WidgetFeedback/WidgetFeedback.component.js
+++ b/src/core_modules/capture-core/components/WidgetFeedback/WidgetFeedback.component.js
@@ -2,10 +2,10 @@
 import React, { useState } from 'react';
 import i18n from '@dhis2/d2-i18n';
 import { Widget } from '../Widget';
-import type { PlainProps } from './WidgetFeedback.types';
+import type { Props } from './WidgetFeedback.types';
 import { WidgetFeedbackContent } from './WidgetFeedbackContent/WidgetFeedbackContent';
 
-export const WidgetFeedback = ({ feedback, emptyText }: PlainProps) => {
+export const WidgetFeedback = ({ feedback, emptyText }: Props) => {
     const [openStatus, setOpenStatus] = useState(true);
 
     return (

--- a/src/core_modules/capture-core/components/WidgetFeedback/WidgetFeedback.types.js
+++ b/src/core_modules/capture-core/components/WidgetFeedback/WidgetFeedback.types.js
@@ -31,11 +31,6 @@ export type Props = {|
     emptyText: string,
 |}
 
-export type PlainProps = {|
-    ...PlainProps,
-    ...CssClasses
-|}
-
 export type IndicatorProps = {|
     indicators?: ?Array<string | FilteredText | FilteredKeyValue>,
     emptyText: string,

--- a/src/core_modules/capture-core/components/WidgetFeedback/index.js
+++ b/src/core_modules/capture-core/components/WidgetFeedback/index.js
@@ -1,1 +1,4 @@
+// @flow
+
 export { WidgetFeedback } from './WidgetFeedback.component';
+export type { FilteredText, FilteredKeyValue } from './WidgetFeedback.types';


### PR DESCRIPTION
[DHIS2-17750](https://dhis2.atlassian.net/browse/DHIS2-17750)

**Tech summary**
- The material-ui `Card` was still used to display the program rules effects when adding a new event to a single event program. I replaced the Card for the Widgets

[DHIS2-17750]: https://dhis2.atlassian.net/browse/DHIS2-17750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ