### PR TITLE
fix: [DHIS2-18951] Ignore Non-searchable attributes error when validating unique attribute

### DIFF
--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/enrollment/DataElementFactory.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/enrollment/DataElementFactory.js
@@ -89,6 +89,14 @@ export class DataElementFactory {
                     valid: otherTrackedEntityInstances.length === 0,
                     data,
                 };
+            }).catch((error) => {
+                if (error?.message?.includes('Non-searchable attribute(s) can not be used during global search')) {
+                    return {
+                        valid: true,
+                        data: {},
+                    };
+                }
+                throw error;
             });
     }
 


### PR DESCRIPTION
[DHIS2-18951](https://dhis2.atlassian.net/browse/DHIS2-18951):

Temporary fix for error message:
`"Non-searchable attribute(s) can not be used during global search: [attributeId]"`

This change catches that specific `409` error in validation and allows the form to be saved instead of blocking the user.
Note: The error still appears in the network tab but no longer prevents saving.

[DHIS2-18951]: https://dhis2.atlassian.net/browse/DHIS2-18951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ