### PR TITLE
fix: [DHIS2-118654] Use importStrategy=DELETE to support older backend

### DIFF
--- a/src/core_modules/capture-core/components/WidgetEventEdit/EditEventDataEntry/editEventDataEntry.actions.js
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/EditEventDataEntry/editEventDataEntry.actions.js
@@ -71,7 +71,7 @@ export const startDeleteEventDataEntry = (serverData: Object, eventId: string, p
     actionCreator(actionTypes.START_DELETE_EVENT_DATA_ENTRY)({ eventId }, {
         offline: {
             effect: {
-                url: 'tracker?async=false&importStrategy=delete',
+                url: 'tracker?async=false&importStrategy=DELETE',
                 method: effectMethods.POST,
                 data: serverData,
             },


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-18654 

The only area where importStrategy=delete was used, every other area used importStrategy=DELETE. 
This is not an issue for newer backend versions (probably v41+, but v39 breaks). Easier to fix frontend than backend. 