### PR TITLE
chore(deps): revert actions/download-artifact from 4.1.7 to 2 in /.github/workflows

### DIFF
--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -214,7 +214,7 @@ jobs:
         with:
           node-version: 18.x
 
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v2
         with:
           name: app-build
 


### PR DESCRIPTION
Reverts dhis2/capture-app#3784 which broke the release job