### PR TITLE
fix: [DHIS2-18704] registration form missing values

### DIFF
--- a/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/hooks/getSubValueForTei.js
+++ b/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/hooks/getSubValueForTei.js
@@ -7,7 +7,7 @@ import { getOrgUnitNames } from '../../../../metadataRetrieval/orgUnitName';
 const getImageOrFileResourceSubvalue = async (key: string, querySingleResource: QuerySingleResource) => {
     const { id, displayName: name } = await querySingleResource({ resource: 'fileResources', id: key });
     return {
-        id,
+        value: id,
         name,
     };
 };

--- a/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/hooks/useFormValues.js
+++ b/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/hooks/useFormValues.js
@@ -71,17 +71,19 @@ const useClientAttributesWithSubvalues = (program: InputProgramData, attributes:
                 }
 
                 const acc = await promisedAcc;
-                return [
-                    ...acc,
-                    {
-                        attribute: id,
-                        key: formName,
-                        optionSet,
-                        value,
-                        unique,
-                        valueType: type,
-                    },
-                ];
+                return value
+                    ? [
+                        ...acc,
+                        {
+                            attribute: id,
+                            key: formName,
+                            optionSet,
+                            value,
+                            unique,
+                            valueType: type,
+                        },
+                    ]
+                    : acc;
             }, Promise.resolve([]));
             setListAttributes(computedAttributes);
         } else {

--- a/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/hooks/useLifecycle.js
+++ b/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/hooks/useLifecycle.js
@@ -23,7 +23,8 @@ export const useLifecycle = (
     const dataEntryReadyRef = useRef(false);
     const dispatch = useDispatch();
     const program = programId && getProgramThrowIfNotFound(programId);
-    const ready = useSelector(({ dataEntries }) => !!dataEntries[dataEntryId]) && !!orgUnit;
+    const ready =
+        useSelector(({ dataEntries }) => !!dataEntries[dataEntryId]) && !!orgUnit && dataEntryReadyRef.current === true;
     const searchTerms = useSelector(({ searchDomain }) => searchDomain.currentSearchInfo.currentSearchTerms);
     const { scopeType } = useScopeInfo(selectedScopeId);
     const { firstStageMetaData } = useBuildFirstStageRegistration(programId, scopeType !== scopeTypes.TRACKER_PROGRAM);

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
@@ -49,7 +49,7 @@ export const NewPage: ComponentType<{||}> = () => {
     const { categoryOptionIsInvalidForOrgUnit } = useCategoryOptionIsValidForOrgUnit({
         selectedOrgUnitId: orgUnitId,
     });
-    const { trackedEntityInstanceAttributes } = useTrackedEntityInstances(teiId, programId);
+    const { trackedEntityInstanceAttributes, loading: isTrackedEntityAttributesLoading } = useTrackedEntityInstances(teiId, programId);
     // $FlowFixMe
     const trackedEntityType = program?.trackedEntityType;
     const teiDisplayName =
@@ -76,7 +76,7 @@ export const NewPage: ComponentType<{||}> = () => {
         useSelector(({ activePage }) => activePage.selectionsError && activePage.selectionsError.error);
 
     const ready: boolean =
-        useSelector(({ activePage }) => (!activePage.isDataEntryLoading));
+        useSelector(({ activePage }) => (!activePage.isDataEntryLoading)) && !isTrackedEntityAttributesLoading;
 
     const currentScopeId: string =
         useSelector(({ currentSelections }) => currentSelections.programId || currentSelections.trackedEntityTypeId);

--- a/src/core_modules/capture-core/components/Pages/New/hooks/useTrackedEntityInstances.js
+++ b/src/core_modules/capture-core/components/Pages/New/hooks/useTrackedEntityInstances.js
@@ -26,6 +26,7 @@ export const useTrackedEntityInstances = (teiId: string, programId: string) => {
     }, [refetch, teiId]);
 
     return {
-        trackedEntityInstanceAttributes: teiId ? !loading && data?.trackedEntityInstance.attributes : undefined,
+        trackedEntityInstanceAttributes: teiId ? data?.trackedEntityInstance.attributes : undefined,
+        loading,
     };
 };


### PR DESCRIPTION
[DHIS2-18704](https://dhis2.atlassian.net/browse/DHIS2-18704)

**Tech summary**
The bug described in the ticket occurs when the internet speed is low, causing the registration form to load before the trackedEntity attributes are retrieved and added to the form. The proposed solution is to show the loading spinner while the trackedEntity attributes are being processed.

[DHIS2-18704]: https://dhis2.atlassian.net/browse/DHIS2-18704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ