### PR TITLE
feat: [DHIS2-16125] hide program stage under certain circumstances

### DIFF
--- a/cypress/e2e/EnrollmentPage/HiddenProgramStage/HiddenProgramStage.feature
+++ b/cypress/e2e/EnrollmentPage/HiddenProgramStage/HiddenProgramStage.feature
@@ -2,5 +2,5 @@ Feature: Hidden program stage
 
     Scenario: The user cannot add an event in a hidden program stage
         Given you add an enrollment event that will result in a rule effect to hide a program stage
-        Then the New Postpartum care visit event button is disabled in the stages and events widget
+        Then the Postpartum care visit stage should not be displayed in the Stages and Events widget
         And the Postpartum care visit button is disabled in the enrollmentEventNew page

--- a/cypress/e2e/EnrollmentPage/HiddenProgramStage/HiddenProgramStage.js
+++ b/cypress/e2e/EnrollmentPage/HiddenProgramStage/HiddenProgramStage.js
@@ -43,9 +43,8 @@ Given('you add an enrollment event that will result in a rule effect to hide a p
     cy.contains('[data-test="dhis2-uicore-button"]', 'Save without completing').click();
 });
 
-Then('the New Postpartum care visit event button is disabled in the stages and events widget', () => {
-    cy.contains('[data-test="create-new-button"]', 'New Postpartum care visit event')
-        .should('be.disabled');
+Then('the Postpartum care visit stage should not be displayed in the Stages and Events widget', () => {
+    cy.get('[data-test="stages-and-events-widget"]').should('not.contain', 'Postpartum care visit');
 });
 
 Then('the Postpartum care visit button is disabled in the enrollmentEventNew page', () => {

--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/Stage.component.js
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/Stage.component.js
@@ -28,7 +28,6 @@ const rulesEffectHideProgramStage = (ruleEffects, stageId) => (
 );
 
 export const StagePlain = ({ stage, events, classes, className, onCreateNew, ruleEffects, ...passOnProps }: Props) => {
-    console.log('ruleEffects', ruleEffects);
     const [open, setOpenStatus] = useState(true);
     const { id, name, icon, description, dataElements, hideDueDate, repeatable, enableUserAssignment } = stage;
     const preventAddingNewEvents = rulesEffectHideProgramStage(ruleEffects, id);
@@ -71,7 +70,6 @@ export const StagePlain = ({ stage, events, classes, className, onCreateNew, rul
                     <Button
                         small
                         secondary
-                        disabled={preventAddingNewEvents}
                         icon={<IconAdd16 />}
                         className={classes.button}
                         dataTest="create-new-button"

--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/Stage.component.js
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/Stage.component.js
@@ -24,14 +24,18 @@ const styles = {
         alignItems: 'center',
     },
 };
-const hideProgramStage = (ruleEffects, stageId) => (
+const rulesEffectHideProgramStage = (ruleEffects, stageId) => (
     Boolean(ruleEffects?.find(ruleEffect => ruleEffect.type === 'HIDEPROGRAMSTAGE' && ruleEffect.id === stageId))
 );
 
 export const StagePlain = ({ stage, events, classes, className, onCreateNew, ruleEffects, ...passOnProps }: Props) => {
+    console.log('ruleEffects', ruleEffects)
     const [open, setOpenStatus] = useState(true);
     const { id, name, icon, description, dataElements, hideDueDate, repeatable, enableUserAssignment } = stage;
-    const hiddenProgramStage = hideProgramStage(ruleEffects, id);
+    const preventAddingNewEvents = rulesEffectHideProgramStage(ruleEffects, id);
+    const hideProgramStage = preventAddingNewEvents && events.length === 0;
+
+    if (hideProgramStage) return null;
 
     return (
         <div
@@ -59,20 +63,14 @@ export const StagePlain = ({ stage, events, classes, className, onCreateNew, rul
                     repeatable={repeatable}
                     enableUserAssignment={enableUserAssignment}
                     onCreateNew={onCreateNew}
-                    hiddenProgramStage={hiddenProgramStage}
+                    hiddenProgramStage={preventAddingNewEvents}
                     {...passOnProps}
                 /> : (
-                    <ConditionalTooltip
-                        content={i18n.t("You can't add any more {{ programStageName }} events", {
-                            programStageName: name,
-                            interpolation: { escapeValue: false },
-                        })}
-                        enabled={hiddenProgramStage}
-                    >
+                    
                         <Button
                             small
                             secondary
-                            disabled={hiddenProgramStage}
+                            disabled={preventAddingNewEvents}
                             icon={<IconAdd16 />}
                             className={classes.button}
                             dataTest="create-new-button"
@@ -83,7 +81,6 @@ export const StagePlain = ({ stage, events, classes, className, onCreateNew, rul
                                 interpolation: { escapeValue: false },
                             })}
                         </Button>
-                    </ConditionalTooltip>
                 )}
             </Widget>
         </div>

--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/Stage.component.js
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/Stage.component.js
@@ -4,7 +4,6 @@ import cx from 'classnames';
 import i18n from '@dhis2/d2-i18n';
 import { withStyles } from '@material-ui/core';
 import { spacersNum, colors, IconAdd16, Button } from '@dhis2/ui';
-import { ConditionalTooltip } from 'capture-core/components/Tooltips/ConditionalTooltip';
 import { StageOverview } from './StageOverview';
 import type { Props } from './stage.types';
 import { Widget } from '../../../Widget';
@@ -29,11 +28,14 @@ const rulesEffectHideProgramStage = (ruleEffects, stageId) => (
 );
 
 export const StagePlain = ({ stage, events, classes, className, onCreateNew, ruleEffects, ...passOnProps }: Props) => {
-    console.log('ruleEffects', ruleEffects)
+    console.log('ruleEffects', ruleEffects);
     const [open, setOpenStatus] = useState(true);
     const { id, name, icon, description, dataElements, hideDueDate, repeatable, enableUserAssignment } = stage;
     const preventAddingNewEvents = rulesEffectHideProgramStage(ruleEffects, id);
     const hideProgramStage = preventAddingNewEvents && events.length === 0;
+
+    const handleOpen = useCallback(() => setOpenStatus(true), [setOpenStatus]);
+    const handleClose = useCallback(() => setOpenStatus(false), [setOpenStatus]);
 
     if (hideProgramStage) return null;
 
@@ -50,8 +52,8 @@ export const StagePlain = ({ stage, events, classes, className, onCreateNew, rul
                     events={events}
                 />}
                 borderless
-                onOpen={useCallback(() => setOpenStatus(true), [setOpenStatus])}
-                onClose={useCallback(() => setOpenStatus(false), [setOpenStatus])}
+                onOpen={handleOpen}
+                onClose={handleClose}
                 open={open}
             >
                 {events.length > 0 ? <StageDetail
@@ -66,21 +68,20 @@ export const StagePlain = ({ stage, events, classes, className, onCreateNew, rul
                     hiddenProgramStage={preventAddingNewEvents}
                     {...passOnProps}
                 /> : (
-                    
-                        <Button
-                            small
-                            secondary
-                            disabled={preventAddingNewEvents}
-                            icon={<IconAdd16 />}
-                            className={classes.button}
-                            dataTest="create-new-button"
-                            onClick={() => onCreateNew(id)}
-                        >
-                            {i18n.t('New {{ eventName }} event', {
-                                eventName: name,
-                                interpolation: { escapeValue: false },
-                            })}
-                        </Button>
+                    <Button
+                        small
+                        secondary
+                        disabled={preventAddingNewEvents}
+                        icon={<IconAdd16 />}
+                        className={classes.button}
+                        dataTest="create-new-button"
+                        onClick={() => onCreateNew(id)}
+                    >
+                        {i18n.t('New {{ eventName }} event', {
+                            eventName: name,
+                            interpolation: { escapeValue: false },
+                        })}
+                    </Button>
                 )}
             </Widget>
         </div>


### PR DESCRIPTION
[DHIS2-16125](https://dhis2.atlassian.net/browse/DHIS2-16125)

- Checked if program rule `Prevent adding new events to stage` is in effect when no events are in stage. If so, the program stage is hidden.
- Change variable names for readability
- Removed `ConditionalTooltip` and `disabled` prop for the scenario where there are no events, because there are no use cases where this button can be disabled.
- Changed Cypress to verify that the stage is hidden (under the certain circumstances) instead of looking after the disabled button in the hidden program stage

[DHIS2-16125]: https://dhis2.atlassian.net/browse/DHIS2-16125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ