### PR TITLE
chore: Remove leaflet CDN dependencies

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,10 +49,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>%REACT_APP_DHIS2_APP_NAME% | DHIS2</title>
-    <!-- leaflet -->
-    <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.3/leaflet.css'>
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.4.2/leaflet.draw.css"/>
-    <script src='//cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.3/leaflet.js'></script>
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
These should already be packaged as part of the app build, so no reason to include them separately via a CDN. 