### PR TITLE
fix: [DHIS2-19336] provide empty array instead of `null` to `RuleEnrollmentJs`

### DIFF
--- a/src/core_modules/capture-core/rules/RuleEngine/helpers/InputBuilder.js
+++ b/src/core_modules/capture-core/rules/RuleEngine/helpers/InputBuilder.js
@@ -344,7 +344,7 @@ export class InputBuilder {
             .map(key => new RuleAttributeValue(
                 key,
                 this.convertTrackedEntityAttributeValue(key, selectedEntity[key]),
-            )) : null;
+            )) : [];
 
         const convertDate = (dateString: ?string) => this.toLocalDate(dateString, LocalDate.now());
 


### PR DESCRIPTION
[DHIS2-19336](https://dhis2.atlassian.net/browse/DHIS2-19336)

[RuleEnrollmentJs](https://github.com/dhis2/dhis2-rule-engine/blob/master/src/jsMain/kotlin/org/hisp/dhis/rules/RuleEnrollmentJs.kt) expects a non-null array value in the last argument.

[DHIS2-19336]: https://dhis2.atlassian.net/browse/DHIS2-19336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ