### PR TITLE
fix: [DHIS2-17859] Add missing ids to Enrollment plugin

### DIFF
--- a/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/EnrollmentPageLayout/renderPageComponents/renderPageComponents.js
+++ b/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/EnrollmentPageLayout/renderPageComponents/renderPageComponents.js
@@ -61,12 +61,12 @@ const renderComponent = (
     );
 };
 
-const getPropsForPlugin = ({ program, enrollmentId, teiId, orgUnitId, programStage, eventId }) => ({
+const getPropsForPlugin = ({ program, enrollmentId, teiId, orgUnitId, programStage, eventId, stageId }) => ({
     programId: program.id,
     enrollmentId,
     teiId,
     orgUnitId,
-    programStageId: programStage?.id,
+    programStageId: stageId ?? programStage?.id,
     eventId,
 });
 

--- a/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/EnrollmentPageLayout/renderPageComponents/renderPageComponents.js
+++ b/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/EnrollmentPageLayout/renderPageComponents/renderPageComponents.js
@@ -61,11 +61,13 @@ const renderComponent = (
     );
 };
 
-const getPropsForPlugin = ({ program, enrollmentId, teiId, orgUnitId }) => ({
+const getPropsForPlugin = ({ program, enrollmentId, teiId, orgUnitId, programStage, eventId }) => ({
     programId: program.id,
     enrollmentId,
     teiId,
     orgUnitId,
+    programStageId: programStage?.id,
+    eventId,
 });
 
 const renderPlugin = (

--- a/src/core_modules/capture-core/components/Pages/common/EnrollmentPlugin/EnrollmentPlugin.js
+++ b/src/core_modules/capture-core/components/Pages/common/EnrollmentPlugin/EnrollmentPlugin.js
@@ -9,6 +9,8 @@ type EnrollmentPluginProps = {|
     teiId: string,
     orgUnitId: string,
     pluginSource: string,
+    programStageId?: string,
+    eventId?: string,
 |};
 
 export const EnrollmentPlugin = ({ pluginSource, ...passOnProps }: EnrollmentPluginProps) => {


### PR DESCRIPTION
We were not passing in programStageId and eventId to enrollment plugins as we should. 

Picture to validate that we're actually providing the correct ids:

1. Enrollment Edit event page 
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d89d0d68-8dd0-4569-a1a0-6f368ff59296">

2. Enrollment new event page 
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/93898cc3-7173-4bc2-b44f-1a24955dd5f5">
