### PR TITLE
fix: [DHIS2-18614] prevent runtime error when only one date range is selected

### DIFF
--- a/src/core_modules/capture-core/components/FiltersForTypes/Date/DateFilter.component.js
+++ b/src/core_modules/capture-core/components/FiltersForTypes/Date/DateFilter.component.js
@@ -117,16 +117,24 @@ const getRelativeRangeErrors = (startValue, endValue, submitAttempted) => {
     return errors;
 };
 
-const isAbsoluteRangeFilterValid = (fromValue, toValue) => {
-    if (!fromValue && !toValue) {
+const isAbsoluteRangeFilterValid = (from, to) => {
+    if (!from?.value && !to?.value) {
         return false;
     }
+    const fromValue = from?.value;
+    const toValue = to?.value;
+    const parseResultFrom = fromValue ? parseDate(fromValue) : { isValid: true, moment: null };
+    const parseResultTo = toValue ? parseDate(toValue) : { isValid: true, moment: null };
 
-    if ((fromValue && !fromValue.isValid) || (toValue && !toValue.isValid)) {
+    if (!(parseResultFrom.isValid && parseResultTo.isValid)) {
         return false;
     }
+    const isValidMomentDate = () =>
+        parseResultFrom.momentDate &&
+        parseResultTo.momentDate &&
+        parseResultFrom.momentDate.isAfter(parseResultTo.momentDate);
 
-    return !DateFilter.isFromAfterTo(fromValue?.value, toValue?.value);
+    return !isValidMomentDate();
 };
 
 const isRelativeRangeFilterValid = (startValue, endValue) => {


### PR DESCRIPTION
Implements [DHIS2-18614](https://dhis2.atlassian.net/browse/DHIS2-18614)
----------
When selecting only a `from` or `to` date in the date range filter, the application throws a runtime error, which this PR fixes 


[DHIS2-18614]: https://dhis2.atlassian.net/browse/DHIS2-18614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ