### PR TITLE
fix: [DHIS2-18571] add explicit pageSize=100 to fetch all enrollments

### DIFF
--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/CompleteAction/hooks/useCompleteBulkEnrollments.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/TrackedEntityBulkActions/Actions/CompleteAction/hooks/useCompleteBulkEnrollments.js
@@ -125,6 +125,7 @@ export const useCompleteBulkEnrollments = ({
                     program: programId,
                     fields: 'trackedEntity,enrollments[*,!attributes,!completedBy,!completedAt,!relationships,events[*,!dataValues,!completedAt,!completedBy,!relationships]]',
                     [filterQueryParam]: Object.keys(selectedRows).join(supportForFeature ? ',' : ';'),
+                    pageSize: 100,
                 });
             },
         },


### PR DESCRIPTION
This PR fixes a bug where the enrollment completion modal was showing incorrect counts due to API pagination limits. The fix adds an explicit pageSize=100 parameter to the API request to ensure all enrollments are fetched.

Changes:

Added pageSize=100 parameter to the tracker/trackedEntities API request in useCompleteBulkEnrollments.js

![localhost_3000_235837](https://github.com/user-attachments/assets/745929f9-7fbf-4194-bd00-83c50e9f0e95)
