### PR TITLE
fix: [DHIS2-18676] display error for age in the future

### DIFF
--- a/src/core_modules/capture-core/components/D2Form/field/configs/ageField/getAgeFieldConfig.js
+++ b/src/core_modules/capture-core/components/D2Form/field/configs/ageField/getAgeFieldConfig.js
@@ -1,14 +1,16 @@
 // @flow
+import moment from 'moment';
 import { orientations } from '../../../../FormFields/New';
 import { createFieldConfig, createProps } from '../base/configBaseDefaultForm';
 import { AgeFieldForForm } from '../../Components';
 import { systemSettingsStore } from '../../../../../metaDataMemoryStores';
-import { type DataElement } from '../../../../../metaData';
+import { convertDateObjectToDateFormatString } from '../../../../../../capture-core/utils/converters/date';
+import { type DateDataElement } from '../../../../../metaData';
 import type { QuerySingleResource } from '../../../../../utils/api/api.types';
 
 const getCalendarAnchorPosition = (formHorizontal: ?boolean) => (formHorizontal ? 'center' : 'left');
 
-export const getAgeFieldConfig = (metaData: DataElement, options: Object, querySingleResource: QuerySingleResource) => {
+export const getAgeFieldConfig = (metaData: DateDataElement, options: Object, querySingleResource: QuerySingleResource) => {
     const props = createProps({
         formHorizontal: options.formHorizontal,
         fieldLabelMediaBasedClass: options.fieldLabelMediaBasedClass,
@@ -18,6 +20,7 @@ export const getAgeFieldConfig = (metaData: DataElement, options: Object, queryS
         datePopupAnchorPosition: getCalendarAnchorPosition(options.formHorizontal),
         calendarType: systemSettingsStore.get().calendar,
         dateFormat: systemSettingsStore.get().dateFormat,
+        calendarMax: !metaData.allowFutureDate ? convertDateObjectToDateFormatString(moment()) : undefined,
     }, options, metaData);
 
     return createFieldConfig({

--- a/src/core_modules/capture-core/components/D2Form/field/defaultFormFieldGetter.js
+++ b/src/core_modules/capture-core/components/D2Form/field/defaultFormFieldGetter.js
@@ -67,7 +67,8 @@ const fieldForTypes: FieldForTypes = {
     [dataElementTypes.TIME_RANGE]: getTextRangeFieldConfig,
     [dataElementTypes.PERCENTAGE]: getTextFieldConfig,
     [dataElementTypes.URL]: getTextFieldConfig,
-    [dataElementTypes.AGE]: getAgeFieldConfig,
+    [dataElementTypes.AGE]: (metaData: any, options: Object, querySingleResource: QuerySingleResource) =>
+        getAgeFieldConfig(metaData, options, querySingleResource),
     [dataElementTypes.ORGANISATION_UNIT]: getOrgUnitFieldConfig,
     [dataElementTypes.COORDINATE]: getCoordinateFieldConfig,
     [dataElementTypes.POLYGON]: getPolygonFieldConfig,

--- a/src/core_modules/capture-core/utils/validation/getValidators.js
+++ b/src/core_modules/capture-core/utils/validation/getValidators.js
@@ -18,6 +18,7 @@ import {
 } from 'capture-core-utils/validators/form';
 import {
     isValidAge,
+    isValidNonFutureAge,
     isValidDate,
     isValidNonFutureDate,
     isValidDateTime,
@@ -153,6 +154,11 @@ const validatorsForTypes = {
         validator: isValidAge,
         message: errorMessages.AGE,
         type: validatorTypes.TYPE_BASE,
+    },
+    {
+        validator: isValidNonFutureAge,
+        type: validatorTypes.TYPE_EXTENDED,
+        message: errorMessages.DATE_FUTURE_NOT_ALLOWED,
     }],
     [dataElementTypes.PHONE_NUMBER]: [{
         validator: isValidPhoneNumber,

--- a/src/core_modules/capture-core/utils/validation/validators/form/ageValidator.js
+++ b/src/core_modules/capture-core/utils/validation/validators/form/ageValidator.js
@@ -62,13 +62,21 @@ export function isValidAge(value: Object, internalComponentError?: ?{error: ?str
         return false;
     }
 
-    const numberResult = validateNumbers(
+    if (internalComponentError && internalComponentError?.errorCode === 'INVALID_DATE_MORE_THAN_MAX') {
+        return { valid: true, errorMessage: null };
+    }
+
+    const dateValidation = value.date
+        ? validateDate(value.date, internalComponentError)
+        : { valid: true, errorMessage: null };
+
+    if (!dateValidation.valid) {
+        return dateValidation;
+    }
+
+    return validateNumbers(
         value.years,
         value.months,
         value.days,
     );
-
-    if (!numberResult.valid) return numberResult;
-
-    return validateDate(value.date, internalComponentError);
 }

--- a/src/core_modules/capture-core/utils/validation/validators/form/index.js
+++ b/src/core_modules/capture-core/utils/validation/validators/form/index.js
@@ -7,3 +7,4 @@ export { getDateRangeValidator } from './getDateRangeValidator';
 export { getDateTimeRangeValidator } from './getDateTimeRangeValidator';
 export { getNumberRangeValidator } from './getNumberRangeValidator';
 export { getTimeRangeValidator } from './getTimeRangeValidator';
+export { isValidNonFutureAge } from './isValidNonFutureAge';

--- a/src/core_modules/capture-core/utils/validation/validators/form/isValidNonFutureAge.js
+++ b/src/core_modules/capture-core/utils/validation/validators/form/isValidNonFutureAge.js
@@ -1,0 +1,21 @@
+// @flow
+import i18n from '@dhis2/d2-i18n';
+
+const CUSTOM_VALIDATION_MESSAGES = {
+    INVALID_DATE_MORE_THAN_MAX: i18n.t('A date in the future is not allowed'),
+};
+
+export const isValidNonFutureAge = (value: string, internalComponentError?: ?{error: ?string, errorCode: ?string}) => {
+    if (!value) {
+        return true;
+    }
+
+    if (internalComponentError && internalComponentError?.errorCode === 'INVALID_DATE_MORE_THAN_MAX') {
+        return {
+            valid: false,
+            errorMessage: { date: CUSTOM_VALIDATION_MESSAGES.INVALID_DATE_MORE_THAN_MAX },
+        };
+    }
+
+    return true;
+};

--- a/src/core_modules/capture-ui/AgeField/ageField.module.css
+++ b/src/core_modules/capture-ui/AgeField/ageField.module.css
@@ -18,6 +18,7 @@
 }
 
 .ageDateInputContainerHorizontal {
+    width: 150px;
 }
 
 .ageClearHorizontal {


### PR DESCRIPTION
Implements [DHIS2-18676](https://dhis2.atlassian.net/browse/DHIS2-18676)

There are two errors displayed when a user selects a future date in the age field:

- `A date in the future is not allowed`: Displayed when a user selects a date in the future from the date field.

- `Please provide a valid positive integer`: Displayed when a user enters a negative number in the Days, Months, or Years fields.

[DHIS2-18676]: https://dhis2.atlassian.net/browse/DHIS2-18676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ