### PR TITLE
fix: [DHIS2-17152] status of autogenerated events with openAfterEnrollment true

### DIFF
--- a/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/helpers/deriveAutoGenerateEvents.js
+++ b/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/helpers/deriveAutoGenerateEvents.js
@@ -42,13 +42,10 @@ export const deriveAutoGenerateEvents = ({
         .map(
             ({
                 id: programStage,
-                reportDateToUse: reportDateToUseInActiveStatus,
                 generatedByEnrollmentDate: generateScheduleDateByEnrollmentDate,
                 openAfterEnrollment,
                 minDaysFromStart,
             }) => {
-                const dateToUseInActiveStatus =
-                    reportDateToUseInActiveStatus === 'enrolledAt' ? enrolledAt : sanitizedOccurredAt;
                 const dateToUseInScheduleStatus = generateScheduleDateByEnrollmentDate
                     ? enrolledAt
                     : sanitizedOccurredAt;
@@ -57,25 +54,17 @@ export const deriveAutoGenerateEvents = ({
                     eventAttributeCategoryOptions.attributeCategoryOptions =
                         convertCategoryOptionsToServer(attributeCategoryOptions, serverMinorVersion);
                 }
-                const eventInfo = openAfterEnrollment
-                    ? {
-                        status: 'ACTIVE',
-                        occurredAt: dateToUseInActiveStatus,
-                        scheduledAt: dateToUseInActiveStatus,
-                    }
-                    : {
-                        status: 'SCHEDULE',
-                        // for schedule type of events we want to add the standard interval days to the date
-                        scheduledAt: convertClientToServer(moment(dateToUseInScheduleStatus)
-                            .add(minDaysFromStart, 'days')
-                            .format('YYYY-MM-DD'),
+                const scheduledAt = openAfterEnrollment
+                    ? dateToUseInScheduleStatus
+                    : convertClientToServer(
+                        moment(dateToUseInScheduleStatus).add(minDaysFromStart, 'days').format('YYYY-MM-DD'),
                         dataElementTypes.DATE,
-                        ),
-                    };
+                    );
 
                 return {
-                    ...eventInfo,
                     ...eventAttributeCategoryOptions,
+                    status: 'SCHEDULE',
+                    scheduledAt,
                     event: generateUID(),
                     programStage,
                     program: programId,


### PR DESCRIPTION
[DHIS2-17152](https://dhis2.atlassian.net/browse/DHIS2-17152)

**Tech summary**
- All the auto-generated events will have status 'SCHEDULE'
- When openAfterEnrollment is true, we do not add minDaysFromStart to the scheduledAt date

[DHIS2-17152]: https://dhis2.atlassian.net/browse/DHIS2-17152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ