### PR TITLE
feat: [DHIS2-18944] add effect to refresh list on event deletion

### DIFF
--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/ViewMenuSetup/EventWorkingListsViewMenuSetup.component.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/ViewMenuSetup/EventWorkingListsViewMenuSetup.component.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import i18n from '@dhis2/d2-i18n';
 import { v4 as uuid } from 'uuid';
 import { EventWorkingListsRowMenuSetup } from '../RowMenuSetup';
@@ -13,6 +13,7 @@ export const EventWorkingListsViewMenuSetup = ({
     downloadRequest,
     program,
     dataSource,
+    lastIdDeleted,
     ...passOnProps
 }: Props) => {
     const [downloadDialogOpen, setDownloadDialogOpenStatus] = useState(false);
@@ -44,6 +45,13 @@ export const EventWorkingListsViewMenuSetup = ({
         setCustomUpdateTrigger(id);
         !disableClearSelection && clearSelection();
     }, [clearSelection]);
+
+    // Listen for event deletion and trigger list refresh
+    useEffect(() => {
+        if (lastIdDeleted) {
+            onUpdateList();
+        }
+    }, [lastIdDeleted, onUpdateList]);
 
     const eventBulkActions = (
         <EventBulkActions

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/ViewMenuSetup/EventWorkingListsViewMenuSetup.component.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/ViewMenuSetup/EventWorkingListsViewMenuSetup.component.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useCallback, useMemo, useState, useEffect } from 'react';
+import React, { useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import i18n from '@dhis2/d2-i18n';
 import { v4 as uuid } from 'uuid';
 import { EventWorkingListsRowMenuSetup } from '../RowMenuSetup';
@@ -18,6 +18,7 @@ export const EventWorkingListsViewMenuSetup = ({
 }: Props) => {
     const [downloadDialogOpen, setDownloadDialogOpenStatus] = useState(false);
     const [customUpdateTrigger, setCustomUpdateTrigger] = useState();
+    const lastProcessedDeletedIdRef = useRef(null);
 
     const {
         selectedRows,
@@ -46,10 +47,10 @@ export const EventWorkingListsViewMenuSetup = ({
         !disableClearSelection && clearSelection();
     }, [clearSelection]);
 
-    // Listen for event deletion and trigger list refresh
     useEffect(() => {
-        if (lastIdDeleted) {
+        if (lastIdDeleted && lastIdDeleted !== lastProcessedDeletedIdRef.current) {
             onUpdateList();
+            lastProcessedDeletedIdRef.current = lastIdDeleted;
         }
     }, [lastIdDeleted, onUpdateList]);
 

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/ViewMenuSetup/EventWorkingListsViewMenuSetup.types.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/ViewMenuSetup/EventWorkingListsViewMenuSetup.types.js
@@ -7,6 +7,7 @@ type ExtractedProps = $ReadOnly<{|
     downloadRequest: { url: string, queryParams: ?Object },
     program: Program,
     programStageId: string,
+    lastIdDeleted?: string,
 |}>;
 
 type RestProps = $Rest<EventWorkingListsTemplateSetupOutputProps, ExtractedProps>;


### PR DESCRIPTION
Added a useEffect that listens to the last deleted ID and refreshes the app when it's updated. Currently, the list does not refresh on delete.