### PR TITLE
feat: [DHIS2-15238] show and filter on assigned user in program stage WL

### DIFF
--- a/cypress/e2e/WorkingLists/EventWorkingLists/EventWorkingListsDev/EventWorkingListsDev.js
+++ b/cypress/e2e/WorkingLists/EventWorkingLists/EventWorkingListsDev/EventWorkingListsDev.js
@@ -1,5 +1,5 @@
 import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
-import '../../sharedSteps';
+import '../sharedSteps';
 
 beforeEach(() => {
     // Disable cache for chromium browsers to force the api to be called

--- a/cypress/e2e/WorkingLists/EventWorkingLists/EventWorkingListsUser/EventWorkingListsUser.js
+++ b/cypress/e2e/WorkingLists/EventWorkingLists/EventWorkingListsUser/EventWorkingListsUser.js
@@ -508,3 +508,19 @@ Then('the custom events working list is deleted', () => {
             cy.contains('toDeleteWorkingList').should('not.exist');
         });
 });
+
+When('you set the assignee filter to anyone', () => {
+    cy.get('[data-test="event-working-lists"]')
+        .contains('Assigned to')
+        .click();
+
+    cy.get('[data-test="list-view-filter-contents"]')
+        .contains('Anyone')
+        .click();
+});
+
+Then('the assigned to filter button should show that the anyone filter is in effect', () => {
+    cy.get('[data-test="event-working-lists"]')
+        .contains('Assigned to: Anyone')
+        .should('exist');
+});

--- a/cypress/e2e/WorkingLists/EventWorkingLists/EventWorkingListsUser/EventWorkingListsUser.js
+++ b/cypress/e2e/WorkingLists/EventWorkingLists/EventWorkingListsUser/EventWorkingListsUser.js
@@ -1,6 +1,6 @@
 import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
 import { v4 as uuid } from 'uuid';
-import '../../sharedSteps';
+import '../sharedSteps';
 import { getCurrentYear, combineDataAndYear } from '../../../../support/date';
 
 Given('you open the main page with Ngelehun and malaria case context', () => {
@@ -507,20 +507,4 @@ Then('the custom events working list is deleted', () => {
         .within(() => {
             cy.contains('toDeleteWorkingList').should('not.exist');
         });
-});
-
-When('you set the assignee filter to anyone', () => {
-    cy.get('[data-test="event-working-lists"]')
-        .contains('Assigned to')
-        .click();
-
-    cy.get('[data-test="list-view-filter-contents"]')
-        .contains('Anyone')
-        .click();
-});
-
-Then('the assigned to filter button should show that the anyone filter is in effect', () => {
-    cy.get('[data-test="event-working-lists"]')
-        .contains('Assigned to: Anyone')
-        .should('exist');
 });

--- a/cypress/e2e/WorkingLists/EventWorkingLists/sharedSteps.js
+++ b/cypress/e2e/WorkingLists/EventWorkingLists/sharedSteps.js
@@ -1,0 +1,18 @@
+import { When, Then } from '@badeball/cypress-cucumber-preprocessor';
+import '../sharedSteps';
+
+When('you set the assignee filter to anyone', () => {
+    cy.get('[data-test="event-working-lists"]')
+        .contains('Assigned to')
+        .click();
+
+    cy.get('[data-test="list-view-filter-contents"]')
+        .contains('Anyone')
+        .click();
+});
+
+Then('the assigned to filter button should show that the anyone filter is in effect', () => {
+    cy.get('[data-test="event-working-lists"]')
+        .contains('Assigned to: Anyone')
+        .should('exist');
+});

--- a/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsDev/TeiWorkingListsDev.feature
+++ b/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsDev/TeiWorkingListsDev.feature
@@ -23,18 +23,6 @@ And teis with an active enrollment should be retrieved from the api
 And the list should display the teis retrieved from the api
 And for a tracker program the page navigation should show that you are on the first page
 
-Scenario: Show only teis with active enrollments and unassinged events using the filter
-Given you open the main page with Ngelehun and Malaria focus investigation context
-When you set the enrollment status filter to active
-And you apply the enrollment status filter
-And you set the assginee filter to none
-And you apply the assignee filter
-Then the enrollment status filter button should show that the active filter is in effect
-And the assignee filter button should show that unassigned filter is in effect
-And teis with active enrollments and unassigned events should be retrieved from the api
-And the list should display the teis retrieved from the api
-And for a tracker program the page navigation should show that you are on the first page
-
 Scenario: Show only teis with first name containig John using the filter
 Given you open the main page with Ngelehun and child programme context
 When you set the first name filter to John

--- a/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsDev/TeiWorkingListsDev.js
+++ b/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsDev/TeiWorkingListsDev.js
@@ -92,35 +92,6 @@ Then('teis with an active enrollment should be retrieved from the api', () => {
     cy.get('@result').its('response.body').as('teis');
 });
 
-When('you apply the assignee filter', () => {
-    cy.intercept('GET', '**/tracker/trackedEntities**').as('getTeisStatusAndAssigneeFilter');
-
-    cy.get('[data-test="list-view-filter-apply-button"]')
-        .click();
-});
-
-Then('teis with active enrollments and unassigned events should be retrieved from the api', () => {
-    cy.wait('@getTeisStatusAndAssigneeFilter', { timeout: 40000 }).as('result');
-
-    cy.get('@result')
-        .its('response.statusCode')
-        .should('eq', 200);
-
-    cy.get('@result')
-        .its('response.url')
-        .should('include', 'programStatus=ACTIVE');
-
-    cy.get('@result')
-        .its('response.url')
-        .should('include', 'assignedUserMode=NONE');
-
-    cy.get('@result')
-        .its('response.url')
-        .should('include', 'page=1');
-
-    cy.get('@result').its('response.body').as('teis');
-});
-
 When('you apply the current filter on the tei working list', () => {
     cy.intercept('GET', '**/tracker/trackedEntities**').as('getTeis');
 

--- a/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/TeiWorkingListsUser.feature
+++ b/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/TeiWorkingListsUser.feature
@@ -208,9 +208,9 @@ And you select the Foci response program stage
 And you apply the current filter
 And you set the assignee filter to anyone
 And you apply the current filter
-Then the assigned to filter button should show that the anyone filter is in effect
-And the assigned column is displayed
-And active events that are assigned to anyone should be retrieved from the api
+Then the assignee filter button should show that the anyone filter is in effect
+And the assignee column is displayed
+And events that are assigned to anyone should be retrieved from the api
 
 @v>=40
 Scenario: The user can create and delete a program stage working list for Foci investigation & classification assigned events

--- a/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/TeiWorkingListsUser.feature
+++ b/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/TeiWorkingListsUser.feature
@@ -201,6 +201,26 @@ And you set the event visit date to Today
 And you apply the current filter
 Then the working list is empty
 
+Scenario: The user can filter the Foci response assigned events
+Given you open the main page with Ngelehun and Malaria focus investigation context
+When you open the program stage filters from the more filters dropdown menu
+And you select the Foci response program stage
+And you apply the current filter
+And you set the assignee filter to anyone
+And you apply the current filter
+Then the assigned to filter button should show that the anyone filter is in effect
+And the assigned column is displayed
+And active events that are assigned to anyone should be retrieved from the api
+
+@v>=40
+Scenario: The user can create and delete a program stage working list for Foci investigation & classification assigned events
+Given you open the main page with Ngelehun and Malaria focus investigation context
+And you filter by assigned Foci investigation & classification events
+When you save the list with the name Custom Program stage list
+Then the new Custom Program stage list is created
+And you delete the name Custom Program stage list
+Then the Custom Program stage list is deleted
+
 @v>=40
 Scenario: The user creates, updates and deletes a Program stage custom working list
 Given you open the main page with Ngelehun and Malaria case diagnosis and Household investigation context

--- a/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/TeiWorkingListsUser.js
+++ b/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/TeiWorkingListsUser.js
@@ -866,3 +866,78 @@ Then('the working list is empty', () => {
         .contains('No items to display')
         .click();
 });
+
+When('you set the assignee filter to anyone', () => {
+    cy.intercept('GET', '**/tracker/events**').as('getEventsAssignedToAnyone');
+
+    cy.get('[data-test="tei-working-lists"]')
+        .contains('Assigned to')
+        .click();
+
+    cy.get('[data-test="list-view-filter-contents"]')
+        .contains('Anyone')
+        .click();
+});
+
+Then('the assigned to filter button should show that the anyone filter is in effect', () => {
+    cy.get('[data-test="tei-working-lists"]')
+        .contains('Assigned to: Anyone')
+        .should('exist');
+});
+
+Then('the assigned column is displayed', () => {
+    cy.get('[data-test="dhis2-uicore-tablehead"]')
+        .contains('Assigned to')
+        .should('exist');
+
+    cy.get('[data-test="dhis2-uicore-tablebody"]')
+        .contains('Tracker demo User (tracker)')
+        .should('exist');
+});
+
+Then('active events that are assigned to anyone should be retrieved from the api', () => {
+    cy.wait('@getEventsAssignedToAnyone', { timeout: 40000 }).as('result');
+
+    cy.get('@result')
+        .its('response.statusCode')
+        .should('equal', 200);
+
+    cy.get('@result')
+        .its('response.url')
+        .should('include', 'assignedUserMode=ANY');
+
+    cy.get('@result')
+        .its('response.url')
+        .should('include', 'page=1');
+
+    cy.get('@result').its('response.body').as('events');
+});
+
+And('you filter by assigned Foci investigation & classification events', () => {
+    cy.get('[data-test="tei-working-lists"]')
+        .within(() => {
+            cy.contains('More filters')
+                .click();
+        });
+
+    cy.get('[data-test="more-filters-menu"]')
+        .within(() => cy.contains('Program stage').click());
+
+    cy.get('[data-test="list-view-filter-contents"]')
+        .contains('Foci investigation & classification')
+        .click();
+
+    cy.get('[data-test="list-view-filter-apply-button"]')
+        .click();
+
+    cy.get('[data-test="tei-working-lists"]')
+        .contains('Assigned to')
+        .click();
+
+    cy.get('[data-test="list-view-filter-contents"]')
+        .contains('Anyone')
+        .click();
+
+    cy.get('[data-test="list-view-filter-apply-button"]')
+        .click();
+});

--- a/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/TeiWorkingListsUser.js
+++ b/cypress/e2e/WorkingLists/TeiWorkingLists/TeiWorkingListsUser/TeiWorkingListsUser.js
@@ -198,39 +198,24 @@ When('you set the WHOMCH Smoking filter to No', () => {
         .click();
 });
 
-When('you set the assginee filter to none', () => {
+When('you set the assignee filter to anyone', () => {
+    cy.intercept('GET', '**/tracker/events**').as('getEventsAssignedToAnyone');
+
     cy.get('[data-test="tei-working-lists"]')
         .contains('Assigned to')
         .click();
 
     cy.get('[data-test="list-view-filter-contents"]')
-        .contains('None')
+        .contains('Anyone')
         .click();
 });
 
-Then('the assignee filter button should show that unassigned filter is in effect', () => {
+Then('the assignee filter button should show that the anyone filter is in effect', () => {
     cy.get('[data-test="tei-working-lists"]')
-        .contains('Assigned to: None')
+        .contains('Assigned to: Anyone')
         .should('exist');
 });
 
-Then('the list should display teis with an active enrollment and unassinged events', () => {
-    const ids = [
-        'ZDA984904',
-        'FSL05494',
-    ];
-
-    cy.get('[data-test="tei-working-lists"]')
-        .find('tr')
-        .should('have.length', 3)
-        .each(($teiRow, index) => {
-            if (index) {
-                cy.wrap($teiRow)
-                    .contains(ids[index - 1])
-                    .should('exist');
-            }
-        });
-});
 
 Then('the list should display teis with John as the first name', () => {
     cy.get('[data-test="tei-working-lists"]')
@@ -627,7 +612,7 @@ When('you select a data element columns and save from the column selector', () =
 });
 
 Then('you see data elements specific filters and columns', () => {
-    cy.get('[data-test="filter-button-container-DX4LVYeP7bw"]')
+    cy.get('[data-test="filter-button-container-assignedUser"]')
         .should('exist');
     cy.get('[data-test="tei-working-lists"]')
         .should('exist');
@@ -867,25 +852,7 @@ Then('the working list is empty', () => {
         .click();
 });
 
-When('you set the assignee filter to anyone', () => {
-    cy.intercept('GET', '**/tracker/events**').as('getEventsAssignedToAnyone');
-
-    cy.get('[data-test="tei-working-lists"]')
-        .contains('Assigned to')
-        .click();
-
-    cy.get('[data-test="list-view-filter-contents"]')
-        .contains('Anyone')
-        .click();
-});
-
-Then('the assigned to filter button should show that the anyone filter is in effect', () => {
-    cy.get('[data-test="tei-working-lists"]')
-        .contains('Assigned to: Anyone')
-        .should('exist');
-});
-
-Then('the assigned column is displayed', () => {
+Then('the assignee column is displayed', () => {
     cy.get('[data-test="dhis2-uicore-tablehead"]')
         .contains('Assigned to')
         .should('exist');
@@ -893,9 +860,13 @@ Then('the assigned column is displayed', () => {
     cy.get('[data-test="dhis2-uicore-tablebody"]')
         .contains('Tracker demo User (tracker)')
         .should('exist');
+
+    cy.get('[data-test="tei-working-lists"]')
+        .find('tr')
+        .should('have.length', 2);
 });
 
-Then('active events that are assigned to anyone should be retrieved from the api', () => {
+Then('events that are assigned to anyone should be retrieved from the api', () => {
     cy.wait('@getEventsAssignedToAnyone', { timeout: 40000 }).as('result');
 
     cy.get('@result')

--- a/cypress/e2e/WorkingLists/sharedSteps.js
+++ b/cypress/e2e/WorkingLists/sharedSteps.js
@@ -12,22 +12,6 @@ Then('for a tracker program the page navigation should show that you are on the 
         .should('exist');
 });
 
-Then('the assigned to filter button should show that the anyone filter is in effect', () => {
-    cy.get('[data-test="event-working-lists"]')
-        .contains('Assigned to: Anyone')
-        .should('exist');
-});
-
-When('you set the assignee filter to anyone', () => {
-    cy.get('[data-test="event-working-lists"]')
-        .contains('Assigned to')
-        .click();
-
-    cy.get('[data-test="list-view-filter-contents"]')
-        .contains('Anyone')
-        .click();
-});
-
 When('you set the status filter to active', () => {
     cy.get('[data-test="event-working-lists"]')
         .contains('Status')

--- a/cypress/e2e/WorkingLists/sharedSteps.js
+++ b/cypress/e2e/WorkingLists/sharedSteps.js
@@ -82,16 +82,6 @@ When('you set the enrollment status filter to active', () => {
         .click();
 });
 
-When('you set the assginee filter to none', () => {
-    cy.get('[data-test="tei-working-lists"]')
-        .contains('Assigned to')
-        .click();
-
-    cy.get('[data-test="list-view-filter-contents"]')
-        .contains('None')
-        .click();
-});
-
 When(/^you set the first name filter to (.*)$/, (name) => {
     cy.get('[data-test="tei-working-lists"]')
         .contains('First name')
@@ -128,12 +118,6 @@ Then('the sort arrow should indicate descending order', () => {
 Then('rows per page should be set to 15', () => {
     cy.get('div[data-test="rows-per-page-selector"]')
         .contains('15')
-        .should('exist');
-});
-
-Then('the assignee filter button should show that unassigned filter is in effect', () => {
-    cy.get('[data-test="tei-working-lists"]')
-        .contains('Assigned to: None')
         .should('exist');
 });
 

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/hooks/useDefaultColumnConfig.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/hooks/useDefaultColumnConfig.js
@@ -36,13 +36,13 @@ const getProgramStageMainConfig = (programStage): Array<MetadataColumnConfig> =>
     [
         {
             id: ADDITIONAL_FILTERS.status,
-            visible: false,
+            visible: true,
             type: dataElementTypes.TEXT,
             header: i18n.t(ADDITIONAL_FILTERS_LABELS.status),
         },
         {
             id: ADDITIONAL_FILTERS.occurredAt,
-            visible: false,
+            visible: true,
             type: dataElementTypes.DATE,
             header: programStage.stageForm.getLabel('occurredAt') || i18n.t(ADDITIONAL_FILTERS_LABELS.occurredAt),
         },
@@ -50,11 +50,21 @@ const getProgramStageMainConfig = (programStage): Array<MetadataColumnConfig> =>
             ? [
                 {
                     id: ADDITIONAL_FILTERS.scheduledAt,
-                    visible: false,
+                    visible: true,
                     type: dataElementTypes.DATE,
                     header:
                           programStage.stageForm.getLabel('scheduledAt') ||
                           i18n.t(ADDITIONAL_FILTERS_LABELS.scheduledAt),
+                },
+            ]
+            : []),
+        ...(programStage.enableUserAssignment
+            ? [
+                {
+                    id: ADDITIONAL_FILTERS.assignedUser,
+                    visible: true,
+                    type: dataElementTypes.ASSIGNEE,
+                    header: i18n.t(ADDITIONAL_FILTERS_LABELS.assignedUser),
                 },
             ]
             : []),

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/hooks/useFiltersOnly.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/hooks/useFiltersOnly.js
@@ -6,11 +6,9 @@ import { MAIN_FILTERS } from '../../constants';
 
 export const useFiltersOnly = ({
     enrollment: { enrollmentDateLabel, incidentDateLabel, showIncidentDate },
-    stages,
 }: TrackerProgram) =>
-    useMemo(() => {
-        const enableUserAssignment = Array.from(stages.values()).find(stage => stage.enableUserAssignment);
-        return [
+    useMemo(
+        () => [
             {
                 id: MAIN_FILTERS.PROGRAM_STATUS,
                 type: dataElementTypes.TEXT,
@@ -74,15 +72,6 @@ export const useFiltersOnly = ({
                     followUp: rawFilter.split(':')[1],
                 }),
             },
-            ...(enableUserAssignment
-                ? [
-                    {
-                        id: MAIN_FILTERS.ASSIGNEE,
-                        type: dataElementTypes.ASSIGNEE,
-                        header: i18n.t('Assigned to'),
-                        transformRecordsFilter: (rawFilter: Object) => rawFilter,
-                    },
-                ]
-                : []),
-        ];
-    }, [enrollmentDateLabel, incidentDateLabel, showIncidentDate, stages]);
+        ],
+        [enrollmentDateLabel, incidentDateLabel, showIncidentDate],
+    );

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/hooks/useProgramStageFilters.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/hooks/useProgramStageFilters.js
@@ -2,7 +2,7 @@
 import { useMemo } from 'react';
 import i18n from '@dhis2/d2-i18n';
 import { statusTypes, translatedStatusTypes } from 'capture-core/events/statusTypes';
-import { type TrackerProgram, type ProgramStage } from '../../../../../metaData';
+import { type TrackerProgram, type ProgramStage, dataElementTypes } from '../../../../../metaData';
 import { ADDITIONAL_FILTERS, ADDITIONAL_FILTERS_LABELS } from '../../helpers';
 
 const useProgramStageData = (programStageId, stages) =>
@@ -13,12 +13,14 @@ const useProgramStageData = (programStageId, stages) =>
                 hideDueDate: programStage.hideDueDate,
                 occurredAtLabel: programStage.stageForm.getLabel('occurredAt'),
                 scheduledAtLabel: programStage.stageForm.getLabel('scheduledAt'),
+                enableUserAssignment: programStage.enableUserAssignment,
             };
         }
         return {
             occurredAtLabel: i18n.t(ADDITIONAL_FILTERS_LABELS.occurredAt),
             scheduledAtLabel: i18n.t(ADDITIONAL_FILTERS_LABELS.scheduledAt),
             hideDueDate: undefined,
+            enableUserAssignment: false,
         };
     }, [programStageId, stages]);
 
@@ -33,7 +35,10 @@ const useProgramStageDropdowOptions = stages =>
     );
 
 export const useProgramStageFilters = ({ stages }: TrackerProgram, programStageId?: string) => {
-    const { hideDueDate, occurredAtLabel, scheduledAtLabel } = useProgramStageData(programStageId, stages);
+    const { hideDueDate, occurredAtLabel, scheduledAtLabel, enableUserAssignment } = useProgramStageData(
+        programStageId,
+        stages,
+    );
     const options: Array<{ text: string, value: string }> = useProgramStageDropdowOptions(stages);
 
     return useMemo(() => {
@@ -117,6 +122,16 @@ export const useProgramStageFilters = ({ stages }: TrackerProgram, programStageI
                     },
                 ]
                 : []),
+            ...(enableUserAssignment
+                ? [
+                    {
+                        id: ADDITIONAL_FILTERS.assignedUser,
+                        type: dataElementTypes.ASSIGNEE,
+                        header: ADDITIONAL_FILTERS_LABELS.assignedUser,
+                        transformRecordsFilter: (rawFilter: Object) => rawFilter,
+                    },
+                ]
+                : []),
         ];
-    }, [programStageId, occurredAtLabel, scheduledAtLabel, hideDueDate, options]);
+    }, [programStageId, occurredAtLabel, scheduledAtLabel, hideDueDate, options, enableUserAssignment]);
 };

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/apiTEIFilterToClientConfigConverter/convertToClientFilters.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/apiTEIFilterToClientConfigConverter/convertToClientFilters.js
@@ -213,7 +213,7 @@ export const convertToClientFilters = async (
     const assignee = await getAssignee(assignedUserMode, assignedUsers, querySingleResource);
 
     return {
-        assignee,
+        [ADDITIONAL_FILTERS.assignedUser]: assignee,
         ...convertToClientMainFilters(restTEIQueryCriteria),
         ...convertAttributeFilters(attributeValueFilters, columnsMetaForDataFetching),
         ...convertDataElementFilters(dataFilters, columnsMetaForDataFetching),

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/convertors.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/convertors.js
@@ -77,7 +77,7 @@ const mainFiltersTable = {
     [MAIN_FILTERS.ENROLLED_AT]: filter => getDateFilter(filter)?.dateFilter,
     [MAIN_FILTERS.OCCURED_AT]: filter => getDateFilter(filter)?.dateFilter,
     [MAIN_FILTERS.FOLLOW_UP]: filter => Boolean(filter.values[0]),
-    [MAIN_FILTERS.ASSIGNEE]: getAssigneeFilter,
+    [ADDITIONAL_FILTERS.assignedUser]: getAssigneeFilter,
     [ADDITIONAL_FILTERS.status]: filter => filter.values[0],
     [ADDITIONAL_FILTERS.occurredAt]: filter => getDateFilter(filter)?.dateFilter,
     [ADDITIONAL_FILTERS.scheduledAt]: filter => getDateFilter(filter)?.dateFilter,
@@ -109,7 +109,7 @@ export const convertMainFilters = ({
 
         const mainValue = mainFiltersTable[key](filter);
         if (mainValue) {
-            if (key === MAIN_FILTERS.ASSIGNEE) {
+            if (key === ADDITIONAL_FILTERS.assignedUser) {
                 return { ...acc, ...mainValue };
             }
             return { ...acc, [key]: mainValue };

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/eventFilters/additionalFiltersConvertor.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/eventFilters/additionalFiltersConvertor.js
@@ -4,6 +4,7 @@ export const ADDITIONAL_FILTERS = {
     occurredAt: 'eventOccurredAt',
     scheduledAt: 'scheduledAt',
     status: 'status',
+    assignedUser: 'assignedUser',
 };
 
 export const ADDITIONAL_FILTERS_LABELS = {
@@ -11,6 +12,7 @@ export const ADDITIONAL_FILTERS_LABELS = {
     occurredAt: 'Report date',
     scheduledAt: 'Scheduled date',
     status: 'Event status',
+    assignedUser: 'Assigned to',
 };
 
 export const ADDITIONAL_FILTERS_API_NAME = {

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/templates/buildArgumentsForTemplate.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/templates/buildArgumentsForTemplate.js
@@ -28,11 +28,11 @@ export const buildArgumentsForTemplate = ({
     programId: string,
     programStageId?: string,
 }) => {
-    const { programStatus, occurredAt, enrolledAt, assignedUserMode, assignedUsers, followUp } = convertMainFilters({
+    const { programStatus, occurredAt, enrolledAt, followUp } = convertMainFilters({
         filters,
         mainFilters: filtersOnly,
     });
-    const { status, eventOccurredAt, scheduledAt } = convertMainFilters({
+    const { status, eventOccurredAt, scheduledAt, assignedUserMode, assignedUsers } = convertMainFilters({
         filters,
         mainFilters: programStageFiltersOnly,
     });


### PR DESCRIPTION
[DHIS2-15238](https://dhis2.atlassian.net/browse/DHIS2-15238)

**Tech summary**
- moved the Assigned to filter from the tracked entity into the program stage filters
- show the Assigned to column by default
- store and load the assignedUser into and from a program stage working list
- sort by assignedUser name 

[DHIS2-15238]: https://dhis2.atlassian.net/browse/DHIS2-15238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ