### PR TITLE
fix: [DHIS2-19307] load section containing a DE not contained in the PS

### DIFF
--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/programStage/ProgramStageFactory.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/programStage/ProgramStageFactory.js
@@ -107,9 +107,6 @@ export class ProgramStageFactory {
                 } else {
                     const id = sectionDataElement.id;
                     const cachedProgramStageDataElement = cachedProgramStageDataElements[id];
-                    const cachedDataElementDefinition = this
-                        .cachedDataElements
-                        ?.get(cachedProgramStageDataElement.dataElementId);
 
                     if (!cachedProgramStageDataElement) {
                         log.error(
@@ -117,6 +114,10 @@ export class ProgramStageFactory {
                                 { sectionDataElement }));
                         return;
                     }
+
+                    const cachedDataElementDefinition = this
+                        .cachedDataElements
+                        ?.get(cachedProgramStageDataElement.dataElementId);
 
                     const element = await this.dataElementFactory.build(
                         cachedProgramStageDataElement,


### PR DESCRIPTION
[DHIS2-19307](https://dhis2.atlassian.net/browse/DHIS2-19307)

This fix just moves an existence check up a few lines. 

[DHIS2-19307]: https://dhis2.atlassian.net/browse/DHIS2-19307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ