### PR TITLE
fix: [DHIS2-18735] deselecting static list breaks breadcrumbs

### DIFF
--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/TeiWorkingListsSetup.component.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/TeiWorkingListsSetup.component.js
@@ -67,6 +67,7 @@ export const TeiWorkingListsSetup = ({
     const programStageFiltersOnly = useProgramStageFilters(program, programStageId);
     const staticTemplates = useStaticTemplates(
         storedTemplates?.find(storedTemplate => storedTemplate.isDefault && storedTemplate.isAltered),
+        `${program.id}-default`,
     );
     const templates = apiTemplates?.length > DEFAULT_TEMPLATES_LENGTH ? apiTemplates : staticTemplates;
     const viewHasChanges = useViewHasTemplateChanges({

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/hooks/useStaticTemplates.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/hooks/useStaticTemplates.js
@@ -3,11 +3,11 @@ import { useMemo } from 'react';
 import i18n from '@dhis2/d2-i18n';
 import type { WorkingListTemplate } from '../../../WorkingListsBase';
 
-export const useStaticTemplates = (defaultAlteredTemplate?: WorkingListTemplate) =>
+export const useStaticTemplates = (defaultAlteredTemplate?: WorkingListTemplate, defaultTemplateId: string) =>
     useMemo(
         () => [
             defaultAlteredTemplate || {
-                id: 'default',
+                id: defaultTemplateId ?? 'default',
                 isDefault: true,
                 name: 'default',
                 access: {
@@ -60,5 +60,5 @@ export const useStaticTemplates = (defaultAlteredTemplate?: WorkingListTemplate)
                 },
             },
         ],
-        [defaultAlteredTemplate],
+        [defaultAlteredTemplate, defaultTemplateId],
     );

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/retrieveTemplates.epics.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/epics/teiViewEpics/retrieveTemplates.epics.js
@@ -10,6 +10,7 @@ import { getProgramStageTemplates } from './templates/getProgramStageTemplates';
 import { getTEITemplates } from './templates/getTEITemplates';
 import { TEI_WORKING_LISTS_TYPE, TEI_WORKING_LISTS, PROGRAM_STAGE_WORKING_LISTS } from '../../constants';
 
+// Deduplicate default template so that only one default template is returned
 const removeDefaultTemplate = templates =>
     templates.reduce(
         (acc, template) => (template.isDefault && acc.find(accItem => accItem.isDefault) ? acc : [...acc, template]),


### PR DESCRIPTION
Summary:
- Selecting and deselecting a static list breaks the breadcrumbs 
- This is due to the wrong URL parameter being put in the URL. 