### PR TITLE
fix: [DHIS2-17971] trigger program stage specific rules on opening new event page

### DIFF
--- a/src/core_modules/capture-core/components/DataEntries/common/ProgramStage/buildProgramStageMetadata.js
+++ b/src/core_modules/capture-core/components/DataEntries/common/ProgramStage/buildProgramStageMetadata.js
@@ -28,6 +28,7 @@ export const buildProgramStageMetadata = async ({
     const storageController = getUserStorageController();
 
     const cachedRelationshipTypes = await storageController.getAll(userStores.RELATIONSHIP_TYPES);
+    const cachedProgramRules = await storageController.getAll(userStores.PROGRAM_RULES);
 
     const programStageFactory = new ProgramStageFactory({
         cachedOptionSets: new Map<string, CachedOptionSet>(cachedOptionSets.map(optionSet => [optionSet.id, optionSet])),
@@ -41,5 +42,8 @@ export const buildProgramStageMetadata = async ({
     return programStageFactory.build(
         cachedProgramStage,
         programId,
-    );
+    ).then((stage) => {
+        stage.programRules = cachedProgramRules.filter(rule => rule.programStageId === cachedProgramStage.id);
+        return stage;
+    });
 };

--- a/src/core_modules/capture-core/components/DataEntries/common/ProgramStage/buildProgramStageMetadata.js
+++ b/src/core_modules/capture-core/components/DataEntries/common/ProgramStage/buildProgramStageMetadata.js
@@ -28,7 +28,9 @@ export const buildProgramStageMetadata = async ({
     const storageController = getUserStorageController();
 
     const cachedRelationshipTypes = await storageController.getAll(userStores.RELATIONSHIP_TYPES);
-    const cachedProgramRules = await storageController.getAll(userStores.PROGRAM_RULES);
+    const cachedProgramRules = await storageController.getAll(userStores.PROGRAM_RULES, {
+        predicate: rule => rule.programStageId === cachedProgramStage.id,
+    });
 
     const programStageFactory = new ProgramStageFactory({
         cachedOptionSets: new Map<string, CachedOptionSet>(cachedOptionSets.map(optionSet => [optionSet.id, optionSet])),
@@ -43,7 +45,7 @@ export const buildProgramStageMetadata = async ({
         cachedProgramStage,
         programId,
     ).then((stage) => {
-        stage.programRules = cachedProgramRules.filter(rule => rule.programStageId === cachedProgramStage.id);
+        stage.programRules = cachedProgramRules;
         return stage;
     });
 };


### PR DESCRIPTION
[DHIS2-17971](https://dhis2.atlassian.net/browse/DHIS2-17971)

In `WidgetEnrollmentEventNew.container.js` we recently switched source for the `stage` object. The program stage's `programRules` array wasn't initialised in this new source. This PR initialises this array.

[DHIS2-17971]: https://dhis2.atlassian.net/browse/DHIS2-17971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ