### PR TITLE
fix: [DHIS2-18116] check return value of `parseDate`

### DIFF
--- a/src/core_modules/capture-core/converters/formToClient.js
+++ b/src/core_modules/capture-core/converters/formToClient.js
@@ -14,16 +14,20 @@ type RangeValue = {
     to: string,
 }
 
-function convertDateTime(formValue: DateTimeValue): string {
+function convertDateTime(formValue: DateTimeValue): ?string {
     const editedDate = formValue.date;
     const editedTime = formValue.time;
 
-    const momentTime = parseTime(editedTime).momentTime;
+    const parsedTime = parseTime(editedTime);
+    if (!parsedTime.isValid) return null;
+    const momentTime = parsedTime.momentTime;
     const hours = momentTime.hour();
     const minutes = momentTime.minute();
 
+    const parsedDate = parseDate(editedDate);
+    if (!parsedDate.isValid) return null;
     // $FlowFixMe[incompatible-type] automated comment
-    const momentDateTime: moment$Moment = parseDate(editedDate).momentDate;
+    const momentDateTime: moment$Moment = parsedDate.momentDate;
     momentDateTime.hour(hours);
     momentDateTime.minute(minutes);
     return momentDateTime.toISOString();
@@ -36,7 +40,9 @@ function convertDate(dateValue: string) {
 }
 
 function convertTime(timeValue: string) {
-    const momentTime = parseTime(timeValue).momentTime;
+    const parsedTime = parseTime(timeValue);
+    if (!parsedTime.isValid) return null;
+    const momentTime = parsedTime.momentTime;
     momentTime.locale('en');
     return momentTime.format('HH:mm');
 }

--- a/src/core_modules/capture-core/converters/formToClient.js
+++ b/src/core_modules/capture-core/converters/formToClient.js
@@ -30,8 +30,9 @@ function convertDateTime(formValue: DateTimeValue): string {
 }
 
 function convertDate(dateValue: string) {
+    const parsedDate = parseDate(dateValue);
     // $FlowFixMe[incompatible-use] automated comment
-    return parseDate(dateValue).momentDate.toISOString();
+    return parsedDate.isValid ? parsedDate.momentDate.toISOString() : null;
 }
 
 function convertTime(timeValue: string) {


### PR DESCRIPTION
[DHIS2-18116](https://dhis2.atlassian.net/browse/DHIS2-18116)

The bug occurred because there was missing validation of the return value from `parseDate`.

There are other occurrences of parseDate (and parseTime) in the same file, but for some reason the obvious way to trigger these functions does not work, and therefore I don't know when or if they ever get called.

EDIT:
Regarding how to trigger the other functions, see [comment below](https://github.com/dhis2/capture-app/pull/3823#issuecomment-2388492705) (thanks @simonadomnisoru)

[DHIS2-18116]: https://dhis2.atlassian.net/browse/DHIS2-18116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ