### PR TITLE
fix: [DHIS2-16918] Event relationship URL link is broken

### DIFF
--- a/src/core_modules/capture-core/components/Pages/ViewEvent/RightColumn/RelationshipsSection/ConnectedEntity/TrackedEntityInstance.js
+++ b/src/core_modules/capture-core/components/Pages/ViewEvent/RightColumn/RelationshipsSection/ConnectedEntity/TrackedEntityInstance.js
@@ -22,7 +22,7 @@ export const TrackedEntityInstance = ({ name, id, orgUnitId, linkProgramId }: Pr
     );
 
     return (
-        <a href={getUrl()} target="_blank" rel="noopener noreferrer">
+        <a href={getUrl()}>
             {name}
         </a>
     );

--- a/src/core_modules/capture-core/components/Pages/ViewEvent/RightColumn/RelationshipsSection/ConnectedEntity/TrackedEntityInstance.js
+++ b/src/core_modules/capture-core/components/Pages/ViewEvent/RightColumn/RelationshipsSection/ConnectedEntity/TrackedEntityInstance.js
@@ -12,7 +12,7 @@ type Props = {
 export const TrackedEntityInstance = ({ name, id, orgUnitId, linkProgramId }: Props) => {
     const getUrl = useCallback(
         () =>
-            `/#/enrollment?${buildUrlQueryString({
+            `/enrollment?${buildUrlQueryString({
                 teiId: id,
                 programId: linkProgramId,
                 orgUnitId,

--- a/src/core_modules/capture-core/components/Pages/ViewEvent/RightColumn/RelationshipsSection/ConnectedEntity/TrackedEntityInstance.js
+++ b/src/core_modules/capture-core/components/Pages/ViewEvent/RightColumn/RelationshipsSection/ConnectedEntity/TrackedEntityInstance.js
@@ -12,7 +12,7 @@ type Props = {
 export const TrackedEntityInstance = ({ name, id, orgUnitId, linkProgramId }: Props) => {
     const getUrl = useCallback(
         () =>
-            `/enrollment?${buildUrlQueryString({
+            `#/enrollment?${buildUrlQueryString({
                 teiId: id,
                 programId: linkProgramId,
                 orgUnitId,

--- a/src/core_modules/capture-core/components/Pages/common/TEIRelationshipsWidget/useLinkedRecordClick.js
+++ b/src/core_modules/capture-core/components/Pages/common/TEIRelationshipsWidget/useLinkedRecordClick.js
@@ -23,7 +23,7 @@ export const useLinkedRecordClick = () => {
             }
         } else if (navigationArgs.trackedEntityId) {
             const { trackedEntityId, programId } = navigationArgs;
-            url = `/enrollment?${buildUrlQueryString({
+            url = `#/enrollment?${buildUrlQueryString({
                 programId,
                 orgUnitId,
                 teiId: trackedEntityId,

--- a/src/core_modules/capture-core/components/Pages/common/TEIRelationshipsWidget/useLinkedRecordClick.js
+++ b/src/core_modules/capture-core/components/Pages/common/TEIRelationshipsWidget/useLinkedRecordClick.js
@@ -23,7 +23,7 @@ export const useLinkedRecordClick = () => {
             }
         } else if (navigationArgs.trackedEntityId) {
             const { trackedEntityId, programId } = navigationArgs;
-            url = `#/enrollment?${buildUrlQueryString({
+            url = `/enrollment?${buildUrlQueryString({
                 programId,
                 orgUnitId,
                 teiId: trackedEntityId,


### PR DESCRIPTION
[DHIS2-16918](https://dhis2.atlassian.net/browse/DHIS2-16918):
- URL is now relative
- The user is now redirected to TE in the existing tab, but the TE can still be opened in a new tab by CTRL+CLICK.

[DHIS2-16918]: https://dhis2.atlassian.net/browse/DHIS2-16918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ