### PR TITLE
fix: [DHIS2-18855] add error logging for program indicators missing expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ src/locales/
 
 # DHIS2 Platform
 .d2
+
+# Cursor
+.cursorrules
+.cursor

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/ProgramRules/rulesContainer.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/ProgramRules/rulesContainer.js
@@ -53,6 +53,7 @@ const addRulesAndVariablesFromProgramIndicators = (program, programIndicators) =
     }
 };
 
+
 export const buildRulesContainer = async ({
     programAPI,
     programRules,

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/ProgramRules/rulesContainer.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/ProgramRules/rulesContainer.js
@@ -1,4 +1,6 @@
 // @flow
+import log from 'loglevel';
+import { errorCreator } from 'capture-core-utils';
 import type { ProgramRulesContainer } from '@dhis2/rules-engine-javascript';
 import { getTrackedEntityAttributeId, getDataElementId, getProgramId, getProgramRuleActions, getProgramStageId } from '../helpers';
 import { getRulesAndVariablesFromProgramIndicators } from '../../../../metaDataMemoryStoreBuilders/programs/getRulesAndVariablesFromIndicators';
@@ -22,7 +24,22 @@ const addProgramRules = (program, programRules) => {
 };
 
 const addRulesAndVariablesFromProgramIndicators = (program, programIndicators) => {
-    const indicators = programIndicators.map(programIndicator => ({
+    const validProgramIndicators = programIndicators.filter((indicator) => {
+        if (!indicator.expression) {
+            log.error(
+                errorCreator('WidgetProfile: Program indicator is missing an expression and will be skipped.')(
+                    {
+                        method: 'addRulesAndVariablesFromProgramIndicators',
+                        object: indicator,
+                    },
+                ),
+            );
+            return false;
+        }
+        return true;
+    });
+
+    const indicators = validProgramIndicators.map(programIndicator => ({
         ...programIndicator,
         programId: getProgramId(programIndicator),
     }));


### PR DESCRIPTION
Currently, the app breaks if it's trying to load in a program indicator without an expression. Instead, we should skip the program indicator and log an error to the console. 