### PR TITLE
fix: [DHIS2-19415] editing two fields simultaneously blocks saving

### DIFF
--- a/src/core_modules/capture-core/components/DataEntries/Enrollment/epics/enrollment.epics.js
+++ b/src/core_modules/capture-core/components/DataEntries/Enrollment/epics/enrollment.epics.js
@@ -2,7 +2,7 @@
 import type { OrgUnit } from '@dhis2/rules-engine-javascript';
 import { ofType } from 'redux-observable';
 import { from } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { map, concatMap } from 'rxjs/operators';
 import { batchActionTypes, runRulesOnUpdateFieldBatch } from '../actions/enrollment.actionBatchs';
 import { actionTypes } from '../actions/enrollment.actions';
 import { getTrackerProgramThrowIfNotFound, ProgramStage, RenderFoundation, Section } from '../../../../metaData';
@@ -95,7 +95,7 @@ export const runRulesOnEnrollmentDataEntryFieldUpdateEpic = (
         ofType(batchActionTypes.UPDATE_DATA_ENTRY_FIELD_NEW_ENROLLMENT_ACTION_BATCH),
         map(actionBatch =>
             actionBatch.payload.find(action => action.type === actionTypes.START_RUN_RULES_ON_UPDATE)),
-        switchMap((action) => {
+        concatMap((action) => {
             const {
                 uid,
                 programId,
@@ -136,7 +136,7 @@ export const runRulesOnEnrollmentFieldUpdateEpic = (
         ofType(batchActionTypes.UPDATE_FIELD_NEW_ENROLLMENT_ACTION_BATCH),
         map(actionBatch =>
             actionBatch.payload.find(action => action.type === actionTypes.START_RUN_RULES_ON_UPDATE)),
-        switchMap((action) => {
+        concatMap((action) => {
             const {
                 innerPayload: payload,
                 searchActions,

--- a/src/core_modules/capture-core/components/DataEntries/SingleEventRegistrationEntry/DataEntryWrapper/DataEntry/epics/newEventDataEntry.epics.js
+++ b/src/core_modules/capture-core/components/DataEntries/SingleEventRegistrationEntry/DataEntryWrapper/DataEntry/epics/newEventDataEntry.epics.js
@@ -1,7 +1,7 @@
 // @flow
 import { ofType } from 'redux-observable';
 import { from } from 'rxjs';
-import { map, filter, switchMap } from 'rxjs/operators';
+import { map, filter, concatMap } from 'rxjs/operators';
 import { batchActions } from 'redux-batched-actions';
 import { type OrgUnit } from '@dhis2/rules-engine-javascript';
 import { rulesExecutedPostUpdateField } from '../../../../../DataEntry/actions/dataEntry.actions';
@@ -182,7 +182,7 @@ export const runRulesOnUpdateDataEntryFieldForSingleEventEpic = (
         ofType(batchActionTypes.UPDATE_DATA_ENTRY_FIELD_NEW_SINGLE_EVENT_ACTION_BATCH),
         map(actionBatch =>
             actionBatch.payload.find(action => action.type === newEventDataEntryActionTypes.START_RUN_RULES_ON_UPDATE)),
-        switchMap((action) => {
+        concatMap((action) => {
             const { dataEntryId, itemId, uid, orgUnit } = action.payload;
             const runRulesForNewSingleEventPromise = runRulesForNewSingleEvent({
                 store,
@@ -204,7 +204,7 @@ export const runRulesOnUpdateFieldForSingleEventEpic = (
         ofType(batchActionTypes.UPDATE_FIELD_NEW_SINGLE_EVENT_ACTION_BATCH),
         map(actionBatch =>
             actionBatch.payload.find(action => action.type === newEventDataEntryActionTypes.START_RUN_RULES_ON_UPDATE)),
-        switchMap((action) => {
+        concatMap((action) => {
             const { dataEntryId, itemId, uid, orgUnit, elementId, value, uiState } = action.payload;
             const fieldData: FieldData = {
                 elementId,

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/DataEntry/epics/dataEntryRules.epics.js
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/DataEntry/epics/dataEntryRules.epics.js
@@ -1,6 +1,6 @@
 // @flow
 import { ofType } from 'redux-observable';
-import { map, switchMap } from 'rxjs/operators';
+import { map, concatMap } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { batchActions } from 'redux-batched-actions';
 import i18n from '@dhis2/d2-i18n';
@@ -96,7 +96,7 @@ export const runRulesOnUpdateDataEntryFieldForNewEnrollmentEventEpic = (
         map(actionBatch =>
             actionBatch.payload
                 .find(action => action.type === newEventWidgetDataEntryActionTypes.RULES_ON_UPDATE_EXECUTE)),
-        switchMap((action) => {
+        concatMap((action) => {
             const { dataEntryId, itemId, uid, rulesExecutionDependenciesClientFormatted } = action.payload;
             const runRulesForNewEventPromise = runRulesForNewEvent({
                 store,
@@ -119,7 +119,7 @@ export const runRulesOnUpdateFieldForNewEnrollmentEventEpic = (
         map(actionBatch =>
             actionBatch.payload
                 .find(action => action.type === newEventWidgetDataEntryActionTypes.RULES_ON_UPDATE_EXECUTE)),
-        switchMap((action) => {
+        concatMap((action) => {
             const {
                 dataEntryId,
                 itemId,

--- a/src/core_modules/capture-core/components/WidgetEventEdit/DataEntry/epics/editEventDataEntry.epics.js
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/DataEntry/epics/editEventDataEntry.epics.js
@@ -2,7 +2,7 @@
 import i18n from '@dhis2/d2-i18n';
 import { from } from 'rxjs';
 import { ofType } from 'redux-observable';
-import { map, switchMap } from 'rxjs/operators';
+import { map, concatMap } from 'rxjs/operators';
 import { batchActions } from 'redux-batched-actions';
 import { rulesExecutedPostUpdateField } from '../../../DataEntry/actions/dataEntry.actions';
 import {
@@ -124,7 +124,7 @@ export const runRulesOnUpdateDataEntryFieldForEditSingleEventEpic = (
         map(actionBatch =>
             actionBatch.payload.find(action => action.type === editEventDataEntryActionTypes.START_RUN_RULES_ON_UPDATE),
         ),
-        switchMap((action) => {
+        concatMap((action) => {
             const { dataEntryId, itemId, uid, programId } = action.payload;
             const runRulesForEditSingleEventPromise = runRulesForEditSingleEvent({
                 store,
@@ -148,7 +148,7 @@ export const runRulesOnUpdateFieldForEditSingleEventEpic = (
         map(actionBatch =>
             actionBatch.payload.find(action => action.type === editEventDataEntryActionTypes.START_RUN_RULES_ON_UPDATE),
         ),
-        switchMap((action) => {
+        concatMap((action) => {
             const {
                 elementId,
                 value,


### PR DESCRIPTION
[DHIS2-19415](https://dhis2.atlassian.net/browse/DHIS2-19415)

Replaces `switchMap` with `concatMap` so that no actions get discarded by accident.

[DHIS2-19415]: https://dhis2.atlassian.net/browse/DHIS2-19415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ