### PR TITLE
test: cleanup after running NewPage tests

### DIFF
--- a/cypress/e2e/NewPage/NewPage.feature
+++ b/cypress/e2e/NewPage/NewPage.feature
@@ -196,6 +196,9 @@ Feature: User creates a new entries from the registration page
     And you fill the Malaria case diagnosis registration form with values
     And you click the save malaria entity submit button
     Then you see the enrollment event Edit page
+    # Cleanup
+    And you delete the recently added malaria entity
+
 
 ## New enrollment of existing TEI
 

--- a/cypress/e2e/NewPage/NewPage.js
+++ b/cypress/e2e/NewPage/NewPage.js
@@ -1,4 +1,4 @@
-import { Given, When, Then, defineStep as And } from '@badeball/cypress-cucumber-preprocessor';
+import { defineStep as And, Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import moment from 'moment';
 import { getCurrentYear } from '../../support/date';
 
@@ -17,7 +17,7 @@ And('there should be informative message explaining you need to select an organi
 });
 
 And('you select tracked entity type person', () => {
-    cy.get('[data-test="dhis2-uicore-select"')
+    cy.get('[data-test="dhis2-uicore-select"]')
         .click();
     cy.get('[data-test="dhis2-uicore-singleselectoption"]')
         .contains('Person')
@@ -643,6 +643,17 @@ And('you delete the recently added tracked entity', () => {
             .click();
     });
     cy.url().should('include', 'selectedTemplateId=IpHINAT79UW');
+});
+
+And('you delete the recently added malaria entity', () => {
+    cy.get('[data-test="widget-profile-overflow-menu"]')
+        .click();
+    cy.contains('Delete Malaria Entity')
+        .click();
+    cy.get('[data-test="widget-profile-delete-modal"]').within(() => {
+        cy.contains('Yes, delete Malaria Entity')
+            .click();
+    });
 });
 
 And(/^you select (.*) from the available tracked entity types/, (selection) => {


### PR DESCRIPTION
The bulk action working list tests are currently failing due to the new page tests are adding data without cleaning it up.