### PR TITLE
chore: [DHIS2-18642] Cypress tests changelog

### DIFF
--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.feature
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.feature
@@ -1,14 +1,14 @@
-@v>=41
 Feature: The user interacts with the changelog widget
 
   Background:
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
     And you select view changelog in the event overflow button
     Then the changelog modal should contain data
-
+  @v>=41
   Scenario: The user can view an event changelog on the enrollment edit event
     Then the number of changelog table rows should be 9
 
+  @v>=41
   Scenario: The user can change the changelog page size
     When you change the page size to 20
     Then the number of changelog table rows should be 19
@@ -16,17 +16,20 @@ Feature: The user interacts with the changelog widget
     Then the number of changelog table rows should be 37
     And the table footer should display page 1
 
+  @v>=41
   Scenario: The user can navigate between pages in the changelog
     When you move to the next page
     Then the table footer should display page 2
     When you move to the previous page
     Then the table footer should display page 1
 
+  @v>=42
   Scenario: The user can filter the changelog by data item
     When you select "Treatment card" from the data item filter flyout menu
     Then the filter pill should be visible with label "Treatment card"
     And only rows with Data item "Treatment card" should be displayed
 
+  @v>=42
   Scenario: Only one filter can be applied at a time
     When you select "HIV testing done" from the data item filter flyout menu
     Then the filter pill should be visible with label "HIV testing done"
@@ -34,12 +37,14 @@ Feature: The user interacts with the changelog widget
     Then the filter pill should be visible with label "Disease Classification"
     And only rows with Data item "Disease Classification" should be displayed
 
+  @v>=42
   Scenario: The filter remains active when sorting is applied
     When you select "Disease Classification" from the data item filter flyout menu
     When you click the sort Date icon
     Then only rows with Data item "Disease Classification" should be displayed
     And the changelog data is sorted on Date in ascending order
 
+  @v>=42
   Scenario: The user can remove the applied filter
     When you select "Disease Classification" from the data item filter flyout menu
     Then the filter pill should be visible with label "Disease Classification"
@@ -47,14 +52,17 @@ Feature: The user interacts with the changelog widget
     When you remove the filter
     Then the filter pill should be visible with label "Show all"
 
+  @v>=42
   Scenario: The user can sort by Date
     When you click the sort Date icon
     Then the changelog data is sorted on Date in ascending order
 
+  @v>=42
   Scenario: The user can sort by User
     When you click the sort User icon
     Then the changelog data is sorted on User in ascending order
 
+  @v>=42
   Scenario: The user can sort by Data item
     When you click the sort Data item icon
     Then the changelog data is sorted on Data item in ascending order

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.feature
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.feature
@@ -4,14 +4,12 @@ Feature: The user interacts with the changelog widget
   Background:
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
     And you select view changelog in the event overflow button
-
+    Then the changelog modal should contain data
 
   Scenario: The user can view an event changelog on the enrollment edit event
-    Then the changelog modal should be visible
-    And the changelog modal should contain data
-    And the number of changelog table rows should be 9
+    Then the number of changelog table rows should be 9
 
-  Scenario: The user can change changelog page size
+  Scenario: The user can change the changelog page size
     When you change the page size to 20
     Then the number of changelog table rows should be 19
     And you change the page size to 100
@@ -49,14 +47,14 @@ Feature: The user interacts with the changelog widget
     When you remove the filter
     Then the filter pill should be visible with label "Show all"
 
-  Scenario: The user can sort by Date in ascending order
+  Scenario: The user can sort by Date
     When you click the sort Date icon
     Then the changelog data is sorted on Date in ascending order
 
-  Scenario: The user can sort by User in ascending order
+  Scenario: The user can sort by User
     When you click the sort User icon
     Then the changelog data is sorted on User in ascending order
 
-  Scenario: The user can sort by Data item in ascending order
+  Scenario: The user can sort by Data item
     When you click the sort Data item icon
     Then the changelog data is sorted on Data item in ascending order

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.feature
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.feature
@@ -1,28 +1,62 @@
+@v>=41
 Feature: The user interacts with the changelog widget
 
-@v>=41
-  Scenario: The user can view an event changelog on the enrollment edit event
+  Background:
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    When you select view changelog in the event overflow button
+    And you select view changelog in the event overflow button
+
+
+  Scenario: The user can view an event changelog on the enrollment edit event
     Then the changelog modal should be visible
     And the changelog modal should contain data
-    # One row is filtered out as the metadata is no longer there
     And the number of changelog table rows should be 9
 
-  @v>=41
   Scenario: The user can change changelog page size
-    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    When you select view changelog in the event overflow button
-    And you change the page size to 20
-    # One row is filtered out as the metadata is no longer there
+    When you change the page size to 20
     Then the number of changelog table rows should be 19
     And you change the page size to 100
     Then the number of changelog table rows should be 37
+    And the table footer should display page 1
+
+  Scenario: The user can navigate between pages in the changelog
+    When you move to the next page
+    Then the table footer should display page 2
+    When you move to the previous page
     Then the table footer should display page 1
 
-  @v>=41
-  Scenario: The user can move to the next page in the changelog
-    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    When you select view changelog in the event overflow button
-    And you move to the next page
-    Then the table footer should display page 2
+  Scenario: The user can filter the changelog by data item
+    When you select "Treatment card" from the data item filter flyout menu
+    Then the filter pill should be visible with label "Treatment card"
+    And only rows with Data item "Treatment card" should be displayed
+
+  Scenario: Only one filter can be applied at a time
+    When you select "HIV testing done" from the data item filter flyout menu
+    Then the filter pill should be visible with label "HIV testing done"
+    When you select "Disease Classification" from the data item filter flyout menu
+    Then the filter pill should be visible with label "Disease Classification"
+    And only rows with Data item "Disease Classification" should be displayed
+
+  Scenario: The filter remains active when sorting is applied
+    When you select "Disease Classification" from the data item filter flyout menu
+    When you click the sort Date icon
+    Then only rows with Data item "Disease Classification" should be displayed
+    And the changelog data is sorted on Date in ascending order
+
+  Scenario: The user can remove the applied filter
+    When you select "Disease Classification" from the data item filter flyout menu
+    Then the filter pill should be visible with label "Disease Classification"
+    And only rows with Data item "Disease Classification" should be displayed
+    When you remove the filter
+    Then the filter pill should be visible with label "Show all"
+
+  Scenario: The user can sort by Date in ascending order
+    When you click the sort Date icon
+    Then the changelog data is sorted on Date in ascending order
+
+  Scenario: The user can sort by User in ascending order
+    When you click the sort User icon
+    Then the changelog data is sorted on User in ascending order
+
+  Scenario: The user can sort by Data item in ascending order
+    When you click the sort Data item icon
+    Then the changelog data is sorted on Data item in ascending order

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.feature
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.feature
@@ -55,14 +55,17 @@ Feature: The user interacts with the changelog widget
   @v>=42
   Scenario: The user can sort by Date
     When you click the sort Date icon
-    Then the changelog data is sorted on Date in ascending order
+    Then the changelog modal should contain data
+    And the changelog data is sorted on Date in ascending order
 
   @v>=42
   Scenario: The user can sort by User
     When you click the sort User icon
-    Then the changelog data is sorted on User in ascending order
+    Then the changelog modal should contain data
+    And the changelog data is sorted on User in ascending order
 
   @v>=42
   Scenario: The user can sort by Data item
     When you click the sort Data item icon
-    Then the changelog data is sorted on Data item in ascending order
+    Then the changelog modal should contain data
+    And the changelog data is sorted on Data item in ascending order

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.feature
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.feature
@@ -1,0 +1,28 @@
+Feature: The user interacts with the changelog widget
+
+@v>=41
+  Scenario: The user can view an event changelog on the enrollment edit event
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    When you select view changelog in the event overflow button
+    Then the changelog modal should be visible
+    And the changelog modal should contain data
+    # One row is filtered out as the metadata is no longer there
+    And the number of changelog table rows should be 9
+
+  @v>=41
+  Scenario: The user can change changelog page size
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    When you select view changelog in the event overflow button
+    And you change the page size to 20
+    # One row is filtered out as the metadata is no longer there
+    Then the number of changelog table rows should be 19
+    And you change the page size to 100
+    Then the number of changelog table rows should be 37
+    Then the table footer should display page 1
+
+  @v>=41
+  Scenario: The user can move to the next page in the changelog
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    When you select view changelog in the event overflow button
+    And you move to the next page
+    Then the table footer should display page 2

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.js
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.js
@@ -1,4 +1,5 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import '../sharedSteps';
 
 Given('you select view changelog in the event overflow button', () => {
     cy.get('[data-test="widget-event-edit-overflow-button"]')

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.js
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.js
@@ -4,9 +4,6 @@ import '../sharedSteps';
 const getChangelogTableBody = () =>
     cy.get('[data-test="changelog-data-table-body"]');
 
-const getChangelogModal = () =>
-    cy.get('[data-test="changelog-modal"]');
-
 const getOverflowButton = () =>
     cy.get('[data-test="widget-event-edit-overflow-button"]');
 
@@ -14,10 +11,6 @@ const getOverflowButton = () =>
 Given('you select view changelog in the event overflow button', () => {
     getOverflowButton().click();
     cy.get('[data-test="event-overflow-view-changelog"] > a').click();
-});
-
-Then('the changelog modal should be visible', () => {
-    getChangelogModal().should('be.visible');
 });
 
 Then('the changelog modal should contain data', () => {
@@ -93,7 +86,6 @@ When('you click the sort Date icon', () => {
     cy.get('[data-test="changelog-sort-date"]')
         .find('svg')
         .click();
-    cy.intercept('GET', '**/changeLogs?*order=createdAt:*');
 });
 
 Then('the changelog data is sorted on Date in ascending order', () => {
@@ -114,48 +106,42 @@ Then('the changelog data is sorted on Date in ascending order', () => {
 });
 
 When('you click the sort User icon', () => {
-    cy.get('[data-test="changelog-sort-date"]')
+    cy.get('[data-test="changelog-sort-user"]')
         .find('svg')
         .click();
-    cy.intercept('GET', '**/changeLogs?*order=createdAt:*');
 });
 
 Then('the changelog data is sorted on User in ascending order', () => {
-    const parseDate = text => new Date(text).getTime();
-    let previous = 0;
-
+    let previous = '';
     cy.get('[data-test="changelog-data-table-body"] tr').each(($row) => {
         cy.wrap($row)
             .find('td')
-            .eq(0)
+            .eq(1)
             .invoke('text')
             .then((text) => {
-                const current = parseDate(text.trim());
-                expect(current).to.be.at.least(previous);
+                const current = text.trim().toLowerCase();
+                expect(current >= previous).to.be.true;
                 previous = current;
             });
     });
 });
 
 When('you click the sort Data item icon', () => {
-    cy.get('[data-test="changelog-sort-date"]')
+    cy.get('[data-test="changelog-sort-dataItem"]')
         .find('svg')
         .click();
-    cy.intercept('GET', '**/changeLogs?*order=createdAt:*');
 });
 
 Then('the changelog data is sorted on Data item in ascending order', () => {
-    const parseDate = text => new Date(text).getTime();
-    let previous = 0;
-
+    let previous = '';
     cy.get('[data-test="changelog-data-table-body"] tr').each(($row) => {
         cy.wrap($row)
             .find('td')
-            .eq(0)
+            .eq(2)
             .invoke('text')
             .then((text) => {
-                const current = parseDate(text.trim());
-                expect(current).to.be.at.least(previous);
+                const current = text.trim().toLowerCase();
+                expect(current >= previous).to.be.true;
                 previous = current;
             });
     });

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.js
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.js
@@ -112,17 +112,16 @@ When('you click the sort User icon', () => {
 });
 
 Then('the changelog data is sorted on User in ascending order', () => {
-    let previous = '';
-    cy.get('[data-test="changelog-data-table-body"] tr').each(($row) => {
-        cy.wrap($row)
-            .find('td')
-            .eq(1)
-            .invoke('text')
-            .then((text) => {
-                const current = text.trim().toLowerCase();
-                expect(current >= previous).to.be.true;
-                previous = current;
-            });
+    cy.get('[data-test="changelog-data-table-body"] tr td:nth-child(2)').then(($cells) => {
+        const values = [...$cells].map(cell => cell.textContent.trim().toLowerCase());
+
+        const collator = new Intl.Collator(undefined, {
+            sensitivity: 'base',
+            numeric: true,
+        });
+
+        const sorted = [...values].sort((a, b) => collator.compare(a, b));
+        expect(values).to.deep.equal(sorted);
     });
 });
 
@@ -133,16 +132,16 @@ When('you click the sort Data item icon', () => {
 });
 
 Then('the changelog data is sorted on Data item in ascending order', () => {
-    let previous = '';
-    cy.get('[data-test="changelog-data-table-body"] tr').each(($row) => {
-        cy.wrap($row)
-            .find('td')
-            .eq(2)
-            .invoke('text')
-            .then((text) => {
-                const current = text.trim().toLowerCase();
-                expect(current >= previous).to.be.true;
-                previous = current;
-            });
+    cy.get('[data-test="changelog-data-table-body"] tr td:nth-child(3)').then(($cells) => {
+        const values = [...$cells].map(cell => cell.textContent.trim().toLowerCase());
+
+        const collator = new Intl.Collator(undefined, {
+            sensitivity: 'base',
+            numeric: true,
+        });
+
+        const sorted = [...values].sort((a, b) => collator.compare(a, b));
+        expect(values).to.deep.equal(sorted);
     });
 });
+

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.js
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.js
@@ -1,50 +1,162 @@
-import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
-import '../sharedSteps';
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor'
+import '../sharedSteps'
+
+const getChangelogTableBody = () =>
+    cy.get('[data-test="changelog-data-table-body"]')
+
+const getChangelogModal = () =>
+    cy.get('[data-test="changelog-modal"]')
+
+const getOverflowButton = () =>
+    cy.get('[data-test="widget-event-edit-overflow-button"]')
+
 
 Given('you select view changelog in the event overflow button', () => {
-    cy.get('[data-test="widget-event-edit-overflow-button"]')
-        .click();
-
-    cy.get('[data-test="event-overflow-view-changelog"] > a')
-        .click({ force: true });
-});
+    getOverflowButton().click()
+    cy.get('[data-test="event-overflow-view-changelog"] > a').click()
+})
 
 Then('the changelog modal should be visible', () => {
-    cy.get('[data-test="changelog-modal"]')
-        .should('be.visible');
-});
+    getChangelogModal().should('be.visible')
+})
 
-Then(/^the number of changelog table rows should be (.*)$/, (numberOfRows) => {
-    cy.get('[data-test="changelog-data-table-body"]')
-        .within(() => {
-            cy.get('tr')
-                .should('have.length', numberOfRows);
-        });
-});
+Then('the changelog modal should contain data', () => {
+    getChangelogTableBody()
+        .should('be.visible')
+        .and('not.contain', 'No changes to display')
+        .and('not.have.class', 'loading')
+})
+
+Then(/^the number of changelog table rows should be (\d+)$/, (rowCount) => {
+    getChangelogTableBody().within(() => {
+        cy.get('tr').should('have.length', rowCount)
+    })
+})
 
 When(/^you change the page size to (.*)$/, (pageSize) => {
-    cy.get('[data-test="changelog-data-table-body"]')
-        .should('not.contain', 'No changes to display');
+    getChangelogTableBody().should('not.contain', 'No changes to display')
 
-    cy.get('[data-test="changelog-pagination-pagesize-select"]')
-        .click();
+    cy.get('[data-test="changelog-pagination-pagesize-select"]').click()
 
     cy.get('[data-test="dhis2-uicore-select-menu-menuwrapper"]')
         .contains(pageSize)
-        .click();
-});
-
-Then('the changelog modal should contain data', () => {
-    cy.get('[data-test="changelog-data-table-body"]')
-        .should('be.visible');
-});
+        .click()
+})
 
 When('you move to the next page', () => {
-    cy.get('[data-test="changelog-pagination-page-next"]')
-        .click();
-});
+    cy.get('[data-test="changelog-pagination-page-next"]').click()
+})
 
-Then(/^the table footer should display page (.*)$/, (number) => {
+When('you move to the previous page', () => {
+    cy.get('[data-test="changelog-pagination-page-previous"]').click()
+})
+
+Then(/^the table footer should display page (\d+)$/, (pageNumber) => {
     cy.get('[data-test="changelog-pagination-summary"]')
-        .contains(`Page ${number}`);
-});
+        .contains(`Page ${pageNumber}`)
+})
+
+When('you select {string} from the data item filter flyout menu', (dataItem) => {
+    cy.get('[data-test="changelog-filter-dataItem"]').click()
+    cy.get('[data-test="changelog-filter-dataItem-flyoutmenu"]')
+        .contains(dataItem)
+        .click()
+})
+
+Then('only rows with Data item {string} should be displayed', (dataItem) => {
+    cy.get('[data-test="changelog-data-table-body"] tr')
+        .first()
+        .should('contain.text', dataItem);
+
+    cy.get('[data-test="changelog-data-table-body"] tr').each(($row) => {
+        cy.wrap($row)
+            .find('td')
+            .eq(2)
+            .should('contain.text', dataItem);
+    });
+})
+
+Then('the filter pill should be visible with label {string}', (filterLabel) => {
+    cy.get('[data-test="changelog-filter-dataItem"]')
+        .should('contain.text', filterLabel)
+        .and('be.visible')
+})
+
+When('you remove the filter', () => {
+    cy.get('[data-test="changelog-filter-dataItem"]').click()
+    cy.get('[data-test="changelog-filter-dataItem-flyoutmenu"]')
+        .contains('Show all')
+        .click()
+})
+
+When('you click the sort Date icon', () => {
+    cy.get('[data-test="changelog-sort-date"]')
+        .find('svg')
+        .click()
+    cy.intercept('GET', '**/changeLogs?*order=createdAt:*')
+})
+
+Then('the changelog data is sorted on Date in ascending order', () => {
+    const parseDate = (text) => new Date(text).getTime()
+    let previous = 0
+
+    cy.get('[data-test="changelog-data-table-body"] tr').each(($row) => {
+        cy.wrap($row)
+            .find('td')
+            .eq(0)
+            .invoke('text')
+            .then((text) => {
+                const current = parseDate(text.trim())
+                expect(current).to.be.at.least(previous)
+                previous = current
+            })
+    })
+})
+
+When('you click the sort User icon', () => {
+    cy.get('[data-test="changelog-sort-date"]')
+        .find('svg')
+        .click()
+    cy.intercept('GET', '**/changeLogs?*order=createdAt:*')
+})
+
+Then('the changelog data is sorted on User in ascending order', () => {
+    const parseDate = (text) => new Date(text).getTime()
+    let previous = 0
+
+    cy.get('[data-test="changelog-data-table-body"] tr').each(($row) => {
+        cy.wrap($row)
+            .find('td')
+            .eq(0)
+            .invoke('text')
+            .then((text) => {
+                const current = parseDate(text.trim())
+                expect(current).to.be.at.least(previous)
+                previous = current
+            })
+    })
+})
+
+When('you click the sort Data item icon', () => {
+    cy.get('[data-test="changelog-sort-date"]')
+        .find('svg')
+        .click()
+    cy.intercept('GET', '**/changeLogs?*order=createdAt:*')
+})
+
+Then('the changelog data is sorted on Data item in ascending order', () => {
+    const parseDate = (text) => new Date(text).getTime()
+    let previous = 0
+
+    cy.get('[data-test="changelog-data-table-body"] tr').each(($row) => {
+        cy.wrap($row)
+            .find('td')
+            .eq(0)
+            .invoke('text')
+            .then((text) => {
+                const current = parseDate(text.trim())
+                expect(current).to.be.at.least(previous)
+                previous = current
+            })
+    })
+})

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.js
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetChangelog/Changelog.js
@@ -1,67 +1,67 @@
-import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor'
-import '../sharedSteps'
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import '../sharedSteps';
 
 const getChangelogTableBody = () =>
-    cy.get('[data-test="changelog-data-table-body"]')
+    cy.get('[data-test="changelog-data-table-body"]');
 
 const getChangelogModal = () =>
-    cy.get('[data-test="changelog-modal"]')
+    cy.get('[data-test="changelog-modal"]');
 
 const getOverflowButton = () =>
-    cy.get('[data-test="widget-event-edit-overflow-button"]')
+    cy.get('[data-test="widget-event-edit-overflow-button"]');
 
 
 Given('you select view changelog in the event overflow button', () => {
-    getOverflowButton().click()
-    cy.get('[data-test="event-overflow-view-changelog"] > a').click()
-})
+    getOverflowButton().click();
+    cy.get('[data-test="event-overflow-view-changelog"] > a').click();
+});
 
 Then('the changelog modal should be visible', () => {
-    getChangelogModal().should('be.visible')
-})
+    getChangelogModal().should('be.visible');
+});
 
 Then('the changelog modal should contain data', () => {
     getChangelogTableBody()
         .should('be.visible')
         .and('not.contain', 'No changes to display')
-        .and('not.have.class', 'loading')
-})
+        .and('not.have.class', 'loading');
+});
 
 Then(/^the number of changelog table rows should be (\d+)$/, (rowCount) => {
     getChangelogTableBody().within(() => {
-        cy.get('tr').should('have.length', rowCount)
-    })
-})
+        cy.get('tr').should('have.length', rowCount);
+    });
+});
 
 When(/^you change the page size to (.*)$/, (pageSize) => {
-    getChangelogTableBody().should('not.contain', 'No changes to display')
+    getChangelogTableBody().should('not.contain', 'No changes to display');
 
-    cy.get('[data-test="changelog-pagination-pagesize-select"]').click()
+    cy.get('[data-test="changelog-pagination-pagesize-select"]').click();
 
     cy.get('[data-test="dhis2-uicore-select-menu-menuwrapper"]')
         .contains(pageSize)
-        .click()
-})
+        .click();
+});
 
 When('you move to the next page', () => {
-    cy.get('[data-test="changelog-pagination-page-next"]').click()
-})
+    cy.get('[data-test="changelog-pagination-page-next"]').click();
+});
 
 When('you move to the previous page', () => {
-    cy.get('[data-test="changelog-pagination-page-previous"]').click()
-})
+    cy.get('[data-test="changelog-pagination-page-previous"]').click();
+});
 
 Then(/^the table footer should display page (\d+)$/, (pageNumber) => {
     cy.get('[data-test="changelog-pagination-summary"]')
-        .contains(`Page ${pageNumber}`)
-})
+        .contains(`Page ${pageNumber}`);
+});
 
 When('you select {string} from the data item filter flyout menu', (dataItem) => {
-    cy.get('[data-test="changelog-filter-dataItem"]').click()
+    cy.get('[data-test="changelog-filter-dataItem"]').click();
     cy.get('[data-test="changelog-filter-dataItem-flyoutmenu"]')
         .contains(dataItem)
-        .click()
-})
+        .click();
+});
 
 Then('only rows with Data item {string} should be displayed', (dataItem) => {
     cy.get('[data-test="changelog-data-table-body"] tr')
@@ -74,31 +74,31 @@ Then('only rows with Data item {string} should be displayed', (dataItem) => {
             .eq(2)
             .should('contain.text', dataItem);
     });
-})
+});
 
 Then('the filter pill should be visible with label {string}', (filterLabel) => {
     cy.get('[data-test="changelog-filter-dataItem"]')
         .should('contain.text', filterLabel)
-        .and('be.visible')
-})
+        .and('be.visible');
+});
 
 When('you remove the filter', () => {
-    cy.get('[data-test="changelog-filter-dataItem"]').click()
+    cy.get('[data-test="changelog-filter-dataItem"]').click();
     cy.get('[data-test="changelog-filter-dataItem-flyoutmenu"]')
         .contains('Show all')
-        .click()
-})
+        .click();
+});
 
 When('you click the sort Date icon', () => {
     cy.get('[data-test="changelog-sort-date"]')
         .find('svg')
-        .click()
-    cy.intercept('GET', '**/changeLogs?*order=createdAt:*')
-})
+        .click();
+    cy.intercept('GET', '**/changeLogs?*order=createdAt:*');
+});
 
 Then('the changelog data is sorted on Date in ascending order', () => {
-    const parseDate = (text) => new Date(text).getTime()
-    let previous = 0
+    const parseDate = text => new Date(text).getTime();
+    let previous = 0;
 
     cy.get('[data-test="changelog-data-table-body"] tr').each(($row) => {
         cy.wrap($row)
@@ -106,23 +106,23 @@ Then('the changelog data is sorted on Date in ascending order', () => {
             .eq(0)
             .invoke('text')
             .then((text) => {
-                const current = parseDate(text.trim())
-                expect(current).to.be.at.least(previous)
-                previous = current
-            })
-    })
-})
+                const current = parseDate(text.trim());
+                expect(current).to.be.at.least(previous);
+                previous = current;
+            });
+    });
+});
 
 When('you click the sort User icon', () => {
     cy.get('[data-test="changelog-sort-date"]')
         .find('svg')
-        .click()
-    cy.intercept('GET', '**/changeLogs?*order=createdAt:*')
-})
+        .click();
+    cy.intercept('GET', '**/changeLogs?*order=createdAt:*');
+});
 
 Then('the changelog data is sorted on User in ascending order', () => {
-    const parseDate = (text) => new Date(text).getTime()
-    let previous = 0
+    const parseDate = text => new Date(text).getTime();
+    let previous = 0;
 
     cy.get('[data-test="changelog-data-table-body"] tr').each(($row) => {
         cy.wrap($row)
@@ -130,23 +130,23 @@ Then('the changelog data is sorted on User in ascending order', () => {
             .eq(0)
             .invoke('text')
             .then((text) => {
-                const current = parseDate(text.trim())
-                expect(current).to.be.at.least(previous)
-                previous = current
-            })
-    })
-})
+                const current = parseDate(text.trim());
+                expect(current).to.be.at.least(previous);
+                previous = current;
+            });
+    });
+});
 
 When('you click the sort Data item icon', () => {
     cy.get('[data-test="changelog-sort-date"]')
         .find('svg')
-        .click()
-    cy.intercept('GET', '**/changeLogs?*order=createdAt:*')
-})
+        .click();
+    cy.intercept('GET', '**/changeLogs?*order=createdAt:*');
+});
 
 Then('the changelog data is sorted on Data item in ascending order', () => {
-    const parseDate = (text) => new Date(text).getTime()
-    let previous = 0
+    const parseDate = text => new Date(text).getTime();
+    let previous = 0;
 
     cy.get('[data-test="changelog-data-table-body"] tr').each(($row) => {
         cy.wrap($row)
@@ -154,9 +154,9 @@ Then('the changelog data is sorted on Data item in ascending order', () => {
             .eq(0)
             .invoke('text')
             .then((text) => {
-                const current = parseDate(text.trim())
-                expect(current).to.be.at.least(previous)
-                previous = current
-            })
-    })
-})
+                const current = parseDate(text.trim());
+                expect(current).to.be.at.least(previous);
+                previous = current;
+            });
+    });
+});

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetsForEnrollmentEditEvent/WidgetsForEnrollmentEditEvent.feature
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetsForEnrollmentEditEvent/WidgetsForEnrollmentEditEvent.feature
@@ -70,33 +70,6 @@ Feature: The user interacts with the widgets on the enrollment edit event
     When you remove the assigned user
     Then the event has no assignd user
 
-  @v>=41
-  Scenario: The user can view an event changelog on the enrollment edit event
-    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    When you select view changelog in the event overflow button
-    Then the changelog modal should be visible
-    And the changelog modal should contain data
-    # One row is filtered out as the metadata is no longer there
-    And the number of changelog table rows should be 9
-
-  @v>=41
-  Scenario: The user can change changelog page size
-    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    When you select view changelog in the event overflow button
-    And you change the page size to 20
-    # One row is filtered out as the metadata is no longer there
-    Then the number of changelog table rows should be 19
-    And you change the page size to 100
-    Then the number of changelog table rows should be 37
-    Then the table footer should display page 1
-
-  @v>=41
-  Scenario: The user can move to the next page in the changelog
-    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    When you select view changelog in the event overflow button
-    And you move to the next page
-    Then the table footer should display page 2
-
   Scenario: User can complete the enrollment and the active events
     Given you land on the enrollment edit event page by having typed #/enrollmentEventEdit?eventId=PyXThVzWJzL&orgUnitId=RzgSFJ9E46G
     And the enrollment widget should be opened

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetsForEnrollmentEditEvent/WidgetsForEnrollmentEditEvent.js
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetsForEnrollmentEditEvent/WidgetsForEnrollmentEditEvent.js
@@ -3,5 +3,3 @@ import '../WidgetEnrollment';
 import '../WidgetProfile';
 import '../WidgetEventNote';
 import '../WidgetAssignee';
-import '../WidgetChangelog';
-

--- a/src/core_modules/capture-core/components/WidgetsChangelog/common/ChangelogFilterBar/DropdownFilter.js
+++ b/src/core_modules/capture-core/components/WidgetsChangelog/common/ChangelogFilterBar/DropdownFilter.js
@@ -51,11 +51,12 @@ const DropdownFilterPlain = ({
         <DropdownButton
             open={isMenuOpen}
             onClick={() => onToggleMenu(filterColumn)}
+            dataTest={`changelog-filter-${filterColumn}`}
             component={
                 isMenuOpen && (
                     <FlyoutMenu
                         role="menu"
-                        dataTest={`changelog-filter-${filterColumn}`}
+                        dataTest={`changelog-filter-${filterColumn}-flyoutmenu`}
                         maxHeight="300px"
                     >
                         <MenuItem

--- a/src/core_modules/capture-core/components/WidgetsChangelog/common/ChangelogTable/ChangelogTableHeader.js
+++ b/src/core_modules/capture-core/components/WidgetsChangelog/common/ChangelogTable/ChangelogTableHeader.js
@@ -28,6 +28,7 @@ type ColumnConfig = {|
     isSortable: boolean,
     name?: string,
     sortIconTitle?: string,
+    dataTest?: string,
 |};
 
 const getCurrentSortDirection = (
@@ -61,6 +62,7 @@ export const ChangelogTableHeader = ({
             sortIconTitle: i18n.t('Sort by date'),
             width: '140px',
             isSortable: true,
+            dataTest: 'changelog-sort-date',
         },
         {
             name: SORT_TARGETS.USERNAME,
@@ -68,6 +70,7 @@ export const ChangelogTableHeader = ({
             sortIconTitle: i18n.t('Sort by username'),
             width: '125px',
             isSortable: supportsChangelogV2,
+            dataTest: 'changelog-sort-username',
         },
         {
             name: sortTargetDataItem,
@@ -75,6 +78,7 @@ export const ChangelogTableHeader = ({
             sortIconTitle: i18n.t('Sort by data item'),
             width: '125px',
             isSortable: supportsChangelogV2,
+            dataTest: 'changelog-sort-dataItem',
         },
         {
             label: i18n.t('Change'),
@@ -97,12 +101,14 @@ export const ChangelogTableHeader = ({
                     sortIconTitle,
                     width,
                     isSortable,
+                    dataTest,
                 }) => (
                     <DataTableColumnHeader
                         key={label}
                         fixed
                         top="0"
                         width={width}
+                        dataTest={dataTest}
                         name={isSortable ? name : undefined}
                         sortDirection={
                             isSortable && name

--- a/src/core_modules/capture-core/components/WidgetsChangelog/common/ChangelogTable/ChangelogTableHeader.js
+++ b/src/core_modules/capture-core/components/WidgetsChangelog/common/ChangelogTable/ChangelogTableHeader.js
@@ -70,7 +70,7 @@ export const ChangelogTableHeader = ({
             sortIconTitle: i18n.t('Sort by username'),
             width: '125px',
             isSortable: supportsChangelogV2,
-            dataTest: 'changelog-sort-username',
+            dataTest: 'changelog-sort-user',
         },
         {
             name: sortTargetDataItem,


### PR DESCRIPTION
[DHIS2-18642](https://dhis2.atlassian.net/browse/DHIS2-18642)

## This PR adds Cypress test for the new Changelog feature

### 📝 What is covered:
- **Sorting**: Validates sorting by Date, User, and Data item.
- **Filtering**: Tests filtering by Data item, with only one active filter at a time. Ensures the filter persists after sorting and can be reset.
- **Paging**: Verifies page size changes, page navigation, and correct footer updates.

---

### 🧭 What is not covered:
- Point and Polygon
- Files and images
- Appearance of Rows for Created, Updated, and Deleted Data

_Further testing requires changes to the Sierra Leone DB_

[DHIS2-18642]: https://dhis2.atlassian.net/browse/DHIS2-18642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ