### PR TITLE
refactor: bump download-artifact and upload-artifact version

### DIFF
--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Build
         run: yarn build
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: app-build
           path: |
@@ -214,7 +214,7 @@ jobs:
         with:
           node-version: 18.x
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: app-build
 


### PR DESCRIPTION
To fix the failures in the [build](https://github.com/dhis2/capture-app/actions/runs/10807955762/job/29979941872?pr=3799) and [release]( https://github.com/dhis2/capture-app/actions/runs/10697575105/job/29655274124) jobs, I bump actions/download-artifact and actions/upload-artifact to `v4`. You can read more details about the issue in the [Github artifacts deprecation notice](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/ ) and the [artifacts compatibility](https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md#which-versions-of-the-artifacts-packages-are-compatible) 