### PR TITLE
refactor: [DHIS2-19604] create special section for data elements not assigned to a section

### DIFF
--- a/src/core_modules/capture-core/components/D2Form/D2Form.component.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Form.component.js
@@ -4,7 +4,7 @@ import log from 'loglevel';
 import { errorCreator } from 'capture-core-utils';
 import { D2SectionContainer } from './D2Section.container';
 import type { Props, PropsForPureComponent } from './D2Form.types';
-import { type Section } from '../../metaData';
+import { Section } from '../../metaData';
 
 class D2Form extends React.PureComponent<PropsForPureComponent> {
     name: string;
@@ -121,7 +121,9 @@ class D2Form extends React.PureComponent<PropsForPureComponent> {
             getCustomContent,
             ...passOnProps
         } = this.props;
-        const metaDataSectionsAsArray = Array.from(formFoundation.sections.entries()).map(entry => entry[1]);
+        const metaDataSectionsAsArray = Array.from(formFoundation.sections.entries())
+            .map(entry => entry[1])
+            .filter(section => section.id !== Section.LEFTOVERS_SECTION_ID);
 
         const sections = metaDataSectionsAsArray.map(section => (
             passOnProps.formHorizontal

--- a/src/core_modules/capture-core/metaData/Program/ProgramStage.js
+++ b/src/core_modules/capture-core/metaData/Program/ProgramStage.js
@@ -4,7 +4,6 @@
 
 import isFunction from 'd2-utilizr/lib/isFunction';
 import type { ProgramRule } from '@dhis2/rules-engine-javascript';
-import type { CachedDataElement } from '../../storageControllers/cache.types';
 import type { Icon } from '../Icon';
 import type { RenderFoundation } from '../RenderFoundation';
 import type { RelationshipType } from '../RelationshipType';
@@ -28,7 +27,6 @@ export class ProgramStage {
     _reportDateToUse: string | void;
     _minDaysFromStart: number;
     _icon: Icon | void;
-    _dataElements: Array<CachedDataElement>;
     _programRules: Array<ProgramRule>;
 
     constructor(initFn: ?(_this: ProgramStage) => void) {
@@ -177,14 +175,6 @@ export class ProgramStage {
 
     set minDaysFromStart(minDays: number = 0) {
         this._minDaysFromStart = minDays;
-    }
-
-    get dataElements(): Array<CachedDataElement> {
-        return this._dataElements;
-    }
-
-    set dataElements(dataElements: Array<CachedDataElement>) {
-        this._dataElements = dataElements;
     }
 
     set programRules(programRules: Array<ProgramRule>) {

--- a/src/core_modules/capture-core/metaData/RenderFoundation/Section.js
+++ b/src/core_modules/capture-core/metaData/RenderFoundation/Section.js
@@ -10,6 +10,7 @@ import type { FormFieldPluginConfig } from '../FormFieldPluginConfig';
 
 export class Section {
     static MAIN_SECTION_ID = '#MAIN#';
+    static LEFTOVERS_SECTION_ID = '#LEFTOVERS#';
 
     static errorMessages = {
         DATA_ELEMENT_NOT_FOUND: 'Data element was not found',

--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/programStage/ProgramStageFactory.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/programStage/ProgramStageFactory.js
@@ -18,7 +18,7 @@ import { buildIcon } from '../../../common/helpers';
 import { isNonEmptyArray } from '../../../../utils/isNonEmptyArray';
 import { DataElementFactory } from './DataElementFactory';
 import { RelationshipTypesFactory } from './RelationshipTypesFactory';
-import type { ConstructorInput, SectionSpecs, RuleProgramStageDataElement } from './programStageFactory.types';
+import type { ConstructorInput, SectionSpecs } from './programStageFactory.types';
 import { transformEventNode } from '../transformNodeFuntions/transformNodeFunctions';
 import type { DataEntryFormConfig } from '../../../../components/DataEntries/common/TEIAndEnrollment';
 import { FormFieldTypes } from '../../../../components/D2Form/FormFieldPlugin/FormFieldPlugin.const';
@@ -154,39 +154,6 @@ export class ProgramStageFactory {
         }
 
         return section;
-    }
-
-    async _buildProgramStageDataElements(
-        cachedProgramStageDataElements: Array<CachedProgramStageDataElement>,
-    ): Promise<RuleProgramStageDataElement> {
-        const cachedDataElements = this.cachedDataElements;
-        if (cachedDataElements) {
-            // $FlowIgnore
-            return cachedProgramStageDataElements
-                .map(dataElement => cachedDataElements.get(dataElement.dataElementId))
-                .filter(Boolean)
-                .map(dataElement => (dataElement && {
-                    id: dataElement.id,
-                    name: dataElement.displayFormName || dataElement.displayName,
-                    valueType: dataElement.valueType,
-                    optionSetId: dataElement.optionSet?.id,
-                }));
-        }
-        // $FlowIgnore
-        const dataElementPromises = cachedProgramStageDataElements
-            .map(async (cachedDataElement) => {
-                // $FlowIgnore
-                const dataElement = await this.dataElementFactory.build(cachedDataElement);
-                return dataElement && {
-                    id: dataElement.id,
-                    name: dataElement.formName || dataElement.name,
-                    valueType: dataElement.type,
-                    optionSetId: dataElement.optionSet?.id,
-                };
-            });
-        const dataElements: Array<?RuleProgramStageDataElement> = await Promise.all(dataElementPromises);
-        // $FlowIgnore
-        return dataElements.filter(Boolean);
     }
 
     static _convertProgramStageDataElementsToObject(
@@ -342,9 +309,6 @@ export class ProgramStageFactory {
         } else {
             stageForm.addSection(await this._buildMainSection(cachedProgramStage.programStageDataElements));
         }
-
-        // $FlowIgnore
-        stage.dataElements = await this._buildProgramStageDataElements(cachedProgramStage.programStageDataElements);
 
         return stage;
     }

--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/programStage/programStageFactory.types.js
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/programStage/programStageFactory.types.js
@@ -24,10 +24,3 @@ export type SectionSpecs = {|
     displayDescription: string,
     dataElements: ?Array<CachedSectionDataElements>,
 |};
-
-export type RuleProgramStageDataElement = {|
-    id: string,
-    name: string,
-    valueType: string,
-    optionSetId: ?string,
-|};

--- a/src/core_modules/capture-core/rules/__tests__/__snapshots__/getApplicableRuleEffectsForTrackerProgram.test.js.snap
+++ b/src/core_modules/capture-core/rules/__tests__/__snapshots__/getApplicableRuleEffectsForTrackerProgram.test.js.snap
@@ -18,14 +18,11 @@ Object {
     "trackedEntityInstanceId": "vCGpQAWG17I",
   },
   "dataElements": Object {
-    "da1Id": DataElement {
-      "_compulsory": false,
-      "_disabled": false,
-      "_displayInForms": true,
-      "_displayInReports": true,
-      "_id": "da1Id",
-      "_name": "dataElement1",
-      "_type": "TEXT",
+    "da1Id": Object {
+      "id": "da1Id",
+      "name": "dataElement1",
+      "optionSetId": undefined,
+      "valueType": "TEXT",
     },
   },
   "optionSets": Object {

--- a/src/core_modules/capture-core/rules/__tests__/__snapshots__/getApplicableRulesEffectsForEventProgram.test.js.snap
+++ b/src/core_modules/capture-core/rules/__tests__/__snapshots__/getApplicableRulesEffectsForEventProgram.test.js.snap
@@ -18,14 +18,11 @@ Object {
     "trackedEntityInstanceId": "vCGpQAWG17I",
   },
   "dataElements": Object {
-    "da1Id": DataElement {
-      "_compulsory": false,
-      "_disabled": false,
-      "_displayInForms": true,
-      "_displayInReports": true,
-      "_id": "da1Id",
-      "_name": "dataElement1",
-      "_type": "TEXT",
+    "da1Id": Object {
+      "id": "da1Id",
+      "name": "dataElement1",
+      "optionSetId": undefined,
+      "valueType": "TEXT",
     },
   },
   "optionSets": Object {

--- a/src/core_modules/capture-core/rules/getDataElementsForRulesExecution.js
+++ b/src/core_modules/capture-core/rules/getDataElementsForRulesExecution.js
@@ -3,8 +3,13 @@ import type { ProgramStage } from '../metaData';
 
 export const getDataElementsForRulesExecution = (stages: Map<string, ProgramStage>) =>
     [...stages.values()]
-        .flatMap(stage => stage.dataElements)
+        .flatMap(stage => stage.stageForm.getElements())
         .reduce((accRulesDataElements, dataElement) => {
-            accRulesDataElements[dataElement.id] = dataElement;
+            accRulesDataElements[dataElement.id] = {
+                id: dataElement.id,
+                valueType: dataElement.type,
+                optionSetId: dataElement.optionSet?.id,
+                name: dataElement.formName || dataElement.name,
+            };
             return accRulesDataElements;
         }, {});


### PR DESCRIPTION
In program stages using **section form**, it is not required for all data elements to be part of the form.

However, any data element not included in the form should still be assignable by means of program rules. Now it turns out that for the app to be able to do this, all such data elements need to be found within the `ProgramStage`s coming from `ProgramStageFactory`.

The problem with the initial implementation of `ProgramStageFactory` is that it just ignored all data elements not assigned to any section, meaning such data elements could not be recovered from the manufactured `ProgramStage`.

The first commit reverts one possible solution to this problem, which is to add all program stage data element in an array separate from the `ProgramStage.stageForm`-object (`ProgramStage.stageForm` is where the data elements used to get extracted from). The main drawback with this approach is that most data elements get saved twice, once in the `ProgramStage.stageForm` and once in the separate array.

This new approach is to include all unassigned data elements to a new special section in `RenderFoundation`. The primary advantage of doing it this way is that it eliminates the duplication of the first approach, and it simplifies the structure of `ProgramStage`. The main disadvantage is that it introduces a special kind of section that should never be displayed in the form, and therefore needs special treatment in the code. Implementing this special behavior turned out to be quite easy though (third commit).