### PR TITLE
fix: [DHIS2-18671] Discard changes dialog not responding

### DIFF
--- a/src/core_modules/capture-core/components/Pages/New/NewPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.component.js
@@ -31,7 +31,6 @@ const NewPagePlain = ({
     classes,
     currentScopeId,
     newPageStatus,
-    newPageKey,
     writeAccess,
     programCategorySelectionIncomplete,
     categoryOptionIsInvalidForOrgUnit,
@@ -91,7 +90,6 @@ const NewPagePlain = ({
                                 selectedScopeId={selectedScopeId}
                                 setScopeId={setScopeId}
                                 trackedEntityInstanceAttributes={trackedEntityInstanceAttributes}
-                                newPageKey={newPageKey}
                             />
                         }
 

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.component.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.component.js
@@ -31,6 +31,7 @@ const NewPagePlain = ({
     classes,
     currentScopeId,
     newPageStatus,
+    newPageKey,
     writeAccess,
     programCategorySelectionIncomplete,
     categoryOptionIsInvalidForOrgUnit,
@@ -90,6 +91,7 @@ const NewPagePlain = ({
                                 selectedScopeId={selectedScopeId}
                                 setScopeId={setScopeId}
                                 trackedEntityInstanceAttributes={trackedEntityInstanceAttributes}
+                                newPageKey={newPageKey}
                             />
                         }
 

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
@@ -1,8 +1,7 @@
 // @flow
 import { useDispatch, useSelector } from 'react-redux';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import type { ComponentType } from 'react';
-import { v4 as uuid } from 'uuid';
 import { NewPageComponent } from './NewPage.component';
 import {
     showMessageToSelectOrgUnitOnNewPage,
@@ -109,11 +108,6 @@ export const NewPage: ComponentType<{||}> = () => {
           || dataEntryHasChanges(state, 'newPageDataEntryId-newTei'),
     );
 
-    const [newPageKey, setNewPageKey] = useState();
-    const handleRefreshNewTeForm = () => {
-        setNewPageKey(uuid());
-    };
-
     return (
         <>
             <TopBar
@@ -124,7 +118,6 @@ export const NewPage: ComponentType<{||}> = () => {
                 trackedEntityName={trackedEntityType?.name}
                 teiDisplayName={teiDisplayName}
                 formIsOpen={newPageStatus === newPageStatuses.DEFAULT}
-                handleRefreshNewTeForm={handleRefreshNewTeForm}
             />
             <NewPageComponent
                 showMessageToSelectOrgUnitOnNewPage={dispatchShowMessageToSelectOrgUnitOnNewPage}
@@ -143,7 +136,6 @@ export const NewPage: ComponentType<{||}> = () => {
                 ready={ready}
                 trackedEntityInstanceAttributes={trackedEntityAttributes}
                 trackedEntityName={trackedEntityType?.name}
-                newPageKey={newPageKey}
             />
         </>
     );

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
@@ -1,9 +1,8 @@
 // @flow
 import { useDispatch, useSelector } from 'react-redux';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import type { ComponentType } from 'react';
 import { v4 as uuid } from 'uuid';
-import { useLocation } from 'react-router-dom';
 import { NewPageComponent } from './NewPage.component';
 import {
     showMessageToSelectOrgUnitOnNewPage,
@@ -110,11 +109,10 @@ export const NewPage: ComponentType<{||}> = () => {
           || dataEntryHasChanges(state, 'newPageDataEntryId-newTei'),
     );
 
-    const location = useLocation();
     const [newPageKey, setNewPageKey] = useState();
-    useEffect(() => {
+    const handleRefreshNewTeForm = () => {
         setNewPageKey(uuid());
-    }, [location]);
+    };
 
     return (
         <>
@@ -126,6 +124,7 @@ export const NewPage: ComponentType<{||}> = () => {
                 trackedEntityName={trackedEntityType?.name}
                 teiDisplayName={teiDisplayName}
                 formIsOpen={newPageStatus === newPageStatuses.DEFAULT}
+                handleRefreshNewTeForm={handleRefreshNewTeForm}
             />
             <NewPageComponent
                 showMessageToSelectOrgUnitOnNewPage={dispatchShowMessageToSelectOrgUnitOnNewPage}

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
@@ -1,8 +1,9 @@
 // @flow
 import { useDispatch, useSelector } from 'react-redux';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import type { ComponentType } from 'react';
 import { v4 as uuid } from 'uuid';
+import { useLocation } from 'react-router-dom';
 import { NewPageComponent } from './NewPage.component';
 import {
     showMessageToSelectOrgUnitOnNewPage,
@@ -109,10 +110,11 @@ export const NewPage: ComponentType<{||}> = () => {
           || dataEntryHasChanges(state, 'newPageDataEntryId-newTei'),
     );
 
+    const location = useLocation();
     const [newPageKey, setNewPageKey] = useState();
-    const handleRefreshNewTeForm = () => {
+    useEffect(() => {
         setNewPageKey(uuid());
-    };
+    }, [location]);
 
     return (
         <>
@@ -124,7 +126,6 @@ export const NewPage: ComponentType<{||}> = () => {
                 trackedEntityName={trackedEntityType?.name}
                 teiDisplayName={teiDisplayName}
                 formIsOpen={newPageStatus === newPageStatuses.DEFAULT}
-                handleRefreshNewTeForm={handleRefreshNewTeForm}
             />
             <NewPageComponent
                 showMessageToSelectOrgUnitOnNewPage={dispatchShowMessageToSelectOrgUnitOnNewPage}

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
@@ -110,7 +110,7 @@ export const NewPage: ComponentType<{||}> = () => {
     );
 
     const [newPageKey, setNewPageKey] = useState();
-    const handleRefreshNewTeForm = () => {
+    const onOpenNewRegistrationPage = () => {
         setNewPageKey(uuid());
     };
 
@@ -124,7 +124,7 @@ export const NewPage: ComponentType<{||}> = () => {
                 trackedEntityName={trackedEntityType?.name}
                 teiDisplayName={teiDisplayName}
                 formIsOpen={newPageStatus === newPageStatuses.DEFAULT}
-                handleRefreshNewTeForm={handleRefreshNewTeForm}
+                onOpenNewRegistrationPage={onOpenNewRegistrationPage}
             />
             <NewPageComponent
                 showMessageToSelectOrgUnitOnNewPage={dispatchShowMessageToSelectOrgUnitOnNewPage}

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.container.js
@@ -1,7 +1,8 @@
 // @flow
 import { useDispatch, useSelector } from 'react-redux';
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import type { ComponentType } from 'react';
+import { v4 as uuid } from 'uuid';
 import { NewPageComponent } from './NewPage.component';
 import {
     showMessageToSelectOrgUnitOnNewPage,
@@ -108,6 +109,11 @@ export const NewPage: ComponentType<{||}> = () => {
           || dataEntryHasChanges(state, 'newPageDataEntryId-newTei'),
     );
 
+    const [newPageKey, setNewPageKey] = useState();
+    const handleRefreshNewTeForm = () => {
+        setNewPageKey(uuid());
+    };
+
     return (
         <>
             <TopBar
@@ -118,6 +124,7 @@ export const NewPage: ComponentType<{||}> = () => {
                 trackedEntityName={trackedEntityType?.name}
                 teiDisplayName={teiDisplayName}
                 formIsOpen={newPageStatus === newPageStatuses.DEFAULT}
+                handleRefreshNewTeForm={handleRefreshNewTeForm}
             />
             <NewPageComponent
                 showMessageToSelectOrgUnitOnNewPage={dispatchShowMessageToSelectOrgUnitOnNewPage}
@@ -136,6 +143,7 @@ export const NewPage: ComponentType<{||}> = () => {
                 ready={ready}
                 trackedEntityInstanceAttributes={trackedEntityAttributes}
                 trackedEntityName={trackedEntityType?.name}
+                newPageKey={newPageKey}
             />
         </>
     );

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.types.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.types.js
@@ -30,12 +30,10 @@ export type ContainerProps = $ReadOnly<{|
   error: boolean,
   ready: boolean,
   programId?: string,
-  newPageKey?: string,
   teiId?: string,
   trackedEntityName?: string,
   teiDisplayName?: string,
   trackedEntityInstanceAttributes?: Array<InputAttribute>
-
 |}
 >
 

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.types.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.types.js
@@ -30,10 +30,12 @@ export type ContainerProps = $ReadOnly<{|
   error: boolean,
   ready: boolean,
   programId?: string,
+  newPageKey?: string,
   teiId?: string,
   trackedEntityName?: string,
   teiDisplayName?: string,
   trackedEntityInstanceAttributes?: Array<InputAttribute>
+
 |}
 >
 

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.types.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.types.js
@@ -35,6 +35,7 @@ export type ContainerProps = $ReadOnly<{|
   trackedEntityName?: string,
   teiDisplayName?: string,
   trackedEntityInstanceAttributes?: Array<InputAttribute>
+
 |}
 >
 

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.types.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.types.js
@@ -35,7 +35,6 @@ export type ContainerProps = $ReadOnly<{|
   trackedEntityName?: string,
   teiDisplayName?: string,
   trackedEntityInstanceAttributes?: Array<InputAttribute>
-
 |}
 >
 

--- a/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/RegistrationDataEntry.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/RegistrationDataEntry.container.js
@@ -21,7 +21,6 @@ export const RegistrationDataEntry: ComponentType<OwnProps> = ({
     dataEntryId,
     setScopeId,
     trackedEntityInstanceAttributes,
-    newPageKey,
 }) => {
     const dispatch = useDispatch();
     const { teiId } = useLocationQuery();
@@ -64,6 +63,5 @@ export const RegistrationDataEntry: ComponentType<OwnProps> = ({
             onSaveWithEnrollment={dispatchOnSaveWithEnrollment}
             teiId={teiId}
             trackedEntityInstanceAttributes={trackedEntityInstanceAttributes}
-            key={newPageKey}
         />);
 };

--- a/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/RegistrationDataEntry.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/RegistrationDataEntry.container.js
@@ -21,6 +21,7 @@ export const RegistrationDataEntry: ComponentType<OwnProps> = ({
     dataEntryId,
     setScopeId,
     trackedEntityInstanceAttributes,
+    newPageKey,
 }) => {
     const dispatch = useDispatch();
     const { teiId } = useLocationQuery();
@@ -63,5 +64,6 @@ export const RegistrationDataEntry: ComponentType<OwnProps> = ({
             onSaveWithEnrollment={dispatchOnSaveWithEnrollment}
             teiId={teiId}
             trackedEntityInstanceAttributes={trackedEntityInstanceAttributes}
+            key={newPageKey}
         />);
 };

--- a/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/RegistrationDataEntry.types.js
+++ b/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/RegistrationDataEntry.types.js
@@ -17,7 +17,6 @@ export type OwnProps = $ReadOnly<{|
   selectedScopeId: string,
   dataEntryId: string,
   teiId?: ?string,
-  newPageKey?: string,
   trackedEntityInstanceAttributes?: Array<InputAttribute>,
 |}>;
 

--- a/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/RegistrationDataEntry.types.js
+++ b/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/RegistrationDataEntry.types.js
@@ -17,6 +17,7 @@ export type OwnProps = $ReadOnly<{|
   selectedScopeId: string,
   dataEntryId: string,
   teiId?: ?string,
+  newPageKey?: string,
   trackedEntityInstanceAttributes?: Array<InputAttribute>,
 |}>;
 

--- a/src/core_modules/capture-core/components/Pages/New/TopBar.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/TopBar.container.js
@@ -26,7 +26,7 @@ type TopBarProps = {
     teiDisplayName?: string,
     isUserInteractionInProgress: boolean,
     formIsOpen: boolean,
-    handleRefreshNewTeForm: () => void,
+    onOpenNewRegistrationPage: () => void,
 };
 
 export const TopBar = ({
@@ -37,7 +37,7 @@ export const TopBar = ({
     trackedEntityName = '',
     teiDisplayName = '',
     formIsOpen,
-    handleRefreshNewTeForm,
+    onOpenNewRegistrationPage,
 }: TopBarProps) => {
     const dispatch = useDispatch();
     const { setProgramId } = useSetProgramId();
@@ -104,7 +104,7 @@ export const TopBar = ({
                 selectedProgramId={programId}
                 selectedOrgUnitId={orgUnitId}
                 isUserInteractionInProgress={isUserInteractionInProgress}
-                handleRefreshNewTeForm={handleRefreshNewTeForm}
+                onOpenNewRegistrationPage={onOpenNewRegistrationPage}
             />
         </ScopeSelector>
     );

--- a/src/core_modules/capture-core/components/Pages/New/TopBar.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/TopBar.container.js
@@ -26,6 +26,7 @@ type TopBarProps = {
     teiDisplayName?: string,
     isUserInteractionInProgress: boolean,
     formIsOpen: boolean,
+    handleRefreshNewTeForm: () => void,
 };
 
 export const TopBar = ({
@@ -36,6 +37,7 @@ export const TopBar = ({
     trackedEntityName = '',
     teiDisplayName = '',
     formIsOpen,
+    handleRefreshNewTeForm,
 }: TopBarProps) => {
     const dispatch = useDispatch();
     const { setProgramId } = useSetProgramId();
@@ -102,6 +104,7 @@ export const TopBar = ({
                 selectedProgramId={programId}
                 selectedOrgUnitId={orgUnitId}
                 isUserInteractionInProgress={isUserInteractionInProgress}
+                handleRefreshNewTeForm={handleRefreshNewTeForm}
             />
         </ScopeSelector>
     );

--- a/src/core_modules/capture-core/components/Pages/New/TopBar.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/TopBar.container.js
@@ -26,7 +26,6 @@ type TopBarProps = {
     teiDisplayName?: string,
     isUserInteractionInProgress: boolean,
     formIsOpen: boolean,
-    handleRefreshNewTeForm: () => void,
 };
 
 export const TopBar = ({
@@ -37,7 +36,6 @@ export const TopBar = ({
     trackedEntityName = '',
     teiDisplayName = '',
     formIsOpen,
-    handleRefreshNewTeForm,
 }: TopBarProps) => {
     const dispatch = useDispatch();
     const { setProgramId } = useSetProgramId();
@@ -104,7 +102,6 @@ export const TopBar = ({
                 selectedProgramId={programId}
                 selectedOrgUnitId={orgUnitId}
                 isUserInteractionInProgress={isUserInteractionInProgress}
-                handleRefreshNewTeForm={handleRefreshNewTeForm}
             />
         </ScopeSelector>
     );

--- a/src/core_modules/capture-core/components/TopBarActions/TopBarActions.container.js
+++ b/src/core_modules/capture-core/components/TopBarActions/TopBarActions.container.js
@@ -1,5 +1,6 @@
 // @flow
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { ActionButtons } from './TopBarActions.component';
 import { DiscardDialog } from '../Dialogs/DiscardDialog.component';
 import type { Props } from './TopBarActions.types';
@@ -17,7 +18,6 @@ export const TopBarActions = ({
     selectedProgramId,
     selectedOrgUnitId,
     isUserInteractionInProgress = false,
-    handleRefreshNewTeForm = () => {},
 }: Props) => {
     const [context, setContext] = useState(defaultContext);
     const {
@@ -33,6 +33,7 @@ export const TopBarActions = ({
         openSearchPageWithoutProgramId;
 
     const { navigate } = useNavigate();
+    const history = useHistory();
 
     const newRegistrationPage = () => {
         const queryArgs = {};
@@ -43,7 +44,7 @@ export const TopBarActions = ({
             queryArgs.programId = selectedProgramId;
         }
 
-        navigate(`new?${buildUrlQueryString(queryArgs)}`);
+        history.replace(`new?${buildUrlQueryString(queryArgs)}`);
     };
 
     const newRegistrationPageWithoutProgramId = () => {
@@ -91,7 +92,6 @@ export const TopBarActions = ({
     };
 
     const handleAccept = () => {
-        handleRefreshNewTeForm();
         openNewRegistrationPage && newRegistrationPage();
         openNewRegistrationPageWithoutProgramId && newRegistrationPageWithoutProgramId();
         openSearchPage && searchPage();

--- a/src/core_modules/capture-core/components/TopBarActions/TopBarActions.container.js
+++ b/src/core_modules/capture-core/components/TopBarActions/TopBarActions.container.js
@@ -17,6 +17,7 @@ export const TopBarActions = ({
     selectedProgramId,
     selectedOrgUnitId,
     isUserInteractionInProgress = false,
+    handleRefreshNewTeForm = () => {},
 }: Props) => {
     const [context, setContext] = useState(defaultContext);
     const {
@@ -90,6 +91,7 @@ export const TopBarActions = ({
     };
 
     const handleAccept = () => {
+        handleRefreshNewTeForm();
         openNewRegistrationPage && newRegistrationPage();
         openNewRegistrationPageWithoutProgramId && newRegistrationPageWithoutProgramId();
         openSearchPage && searchPage();

--- a/src/core_modules/capture-core/components/TopBarActions/TopBarActions.container.js
+++ b/src/core_modules/capture-core/components/TopBarActions/TopBarActions.container.js
@@ -17,7 +17,6 @@ export const TopBarActions = ({
     selectedProgramId,
     selectedOrgUnitId,
     isUserInteractionInProgress = false,
-    handleRefreshNewTeForm = () => {},
 }: Props) => {
     const [context, setContext] = useState(defaultContext);
     const {
@@ -91,7 +90,6 @@ export const TopBarActions = ({
     };
 
     const handleAccept = () => {
-        handleRefreshNewTeForm();
         openNewRegistrationPage && newRegistrationPage();
         openNewRegistrationPageWithoutProgramId && newRegistrationPageWithoutProgramId();
         openSearchPage && searchPage();

--- a/src/core_modules/capture-core/components/TopBarActions/TopBarActions.container.js
+++ b/src/core_modules/capture-core/components/TopBarActions/TopBarActions.container.js
@@ -1,6 +1,5 @@
 // @flow
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
 import { ActionButtons } from './TopBarActions.component';
 import { DiscardDialog } from '../Dialogs/DiscardDialog.component';
 import type { Props } from './TopBarActions.types';
@@ -18,6 +17,7 @@ export const TopBarActions = ({
     selectedProgramId,
     selectedOrgUnitId,
     isUserInteractionInProgress = false,
+    handleRefreshNewTeForm = () => {},
 }: Props) => {
     const [context, setContext] = useState(defaultContext);
     const {
@@ -33,7 +33,6 @@ export const TopBarActions = ({
         openSearchPageWithoutProgramId;
 
     const { navigate } = useNavigate();
-    const history = useHistory();
 
     const newRegistrationPage = () => {
         const queryArgs = {};
@@ -44,7 +43,7 @@ export const TopBarActions = ({
             queryArgs.programId = selectedProgramId;
         }
 
-        history.replace(`new?${buildUrlQueryString(queryArgs)}`);
+        navigate(`new?${buildUrlQueryString(queryArgs)}`);
     };
 
     const newRegistrationPageWithoutProgramId = () => {
@@ -92,6 +91,7 @@ export const TopBarActions = ({
     };
 
     const handleAccept = () => {
+        handleRefreshNewTeForm();
         openNewRegistrationPage && newRegistrationPage();
         openNewRegistrationPageWithoutProgramId && newRegistrationPageWithoutProgramId();
         openSearchPage && searchPage();

--- a/src/core_modules/capture-core/components/TopBarActions/TopBarActions.container.js
+++ b/src/core_modules/capture-core/components/TopBarActions/TopBarActions.container.js
@@ -17,7 +17,7 @@ export const TopBarActions = ({
     selectedProgramId,
     selectedOrgUnitId,
     isUserInteractionInProgress = false,
-    handleRefreshNewTeForm = () => {},
+    onOpenNewRegistrationPage = () => {},
 }: Props) => {
     const [context, setContext] = useState(defaultContext);
     const {
@@ -91,7 +91,7 @@ export const TopBarActions = ({
     };
 
     const handleAccept = () => {
-        handleRefreshNewTeForm();
+        onOpenNewRegistrationPage();
         openNewRegistrationPage && newRegistrationPage();
         openNewRegistrationPageWithoutProgramId && newRegistrationPageWithoutProgramId();
         openSearchPage && searchPage();

--- a/src/core_modules/capture-core/components/TopBarActions/TopBarActions.types.js
+++ b/src/core_modules/capture-core/components/TopBarActions/TopBarActions.types.js
@@ -1,7 +1,6 @@
 // @flow
 
 export type Props = {
-    handleRefreshNewTeForm?: () => void,
     selectedProgramId?: ?string,
     selectedOrgUnitId?: string,
     isUserInteractionInProgress?: boolean,

--- a/src/core_modules/capture-core/components/TopBarActions/TopBarActions.types.js
+++ b/src/core_modules/capture-core/components/TopBarActions/TopBarActions.types.js
@@ -1,6 +1,7 @@
 // @flow
 
 export type Props = {
+    handleRefreshNewTeForm?: () => void,
     selectedProgramId?: ?string,
     selectedOrgUnitId?: string,
     isUserInteractionInProgress?: boolean,

--- a/src/core_modules/capture-core/components/TopBarActions/TopBarActions.types.js
+++ b/src/core_modules/capture-core/components/TopBarActions/TopBarActions.types.js
@@ -1,7 +1,7 @@
 // @flow
 
 export type Props = {
-    handleRefreshNewTeForm?: () => void,
+    onOpenNewRegistrationPage?: () => void,
     selectedProgramId?: ?string,
     selectedOrgUnitId?: string,
     isUserInteractionInProgress?: boolean,


### PR DESCRIPTION
[DHIS2-18671](https://dhis2.atlassian.net/browse/DHIS2-18671):

## This PR adds the ability to reset the _New TEI form_ via a unique key

### 🔄 Refreshing the New TEI form

1. A `newPageKey` state was introduced using `useState` and `uuid` to generate a unique key.  
2. The `handleRefreshNewTeForm` function updates this key, which forces the form to reload.  
3. The refresh functionality is integrated into the top bar, allowing users to trigger a form reset from there.




[DHIS2-18671]: https://dhis2.atlassian.net/browse/DHIS2-18671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ