### PR TITLE
fix: [DHIS2-18839] TEA with number option set value does not show in Profile widget on Capture App

### DIFF
--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/helpers/convertClientToView.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/helpers/convertClientToView.js
@@ -1,6 +1,9 @@
 // @flow
 import { dataElementTypes, DataElement, OptionSet, Option } from '../../../../metaData';
-import { convertValue } from '../../../../converters/clientToView';
+import {
+    convertOptionSetValueServerToClient,
+    convertClientToView as convertValue,
+} from '../../../../converters';
 
 type Attribute = {
     attribute: string,
@@ -21,7 +24,7 @@ export const convertClientToView = (clientAttribute: Attribute) => {
             option =>
                 new Option((o) => {
                     o.text = option.displayName;
-                    o.value = option.code;
+                    o.value = convertOptionSetValueServerToClient(option.code, valueType) ?? option.code;
                 }),
         );
         dataElement.optionSet = new OptionSet(attribute, options, null, dataElement);


### PR DESCRIPTION
[DHIS2-18839](https://dhis2.atlassian.net/browse/DHIS2-18839)

- Added converting from server to client value for options.

[DHIS2-18839]: https://dhis2.atlassian.net/browse/DHIS2-18839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ