### PR TITLE
fix: [DHIS2-18004] sort events in rules engine by occurredAt and createdAt

### DIFF
--- a/packages/rules-engine/src/services/VariableService/VariableService.js
+++ b/packages/rules-engine/src/services/VariableService/VariableService.js
@@ -85,7 +85,7 @@ export class VariableService {
 
         this.defaultValues = defaultValues;
 
-        this.structureEvents = getStructureEvents(dateUtils.compareDates);
+        this.structureEvents = getStructureEvents(dateUtils.compareDates, onProcessValue);
     }
 
     getVariables({

--- a/packages/rules-engine/src/services/VariableService/variableService.types.js
+++ b/packages/rules-engine/src/services/VariableService/variableService.types.js
@@ -1,4 +1,5 @@
 // @flow
+import { typeof typeKeys } from '../../constants';
 import { typeof eventStatuses } from './constants';
 import type { DataElements, TrackedEntityAttributes, OrgUnit } from '../../rulesEngine.types';
 
@@ -89,3 +90,5 @@ export type VariableServiceInput = {|
 |};
 
 export type CompareDates = (firstRulesDate: ?string, secondRulesDate: ?string) => number;
+
+export type ProcessValue = (value: any, type: $Values<typeKeys>) => any;

--- a/src/core_modules/capture-core/rules/converters/dateUtils.js
+++ b/src/core_modules/capture-core/rules/converters/dateUtils.js
@@ -51,16 +51,10 @@ export const dateUtils: IDateUtils = {
         return momentToRulesDate(newDateMoment);
     },
     compareDates: (firstRulesDate: ?string, secondRulesDate: ?string): number => {
-        const diff = dateUtils.daysBetween(secondRulesDate, firstRulesDate);
-        if (!diff) {
-            return 0;
-        }
-        if (diff < 0) {
-            return -1;
-        }
-        if (diff > 0) {
-            return 1;
-        }
-        return 0;
+        // Empty input dates will be replaced by "MAX_SAFE_INTEGER" when creating the timestamp.
+        // This ensures empty input will be bigger than any actual date
+        const firstDateTimestamp = firstRulesDate ? moment(firstRulesDate).valueOf() : Number.MAX_SAFE_INTEGER;
+        const secondDateTimestamp = secondRulesDate ? moment(secondRulesDate).valueOf() : Number.MAX_SAFE_INTEGER;
+        return firstDateTimestamp - secondDateTimestamp;
     },
 };


### PR DESCRIPTION
The events weren't sorted because the dates weren't in the right format. Ended up removing the validation in the end as it is not needed. Without the validation the old format would probably have worked, but for consistency, the values are now converted to the right "rules engine format".

Additionally, if two events occurred on the same date, they are now sorted by their creation date, ensuring the result is idempotent.  