### PR TITLE
fix: [DHIS2-18668] remove delete button in enrollment event pages

### DIFF
--- a/cypress/e2e/NewPage/NewPage.js
+++ b/cypress/e2e/NewPage/NewPage.js
@@ -649,16 +649,25 @@ And('you delete the recently added tracked entity', () => {
 });
 
 And('you delete the recently added malaria entity', () => {
-    cy.get('[data-test="profile-widget"]')
-        .contains('Malaria Entity profile')
-        .should('exist');
-    cy.get('[data-test="widget-profile-overflow-menu"]')
-        .click();
-    cy.contains('Delete Malaria Entity')
-        .click();
-    cy.get('[data-test="widget-profile-delete-modal"]').within(() => {
-        cy.contains('Yes, delete Malaria Entity')
+    // get all url query params
+    cy.url().then((url) => {
+        const urlParams = new URLSearchParams(url);
+        urlParams.delete('stageId');
+        urlParams.delete('eventId');
+
+        cy.visit(`/#/enrollment?${urlParams.toString()}`);
+
+        cy.get('[data-test="profile-widget"]')
+            .contains('Malaria Entity profile')
+            .should('exist');
+        cy.get('[data-test="widget-profile-overflow-menu"]')
             .click();
+        cy.contains('Delete Malaria Entity')
+            .click();
+        cy.get('[data-test="widget-profile-delete-modal"]').within(() => {
+            cy.contains('Yes, delete Malaria Entity')
+                .click();
+        });
     });
 });
 

--- a/cypress/e2e/NewPage/NewPage.js
+++ b/cypress/e2e/NewPage/NewPage.js
@@ -649,25 +649,24 @@ And('you delete the recently added tracked entity', () => {
 });
 
 And('you delete the recently added malaria entity', () => {
-    // get all url query params
-    cy.url().then((url) => {
-        const urlParams = new URLSearchParams(url);
-        urlParams.delete('stageId');
-        urlParams.delete('eventId');
+    // deselect the program stage from the context selector
+    cy.get('[data-test="stage-selector-container-clear-icon"]')
+        .click();
 
-        cy.visit(`/#/enrollment?${urlParams.toString()}`);
+    cy.get('[data-test="dhis2-uicore-button"]')
+        .contains('Yes, discard changes')
+        .click();
 
-        cy.get('[data-test="profile-widget"]')
-            .contains('Malaria Entity profile')
-            .should('exist');
-        cy.get('[data-test="widget-profile-overflow-menu"]')
+    cy.get('[data-test="profile-widget"]')
+        .contains('Malaria Entity profile')
+        .should('exist');
+    cy.get('[data-test="widget-profile-overflow-menu"]')
+        .click();
+    cy.contains('Delete Malaria Entity')
+        .click();
+    cy.get('[data-test="widget-profile-delete-modal"]').within(() => {
+        cy.contains('Yes, delete Malaria Entity')
             .click();
-        cy.contains('Delete Malaria Entity')
-            .click();
-        cy.get('[data-test="widget-profile-delete-modal"]').within(() => {
-            cy.contains('Yes, delete Malaria Entity')
-                .click();
-        });
     });
 });
 

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetsForEnrollmentAddEventPage/WidgetsForEnrollmentAddEventPage.feature
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetsForEnrollmentAddEventPage/WidgetsForEnrollmentAddEventPage.feature
@@ -38,15 +38,6 @@ Feature: The user interacts with the widgets on the enrollment add event page
     And the user sees the owner organisation unit
     And the user sees the last update date
 
-  Scenario: You can delete a tracked entity from the profile widget
-    Given you add a new tracked entity in the Malaria focus investigation program
-    When the user clicks the "Back to all stages and events" button
-    When the user clicks the "New Event" button 
-    When you open the overflow menu and click the "Delete Focus area" button
-    Then you see the delete tracked entity confirmation modal
-    When you confirm by clicking the "Yes, delete Focus area" button
-    Then you are redirected to the home page
-
   Scenario: User can open the delete modal
     Given you land on the enrollment add event page by having typed #/enrollmentEventNew?programId=IpHINAT79UW&orgUnitId=DiszpKrYNg8&teiId=EaOyKGOIGRp&enrollmentId=wBU0RAsYjKE&stageId=A03MvHHogjR
     Then the enrollment widget should be opened

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetsForEnrollmentEditEvent/WidgetsForEnrollmentEditEvent.feature
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetsForEnrollmentEditEvent/WidgetsForEnrollmentEditEvent.feature
@@ -38,13 +38,6 @@ Feature: The user interacts with the widgets on the enrollment edit event
     And the user sees the owner organisation unit
     And the user sees the last update date
 
-  Scenario: You can delete a tracked entity from the profile widget
-    Given you add a new tracked entity in the Malaria focus investigation program
-    When you open the overflow menu and click the "Delete Focus area" button
-    Then you see the delete tracked entity confirmation modal
-    When you confirm by clicking the "Yes, delete Focus area" button
-    Then you are redirected to the home page
-
   Scenario: User can open the delete modal
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=XGLkLlOXgmE&orgUnitId=DiszpKrYNg8
     Then the enrollment widget should be opened
@@ -76,7 +69,7 @@ Feature: The user interacts with the widgets on the enrollment edit event
     Then the event has the user Tracker demo User assigned
     When you remove the assigned user
     Then the event has no assignd user
-  
+
   @v>=41
   Scenario: The user can view an event changelog on the enrollment edit event
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
@@ -85,7 +78,7 @@ Feature: The user interacts with the widgets on the enrollment edit event
     And the changelog modal should contain data
     # One row is filtered out as the metadata is no longer there
     And the number of changelog table rows should be 9
-  
+
   @v>=41
   Scenario: The user can change changelog page size
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
@@ -96,7 +89,7 @@ Feature: The user interacts with the widgets on the enrollment edit event
     And you change the page size to 100
     Then the number of changelog table rows should be 37
     Then the table footer should display page 1
-  
+
   @v>=41
   Scenario: The user can move to the next page in the changelog
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8

--- a/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.component.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.component.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { useState } from 'react';
-import { FlyoutMenu, IconMore16, MenuItem, MenuDivider } from '@dhis2/ui';
+import { FlyoutMenu, IconMore16, MenuItem } from '@dhis2/ui';
 import i18n from '@dhis2/d2-i18n';
 import type { PlainProps } from './OverflowMenu.types';
 import { DeleteMenuItem, DeleteModal } from './Delete';
@@ -39,16 +39,13 @@ export const OverflowMenuComponent = ({
                 component={
                     <FlyoutMenu dense>
                         {displayChangelog && (
-                            <>
-                                <MenuItem
-                                    label={i18n.t('View changelog')}
-                                    onClick={() => {
-                                        setChangelogIsOpen(true);
-                                        setActionsIsOpen(false);
-                                    }}
-                                />
-                                <MenuDivider dense />
-                            </>
+                            <MenuItem
+                                label={i18n.t('View changelog')}
+                                onClick={() => {
+                                    setChangelogIsOpen(true);
+                                    setActionsIsOpen(false);
+                                }}
+                            />
                         )}
                         {!readOnlyMode && (
                             <DeleteMenuItem

--- a/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.component.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.component.js
@@ -17,10 +17,15 @@ export const OverflowMenuComponent = ({
     displayChangelog,
     teiId,
     programAPI,
+    readOnlyMode,
 }: PlainProps) => {
     const [actionsIsOpen, setActionsIsOpen] = useState(false);
     const [deleteModalIsOpen, setDeleteModalIsOpen] = useState(false);
     const [changelogIsOpen, setChangelogIsOpen] = useState(false);
+
+    if (readOnlyMode && !displayChangelog) {
+        return null;
+    }
 
     return (
         <>
@@ -45,13 +50,15 @@ export const OverflowMenuComponent = ({
                                 <MenuDivider dense />
                             </>
                         )}
-                        <DeleteMenuItem
-                            trackedEntityTypeName={trackedEntityTypeName}
-                            canWriteData={canWriteData}
-                            canCascadeDeleteTei={canCascadeDeleteTei}
-                            setActionsIsOpen={setActionsIsOpen}
-                            setDeleteModalIsOpen={setDeleteModalIsOpen}
-                        />
+                        {!readOnlyMode && (
+                            <DeleteMenuItem
+                                trackedEntityTypeName={trackedEntityTypeName}
+                                canWriteData={canWriteData}
+                                canCascadeDeleteTei={canCascadeDeleteTei}
+                                setActionsIsOpen={setActionsIsOpen}
+                                setDeleteModalIsOpen={setDeleteModalIsOpen}
+                            />
+                        )}
                     </FlyoutMenu>
                 }
             />

--- a/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.container.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.container.js
@@ -13,6 +13,7 @@ export const OverflowMenu = ({
     displayChangelog,
     teiId,
     programAPI,
+    readOnlyMode,
 }: Props) => {
     const { hasAuthority } = useAuthorities({ authorities: ['F_TEI_CASCADE_DELETE'] });
 
@@ -27,6 +28,7 @@ export const OverflowMenu = ({
             displayChangelog={displayChangelog}
             teiId={teiId}
             programAPI={programAPI}
+            readOnlyMode={readOnlyMode}
         />
     );
 };

--- a/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.types.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.types.js
@@ -9,6 +9,7 @@ export type Props = {|
     displayChangelog: boolean,
     teiId: string,
     programAPI: any,
+    readOnlyMode: boolean,
 |};
 
 export type PlainProps = {|
@@ -21,4 +22,5 @@ export type PlainProps = {|
     displayChangelog: boolean,
     teiId: string,
     programAPI: any,
+    readOnlyMode: boolean,
 |};

--- a/src/core_modules/capture-core/components/WidgetProfile/WidgetProfile.component.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/WidgetProfile.component.js
@@ -171,6 +171,7 @@ const WidgetProfilePlain = ({
                                 trackedEntityData={clientAttributesWithSubvalues}
                                 teiId={teiId}
                                 programAPI={program}
+                                readOnlyMode={readOnlyMode || false}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
Summary:
- Added readOnlyMode prop to OverflowMenu component
- Hide the entire overflow menu when readOnlyMode is true and changelog is disabled
- Hide only the Delete action when readOnlyMode is true but changelog is enabled
- Verified readOnlyMode settings in DefaultPageLayout files:
    - true for add/edit event pages (to hide Delete)
    - false for enrollment dashboard (to show Delete)