### PR TITLE
fix: [DHIS2-18355] runtime error occurs when saving empty widget in Related stages

### DIFF
--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/Validated.container.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/Validated.container.js
@@ -79,7 +79,7 @@ export const Validated = ({
         formFoundationArgument: RenderFoundation,
         saveType: ?$Values<typeof addEventSaveTypes>,
         enrollment: ?Object,
-    ) => new Promise((resolve, reject) => {
+    ) => new Promise((resolve) => {
         // Creating a promise to be able to stop navigation if related stages has an error
         window.scrollTo(0, 0);
         const {
@@ -94,7 +94,7 @@ export const Validated = ({
         );
 
         if (formHasError) {
-            reject(new Error('Form has error'));
+            resolve({ success: false });
             return;
         }
 
@@ -127,13 +127,12 @@ export const Validated = ({
         ], newEventBatchActionTypes.REQUEST_SAVE_AND_SET_SUBMISSION_IN_PROGRESS),
         );
 
-        resolve();
+        resolve({ success: true });
     }), [buildNewEventPayload, dispatch, onSaveExternal, onSaveAndCompleteEnrollmentSuccessActionType, onSaveSuccessActionType, onSaveAndCompleteEnrollmentErrorActionType, onSaveErrorActionType]);
 
     const handleCreateNew = useCallback(async (isCreateNew?: boolean) => {
-        try {
-            await handleSave(itemId, dataEntryId, formFoundation, addEventSaveTypes.COMPLETE);
-
+        const saveResult = await handleSave(itemId, dataEntryId, formFoundation, addEventSaveTypes.COMPLETE);
+        if (saveResult?.success) {
             dispatch(startCreateNewAfterCompleting({
                 enrollmentId,
                 isCreateNew,
@@ -142,8 +141,6 @@ export const Validated = ({
                 teiId,
                 availableProgramStages,
             }));
-        } catch (error) {
-            // Related stages has displayed an error message. No need to do anything here.
         }
     }, [handleSave, formFoundation, dispatch, enrollmentId, orgUnit.id, program.id, teiId, availableProgramStages]);
 


### PR DESCRIPTION
Implements [DHIS2-18355](https://dhis2.atlassian.net/browse/DHIS2-18355)

[DHIS2-18355]: https://dhis2.atlassian.net/browse/DHIS2-18355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ