### PR TITLE
docs: block entry form after completed

### DIFF
--- a/docs/user/using-the-capture-app.md
+++ b/docs/user/using-the-capture-app.md
@@ -386,6 +386,10 @@ You now have two options:
 
 6. Modify the event details and click **Save**.
 
+> **Note**  
+> The **Edit event** button is disabled if the program stage has **Block entry form after completed** enabled and your user role does not include the **Uncomplete events** authority.
+
+
 ## Delete an event { #capture_delete_event } 
 
 1. Open the **Capture** app.


### PR DESCRIPTION
Adding this note to clarify that the Edit event button is only blocked when Block entry form after completed is enabled and the user lacks the Uncomplete events authority.

Several bug reports were filed because users had the authority and misunderstood the setting. This aims to prevent further confusion.