### PR TITLE
fix: [DHIS2-19467] form inconsistencies

### DIFF
--- a/src/core_modules/capture-core/components/D2Form/D2Section.component.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Section.component.js
@@ -30,7 +30,7 @@ type Props = {
     sectionId: string,
     formBuilderId: string,
     formId: string,
-    onFieldsValidated: ?(any, formBuilderId: string) => void,
+    onFieldsValidated: ?(fieldsUI: Object, formId: string, uidsForIsValidating: Array<string>) => void,
 };
 
 class D2SectionPlain extends React.PureComponent<Props> {
@@ -39,9 +39,13 @@ class D2SectionPlain extends React.PureComponent<Props> {
     componentDidMount() {
         if (this.props.isHidden) {
             // Inform withSaveHandler that this section is done initialising
-            this.props.onFieldsValidated && this.props.onFieldsValidated(
-                {},
-                this.props.formBuilderId,
+            this.props.onFieldsValidated?.(
+                Array.from(this.props.sectionMetaData.elements.keys()).reduce((acc, fieldKey) => {
+                    acc[fieldKey] = { valid: true };
+                    return acc;
+                }, {}),
+                this.props.formId,
+                [],
             );
         }
     }

--- a/src/core_modules/capture-core/components/D2Form/D2Section.container.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Section.container.js
@@ -10,10 +10,10 @@ const mapStateToProps = (state: Object, props: { sectionMetaData: MetaDataSectio
         const visibleFields = Array.from(props.sectionMetaData.elements.keys())
             .filter(id => !fieldsHiddenByRules[id]);
 
-        return { isHidden: visibleFields.length == 0 };
+        return { isHidden: !visibleFields.length };
     }
 
-    return { isHidden: props.sectionMetaData.elements.size == 0 };
+    return { isHidden: !props.sectionMetaData.elements.size };
 };
 
 const mapDispatchToProps = () => ({});

--- a/src/core_modules/capture-core/components/Pages/New/NewPage.actions.js
+++ b/src/core_modules/capture-core/components/Pages/New/NewPage.actions.js
@@ -7,7 +7,6 @@ export const newPageActionTypes = {
     NEW_PAGE_WITHOUT_PROGRAM_CATEGORY_SELECTED_VIEW: 'NewPage.WithoutProgramComboSelectedView',
     NEW_PAGE_CATEGORY_OPTION_INVALID_FOR_ORG_UNIT_VIEW: 'NewPage.InvalidCategoryOptionSelectedView',
     NEW_PAGE_DEFAULT_VIEW: 'NewPage.DefaultView',
-    CLEAN_UP_DATA_ENTRY: 'NewPage.DataEntryCleanUp',
     CATEGORY_OPTION_SET: 'NewPage.CategoryOptionSet',
     CATEGORY_OPTION_RESET: 'NewPage.CategoryOptionReset',
     ALL_CATEGORY_OPTIONS_RESET: 'NewPage.AllCategoryOptionsReset',
@@ -24,9 +23,6 @@ export const showMessageThatCategoryOptionIsInvalidForOrgUnit = () =>
     actionCreator(newPageActionTypes.NEW_PAGE_CATEGORY_OPTION_INVALID_FOR_ORG_UNIT_VIEW)();
 
 export const showDefaultViewOnNewPage = () => actionCreator(newPageActionTypes.NEW_PAGE_DEFAULT_VIEW)();
-
-export const cleanUpDataEntry = (dataEntryId: string) =>
-    actionCreator(newPageActionTypes.CLEAN_UP_DATA_ENTRY)({ dataEntryId });
 
 export const setCategoryOption = (categoryId: string, categoryOption: Object) =>
     actionCreator(newPageActionTypes.CATEGORY_OPTION_SET)({ categoryId, categoryOption });

--- a/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/RegistrationDataEntry.container.js
+++ b/src/core_modules/capture-core/components/Pages/New/RegistrationDataEntry/RegistrationDataEntry.container.js
@@ -9,7 +9,8 @@ import {
     startSavingNewTrackedEntityInstance,
     startSavingNewTrackedEntityInstanceWithEnrollment,
 } from './RegistrationDataEntry.actions';
-import { cleanUpDataEntry, openNewPage } from '../NewPage.actions';
+import { openNewPage } from '../NewPage.actions';
+import { cleanUpDataEntry } from '../../../DataEntry';
 import {
     NEW_RELATIONSHIP_EVENT_DATA_ENTRY_ID,
     NEW_SINGLE_EVENT_DATA_ENTRY_ID,

--- a/src/core_modules/capture-core/reducers/descriptions/dataEntry.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/dataEntry.reducerDescription.js
@@ -7,7 +7,6 @@ import {
     loadEditActionTypes,
 } from '../../components/DataEntry';
 import { getDataEntryKey } from '../../components/DataEntry/common/getDataEntryKey';
-import { newPageActionTypes } from '../../components/Pages/New/NewPage.actions';
 import { newRelationshipActionTypes } from '../../components/DataEntries/SingleEventRegistrationEntry';
 
 // cleans up data entries that start with dataEntryId
@@ -128,7 +127,7 @@ export const dataEntriesFieldsValueDesc = createReducerDescription({
         dataEntryValues[payload.fieldId] = payload.value;
         return newState;
     },
-    [newPageActionTypes.CLEAN_UP_DATA_ENTRY]: cleanUp,
+    [actionTypes.CLEAN_UP_DATA_ENTRY]: cleanUp,
     [newRelationshipActionTypes.NEW_EVENT_CANCEL_NEW_RELATIONSHIP]: cleanUp,
 }, 'dataEntriesFieldsValue');
 
@@ -222,7 +221,7 @@ export const dataEntriesFieldsUIDesc = createReducerDescription({
         dataEntryValuesUI[payload.fieldId] = { ...dataEntryValuesUI[payload.fieldId], ...payload.valueMeta, modified: true };
         return newState;
     },
-    [newPageActionTypes.CLEAN_UP_DATA_ENTRY]: cleanUp,
+    [actionTypes.CLEAN_UP_DATA_ENTRY]: cleanUp,
     [newRelationshipActionTypes.NEW_EVENT_CANCEL_NEW_RELATIONSHIP]: cleanUp,
 }, 'dataEntriesFieldsUI');
 

--- a/src/core_modules/capture-core/reducers/descriptions/form.reducerDescription.js
+++ b/src/core_modules/capture-core/reducers/descriptions/form.reducerDescription.js
@@ -11,7 +11,6 @@ import { actionTypes as dataEntryActionTypes } from '../../components/DataEntry/
 import { rulesEffectsActionTypes } from '../../rules';
 import { actionTypes as orgUnitFormFieldActionTypes } from '../../components/D2Form/field/Components/OrgUnitField/orgUnitFieldForForms.actions';
 import { newRelationshipActionTypes } from '../../components/DataEntries/SingleEventRegistrationEntry';
-import { newPageActionTypes } from '../../components/Pages/New/NewPage.actions';
 
 const removeFormData = (state, { payload: { formId } }) => {
     const remainingKeys = Object.keys(state).filter(key => !key.includes(formId));
@@ -85,7 +84,7 @@ export const formsValuesDesc = createReducerDescription({
         return newState;
     },
     [loaderActionTypes.FORM_DATA_REMOVE]: removeFormData,
-    [newPageActionTypes.CLEAN_UP_DATA_ENTRY]: cleanUp,
+    [dataEntryActionTypes.CLEAN_UP_DATA_ENTRY]: cleanUp,
     [newRelationshipActionTypes.NEW_EVENT_CANCEL_NEW_RELATIONSHIP]: cleanUp,
 }, 'formsValues');
 
@@ -202,7 +201,7 @@ export const formsSectionsFieldsUIDesc = createReducerDescription({
         };
     },
     [loaderActionTypes.FORM_DATA_REMOVE]: removeFormData,
-    [newPageActionTypes.CLEAN_UP_DATA_ENTRY]: cleanUp,
+    [dataEntryActionTypes.CLEAN_UP_DATA_ENTRY]: cleanUp,
     [rulesEffectsActionTypes.UPDATE_RULES_EFFECTS]: (state, action) => {
         const { formId, rulesEffects } = action.payload;
         const formSectionFields = state[formId];


### PR DESCRIPTION
- Ensures form initialisation executes before rules.
- Ensures all fields have a valid Redux state for `formsSectionsFieldsUI`. 

I couldn't reproduce the error reported in the newest Capture app (in the versions mentioned in the ticket I could). However, the code was highly error-prone and didn't behave as intended. @MatiasArriola: Thanks for such a thorough description in this PR (https://github.com/EyeSeeTea/capture-app/pull/4)