### PR TITLE
fix: [DHIS2-19165] handle empty schedule date

### DIFF
--- a/src/core_modules/capture-core-utils/featuresSupport/support.js
+++ b/src/core_modules/capture-core-utils/featuresSupport/support.js
@@ -15,6 +15,7 @@ export const FEATURES = Object.freeze({
     newNoteEndpoint: 'newNoteEndpoint',
     newPagingQueryParam: 'newPagingQueryParam',
     newOrgUnitModeQueryParam: 'newOrgUnitModeQueryParam',
+    sendEmptyScheduledAt: 'sendEmptyScheduledAt',
 });
 
 // The first minor version that supports the feature
@@ -34,6 +35,7 @@ const MINOR_VERSION_SUPPORT = Object.freeze({
     [FEATURES.newNoteEndpoint]: 42,
     [FEATURES.newPagingQueryParam]: 41,
     [FEATURES.newOrgUnitModeQueryParam]: 41,
+    [FEATURES.sendEmptyScheduledAt]: 41,
 });
 
 export const hasAPISupportForFeature = (minorVersion: string | number, featureName: string) =>

--- a/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/helpers/deriveFirstStageDuringRegistrationEvent.js
+++ b/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/helpers/deriveFirstStageDuringRegistrationEvent.js
@@ -1,5 +1,5 @@
 // @flow
-import { pipe } from 'capture-core-utils';
+import { pipe, FEATURES, featureAvailable } from 'capture-core-utils';
 import { generateUID } from '../../../../utils/uid/generateUID';
 import { dataElementTypes, ProgramStage } from '../../../../metaData';
 import { convertFormToClient, convertClientToServer } from '../../../../converters';
@@ -40,7 +40,8 @@ export const deriveFirstStageDuringRegistrationEvent = ({
         status: convertStatusOut(stageComplete),
         geometry: standardGeoJson(stageGeometry),
         occurredAt: convertFn(stageOccurredAt, dataElementTypes.DATE),
-        scheduledAt: convertFn(enrolledAt, dataElementTypes.DATE),
+        // $FlowFixMe
+        ...(featureAvailable(FEATURES.sendEmptyScheduledAt) ? {} : { scheduledAt: convertFn(enrolledAt, dataElementTypes.DATE) }),
         programStage: firstStageMetadata.id,
         program: programId,
         orgUnit: orgUnitId,

--- a/src/core_modules/capture-core/components/DataEntries/converters/getConvertedRelatedStageEvent/getConvertedRelatedStageEvent.js
+++ b/src/core_modules/capture-core/components/DataEntries/converters/getConvertedRelatedStageEvent/getConvertedRelatedStageEvent.js
@@ -65,10 +65,11 @@ const getEventDetailsByLinkMode = ({
                 }),
             );
         }
+
         return ({
             linkedEvent: {
                 ...baseEventDetails,
-                scheduledAt: serverRequestEvent.scheduledAt,
+                scheduledAt: serverRequestEvent.occurredAt,
                 orgUnit: convertFn(linkedEventOrgUnit, dataElementTypes.ORGANISATION_UNIT),
             },
             linkedEventId: baseEventDetails.event,

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/getConvertedAddEvent.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/getConvertedAddEvent.js
@@ -1,10 +1,10 @@
 // @flow
 import moment from 'moment';
+import { FEATURES, featureAvailable } from 'capture-core-utils';
 import { convertDataEntryToClientValues } from '../../DataEntry/common/convertDataEntryToClientValues';
 import { convertValue as convertToServerValue } from '../../../converters/clientToServer';
 import { convertMainEventClientToServer } from '../../../events/mainConverters';
 import { type RenderFoundation } from '../../../metaData';
-import { FEATURES, featureAvailable } from '../../../../capture-core-utils';
 
 export const getAddEventEnrollmentServerData = ({
     formFoundation,

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/getConvertedAddEvent.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/getConvertedAddEvent.js
@@ -4,6 +4,7 @@ import { convertDataEntryToClientValues } from '../../DataEntry/common/convertDa
 import { convertValue as convertToServerValue } from '../../../converters/clientToServer';
 import { convertMainEventClientToServer } from '../../../events/mainConverters';
 import { type RenderFoundation } from '../../../metaData';
+import { FEATURES, featureAvailable } from '../../../../capture-core-utils';
 
 export const getAddEventEnrollmentServerData = ({
     formFoundation,
@@ -47,6 +48,7 @@ export const getAddEventEnrollmentServerData = ({
         orgUnitName: mainDataServerValues.orgUnit.name,
         trackedEntity: teiId,
         enrollment: enrollmentId,
+        ...(featureAvailable(FEATURES.sendEmptyScheduledAt) ? {} : { scheduledAt: mainDataServerValues.occurredAt }),
         updatedAt,
         uid,
         dataValues: Object

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/getConvertedAddEvent.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/getConvertedAddEvent.js
@@ -47,7 +47,6 @@ export const getAddEventEnrollmentServerData = ({
         orgUnitName: mainDataServerValues.orgUnit.name,
         trackedEntity: teiId,
         enrollment: enrollmentId,
-        scheduledAt: mainDataServerValues.occurredAt,
         updatedAt,
         uid,
         dataValues: Object

--- a/src/core_modules/capture-core/components/WidgetEventEdit/DataEntry/editEventDataEntry.actions.js
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/DataEntry/editEventDataEntry.actions.js
@@ -111,7 +111,6 @@ export const openEventForEditInDataEntry = ({
         {
             id: 'scheduledAt',
             type: 'DATE',
-            validatorContainers: getEventDateValidatorContainers(),
         },
         {
             id: 'orgUnit',

--- a/src/core_modules/capture-core/components/WidgetEventEdit/EditEventDataEntry/EditEventDataEntry.component.js
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/EditEventDataEntry/EditEventDataEntry.component.js
@@ -189,12 +189,12 @@ const buildScheduleDateSettingsFn = () => {
             calendarWidth: 350,
             label: props.formFoundation.getLabel('scheduledAt'),
             disabled: true,
+            required: false,
             calendarType: systemSettingsStore.get().calendar,
             dateFormat: systemSettingsStore.get().dateFormat,
         }),
         getIsHidden: (props: Object) => props.id !== dataEntryIds.ENROLLMENT_EVENT || props.hideDueDate,
         getPropName: () => 'scheduledAt',
-        getValidatorContainers: () => getEventDateValidatorContainers(),
         getMeta: () => ({
             placement: placements.TOP,
             section: dataEntrySectionNames.BASICINFO,


### PR DESCRIPTION
1. Don't save a scheduled date when directly adding a tracker event (from version 41). 
2. Handle empty value for `scheduledAt` when editing tracker event.