### PR TITLE
fix: [DHIS2-18248] pass on createdAt to rules engine when editing

### DIFF
--- a/packages/rules-engine/src/services/VariableService/variableService.types.js
+++ b/packages/rules-engine/src/services/VariableService/variableService.types.js
@@ -27,6 +27,7 @@ type EventMain = {
     +status?: $Values<eventStatuses>,
     +occurredAt?: string,
     +scheduledAt?: string,
+    +createdAt?: string,
 };
 
 export type EventValues = {

--- a/src/core_modules/capture-core/components/WidgetEventEdit/DataEntry/epics/editEventDataEntry.epics.js
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/DataEntry/epics/editEventDataEntry.epics.js
@@ -65,14 +65,21 @@ const runRulesForEditSingleEvent = ({
     if (program instanceof TrackerProgram) {
         const { enrollment, attributeValues } = state.enrollmentDomain;
 
+        const { apiOtherEvents, apiCurrentEventOriginal } = enrollment.events.reduce((acc, apiEvent) => {
+            if (apiEvent.event === currentEvent.eventId) {
+                acc.apiCurrentEventOriginal = apiEvent;
+            } else {
+                acc.apiOtherEvents.push(apiEvent);
+            }
+            return acc;
+        }, { apiOtherEvents: [] });
+
         effects = getApplicableRuleEffectsForTrackerProgram({
             program,
             stage,
             orgUnit,
-            currentEvent,
-            otherEvents: prepareEnrollmentEventsForRulesEngine(
-                enrollment?.events.filter(enrollmentEvent => enrollmentEvent.event !== currentEvent.eventId),
-            ),
+            currentEvent: { ...currentEvent, createdAt: apiCurrentEventOriginal.createdAt },
+            otherEvents: prepareEnrollmentEventsForRulesEngine(apiOtherEvents),
             enrollmentData: getEnrollmentForRulesEngine(enrollment),
             attributeValues: getAttributeValuesForRulesEngine(attributeValues, program.attributes),
         });


### PR DESCRIPTION
There was a missing piece in https://dhis2.atlassian.net/browse/DHIS2-18004. `createdAt` wasn't passed on the rules engine when editing an event.

FYI: I didn't convert the value from "server value" because the `DATE_TIME` value type conversion needs some work. I have created another ticket for this (https://dhis2.atlassian.net/browse/DHIS2-18249). This exact scenario should work without conversion though.