### PR TITLE
fix: [DHIS2-18902] keep program selection on unique id fallback search

### DIFF
--- a/src/core_modules/capture-core/components/SearchBox/SearchBox.actions.js
+++ b/src/core_modules/capture-core/components/SearchBox/SearchBox.actions.js
@@ -32,8 +32,8 @@ export const saveCurrentSearchInfo = ({
 }) => actionCreator(searchBoxActionTypes.CURRENT_SEARCH_INFO_SAVE)(
     { searchScopeType, searchScopeId, formId, currentSearchTerms });
 
-export const searchViaUniqueIdOnScopeTrackedEntityType = ({ trackedEntityTypeId, formId }) =>
-    actionCreator(searchBoxActionTypes.VIA_UNIQUE_ID_ON_SCOPE_TRACKED_ENTITY_TYPE_SEARCH)({ trackedEntityTypeId, formId });
+export const searchViaUniqueIdOnScopeTrackedEntityType = ({ trackedEntityTypeId, formId, programId }) =>
+    actionCreator(searchBoxActionTypes.VIA_UNIQUE_ID_ON_SCOPE_TRACKED_ENTITY_TYPE_SEARCH)({ trackedEntityTypeId, formId, programId });
 
 export const searchViaUniqueIdOnScopeProgram = ({ programId, formId }) =>
     actionCreator(searchBoxActionTypes.VIA_UNIQUE_ID_ON_SCOPE_PROGRAM_SEARCH)({ programId, formId });

--- a/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchForm.epics.js
+++ b/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchForm.epics.js
@@ -58,7 +58,7 @@ const searchViaUniqueIdStream = ({
         flatMap(({ trackedEntityInstanceContainers }) => {
             const searchResults = trackedEntityInstanceContainers;
             if (searchResults.length === 0 && queryArgs.program) {
-                return of(searchViaUniqueIdOnScopeTrackedEntityType({ trackedEntityTypeId: programTETId, formId }));
+                return of(searchViaUniqueIdOnScopeTrackedEntityType({ trackedEntityTypeId: programTETId, formId, programId }));
             }
             if (searchResults.length > 0) {
                 const { id, tei: { orgUnit: orgUnitId, enrollments } } = searchResults[0];
@@ -183,7 +183,7 @@ export const searchViaUniqueIdOnScopeTrackedEntityTypeEpic = (
 ) =>
     action$.pipe(
         ofType(searchBoxActionTypes.VIA_UNIQUE_ID_ON_SCOPE_TRACKED_ENTITY_TYPE_SEARCH),
-        flatMap(({ payload: { formId, trackedEntityTypeId } }) => {
+        flatMap(({ payload: { formId, trackedEntityTypeId, programId } }) => {
             const {
                 formsValues,
             } = store.value;
@@ -200,6 +200,7 @@ export const searchViaUniqueIdOnScopeTrackedEntityTypeEpic = (
             return searchViaUniqueIdStream({
                 queryArgs,
                 attributes,
+                programId,
                 absoluteApiPath,
                 querySingleResource,
             });


### PR DESCRIPTION
[DHIS2-18902](https://dhis2.atlassian.net/browse/DHIS2-18902)

This should cover the main case. There are two other similar search components which are used in the context of relationships, but I think these do not lead to opening a tracked entity, and are therefore not subject to the reported issue.

[DHIS2-18902]: https://dhis2.atlassian.net/browse/DHIS2-18902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ