### PR TITLE
fix: [DHIS2-18958] Add loading functionality to Search in all programs button

### DIFF
--- a/src/core_modules/capture-core/components/SearchBox/SearchResults/SearchResults.component.js
+++ b/src/core_modules/capture-core/components/SearchBox/SearchResults/SearchResults.component.js
@@ -8,7 +8,7 @@ import React, {
 import { withStyles } from '@material-ui/core';
 import i18n from '@dhis2/d2-i18n';
 import { Pagination } from 'capture-ui';
-import { Button, colors } from '@dhis2/ui';
+import { Button, CircularLoader, colors } from '@dhis2/ui';
 import { CardList, CardListButtons } from '../../CardList';
 import { withNavigation } from '../../Pagination/withDefaultNavigation';
 import { searchScopes } from '../SearchBox.constants';
@@ -34,6 +34,12 @@ export const getStyles = (theme: Theme) => ({
         color: colors.grey800,
         marginTop: theme.typography.pxToRem(12),
         marginBottom: theme.typography.pxToRem(12),
+    },
+    loadingMask: {
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minHeight: theme.typography.pxToRem(545),
     },
 });
 
@@ -86,6 +92,7 @@ export const SearchResultsIndex = ({
     };
 
     const handleOtherPageChange = (newOtherPage) => {
+        setIsFallbackLoading(true);
         startFallbackSearch({
             programId: currentSearchScopeId,
             formId: currentFormId,
@@ -158,23 +165,29 @@ export const SearchResultsIndex = ({
             onClose={() => setOtherResultsOpen(false)}
             onOpen={() => setOtherResultsOpen(true)}
         >
-            <CardList
-                noItemsText={i18n.t('No results found')}
-                currentSearchScopeName={currentSearchScopeName}
-                currentSearchScopeType={searchScopes.ALL_PROGRAMS}
-                items={otherResults}
-                dataElements={dataElements}
-                renderCustomCardActions={({
-                    item, enrollmentType, currentSearchScopeType: searchScopeType, programName,
-                }) => (<CardListButtons
-                    programName={programName}
-                    currentSearchScopeType={searchScopeType}
-                    currentSearchScopeId={currentSearchScopeId}
-                    id={item.id}
-                    orgUnitId={orgUnitId}
-                    enrollmentType={enrollmentType}
-                />)}
-            />
+            {isFallbackLoading ? (
+                <div className={classes.loadingMask}>
+                    <CircularLoader />
+                </div>
+            ) : (
+                <CardList
+                    noItemsText={i18n.t('No results found')}
+                    currentSearchScopeName={currentSearchScopeName}
+                    currentSearchScopeType={searchScopes.ALL_PROGRAMS}
+                    items={otherResults}
+                    dataElements={dataElements}
+                    renderCustomCardActions={({
+                        item, enrollmentType, currentSearchScopeType: searchScopeType, programName,
+                    }) => (<CardListButtons
+                        programName={programName}
+                        currentSearchScopeType={searchScopeType}
+                        currentSearchScopeId={currentSearchScopeId}
+                        id={item.id}
+                        orgUnitId={orgUnitId}
+                        enrollmentType={enrollmentType}
+                    />)}
+                />
+            )}
             <div className={classes.pagination}>
                 <SearchPagination
                     nextPageButtonDisabled={otherResults.length < resultsPageSize}

--- a/src/core_modules/capture-core/components/SearchBox/SearchResults/SearchResults.component.js
+++ b/src/core_modules/capture-core/components/SearchBox/SearchResults/SearchResults.component.js
@@ -60,6 +60,8 @@ export const SearchResultsIndex = ({
     const { resultsPageSize } = useContext(ResultsPageSizeContext);
     const [isTopResultsOpen, setTopResultsOpen] = useState(true);
     const [isOtherResultsOpen, setOtherResultsOpen] = useState(true);
+    const [isFallbackLoading, setIsFallbackLoading] = useState(false);
+
     const handlePageChange = (newPage) => {
         switch (currentSearchScopeType) {
         case searchScopes.PROGRAM:
@@ -91,7 +93,6 @@ export const SearchResultsIndex = ({
             page: newOtherPage,
         });
     };
-    const [isFallbackLoading, setIsFallbackLoading] = useState(false);
 
     useEffect(() => {
         if (otherResults !== undefined) {

--- a/src/core_modules/capture-core/components/SearchBox/SearchResults/SearchResults.component.js
+++ b/src/core_modules/capture-core/components/SearchBox/SearchResults/SearchResults.component.js
@@ -1,5 +1,10 @@
 // @flow
-import React, { type ComponentType, useContext, useState } from 'react';
+import React, {
+    type ComponentType,
+    useContext,
+    useState,
+    useEffect,
+} from 'react';
 import { withStyles } from '@material-ui/core';
 import i18n from '@dhis2/d2-i18n';
 import { Pagination } from 'capture-ui';
@@ -86,15 +91,22 @@ export const SearchResultsIndex = ({
             page: newOtherPage,
         });
     };
+    const [isFallbackLoading, setIsFallbackLoading] = useState(false);
+
+    useEffect(() => {
+        if (otherResults !== undefined) {
+            setIsFallbackLoading(false);
+        }
+    }, [otherResults]);
 
     const handleFallbackSearch = () => {
+        setIsFallbackLoading(true);
         startFallbackSearch({
             programId: currentSearchScopeId,
             formId: currentFormId,
             resultsPageSize,
         });
     };
-
     const currentProgramId = (currentSearchScopeType === searchScopes.PROGRAM) ? currentSearchScopeId : '';
 
     const { trackedEntityName } = useScopeInfo(currentSearchScopeId);
@@ -172,16 +184,19 @@ export const SearchResultsIndex = ({
         </Widget>}
         {
             currentSearchScopeType === searchScopes.PROGRAM && !fallbackTriggered && otherResults === undefined &&
-
-                <div className={classes.bottom}>
-                    <div className={classes.bottomText}>
-                        {i18n.t('Not finding the results you were looking for? Try to search all programs that use type ')}&quot;{trackedEntityName}&quot;.
-                    </div>
-
-                    <Button onClick={handleFallbackSearch} dataTest="fallback-search-button">
-                        {i18n.t('Search in all programs')}
-                    </Button>
+            <div className={classes.bottom}>
+                <div className={classes.bottomText}>
+                    {i18n.t('Not finding the results you were looking for? Try to search all programs that use type ')}&quot;{trackedEntityName}&quot;.
                 </div>
+
+                <Button
+                    onClick={handleFallbackSearch}
+                    dataTest="fallback-search-button"
+                    loading={isFallbackLoading}
+                >
+                    {i18n.t('Search in all programs')}
+                </Button>
+            </div>
         }
         <div className={classes.bottom}>
             <div className={classes.bottomText}>


### PR DESCRIPTION
[DHIS2-18958](https://dhis2.atlassian.net/browse/DHIS2-18958):

When the button is clicked, it enters a loading state. It will remain in this state until the Redux variable `otherResults` is defined. This ensures that the button stays in a loading state while the search is in progress and updates only when results are available.

A loading spinner is also implemented when navigating between pages while searching across all programs.

[DHIS2-18958]: https://dhis2.atlassian.net/browse/DHIS2-18958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ