### PR TITLE
fix: Event notes uses wrong date format

### DIFF
--- a/src/core_modules/capture-core/components/WidgetNote/NoteSection/NoteSection.js
+++ b/src/core_modules/capture-core/components/WidgetNote/NoteSection/NoteSection.js
@@ -120,6 +120,7 @@ const NoteSectionPlain = ({
         </div>
     );
 
+    console.log('NoteSectionPlain: notes', notes);
 
     return (
         <div className={classes.wrapper}>


### PR DESCRIPTION
Closed, fixed in another PR.

[DHIS2-18770]: https://dhis2.atlassian.net/browse/DHIS2-18770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ