### PR TITLE
fix: [DHIS2-19694] use the EQ operator when filtering by unique TEA in the WLs

### DIFF
--- a/src/core_modules/capture-core/components/ListView/types/listView.types.js
+++ b/src/core_modules/capture-core/components/ListView/types/listView.types.js
@@ -12,6 +12,7 @@ export type Column = {
     multiValueFilter?: boolean,
     filterHidden?: boolean,
     additionalColumn?: boolean,
+    unique?: boolean,
 };
 
 export type Columns = Array<Column>;

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingListsCommon/types/eventWorkingListsCommon.types.js
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingListsCommon/types/eventWorkingListsCommon.types.js
@@ -14,6 +14,7 @@ export type ColumnConfigBase = {|
     multiValueFilter?: boolean,
     filterHidden?: boolean,
     additionalColumn?: boolean,
+    unique?: boolean,
 |};
 export type MetadataColumnConfig = {
     ...ColumnConfigBase,

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/hooks/useDefaultColumnConfig.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/hooks/useDefaultColumnConfig.js
@@ -99,6 +99,7 @@ const getTEIMetaDataConfig = (attributes: Array<DataElement>, orgUnitId: ?string
         options: optionSet && optionSet.options.map(({ text, value }) => ({ text, value })),
         multiValueFilter: !!optionSet || type === dataElementTypes.BOOLEAN,
         filterHidden: !(orgUnitId || searchable || unique),
+        unique: Boolean(unique),
     }));
 
 const getDataValuesMetaDataConfig = (dataElements): Array<MetadataColumnConfig> =>

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/hooks/useInjectDataFetchingMeta.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/Setup/hooks/useInjectDataFetchingMeta.js
@@ -21,7 +21,7 @@ export const useInjectDataFetchingMetaToLoadList = (
             const columnsMetaForDataFetching: TeiColumnsMetaForDataFetching = new Map(
                 defaultColumns.map((defaultColumn: TeiWorkingListsColumnConfig) => {
                     // $FlowFixMe Destructuring of union types is not handled properly by Flow.
-                    const { id, type, visible, apiViewName } = defaultColumn;
+                    const { id, type, visible, apiViewName, unique } = defaultColumn;
                     const mainProperty = defaultColumn.mainProperty && typeof defaultColumn.mainProperty === 'boolean'
                         ? defaultColumn.mainProperty
                         : undefined;
@@ -38,6 +38,7 @@ export const useInjectDataFetchingMetaToLoadList = (
                             mainProperty,
                             additionalColumn,
                             apiViewName,
+                            unique,
                         },
                     ];
                 }),
@@ -70,7 +71,7 @@ export const useInjectDataFetchingMetaToUpdateList = (
         (queryArgs: Object) => {
             const columnsMetaForDataFetching: TeiColumnsMetaForDataFetching = new Map(
                 defaultColumns.map((defaultColumn: TeiWorkingListsColumnConfig) => {
-                    const { id, type, visible } = defaultColumn;
+                    const { id, type, visible, unique } = defaultColumn;
                     const mainProperty = defaultColumn.mainProperty && typeof defaultColumn.mainProperty === 'boolean'
                         ? defaultColumn.mainProperty
                         : undefined;
@@ -86,6 +87,7 @@ export const useInjectDataFetchingMetaToUpdateList = (
                             visible,
                             mainProperty,
                             additionalColumn,
+                            unique,
                         },
                     ];
                 }),

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/apiTEIFilterToClientConfigConverter/convertToClientFilters.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/apiTEIFilterToClientConfigConverter/convertToClientFilters.js
@@ -12,6 +12,7 @@ import type {
     ApiDataFilter,
     ApiDataFilterNumeric,
     ApiDataFilterText,
+    ApiDataFilterTextUnique,
     ApiDataFilterBoolean,
     ApiDataFilterDate,
     ApiDataFilterDateContents,
@@ -23,9 +24,15 @@ import { areRelativeRangeValuesSupported }
     from '../../../../../../utils/validation/validators/areRelativeRangeValuesSupported';
 import { DATE_TYPES, ASSIGNEE_MODES, MAIN_FILTERS } from '../../../constants';
 import { ADDITIONAL_FILTERS } from '../../../helpers';
+import { type DataElement } from '../../../../../../metaData';
 
-const getTextFilter = (filter: ApiDataFilterText): ?TextFilterData => {
-    const value = filter.like;
+const getTextFilter = (
+    filter: ApiDataFilterText & ApiDataFilterTextUnique,
+    dataElement?: DataElement,
+): ?TextFilterData => {
+    const value = dataElement?.unique
+        ? filter.eq ?? filter.like
+        : filter.like;
     return value ? { value } : undefined;
 };
 
@@ -185,7 +192,7 @@ const convertAttributeFilters = (
             ? // $FlowFixMe
             getOptionSetFilter(serverFilter, element.type)
             : // $FlowFixMe
-            getFilterByType[element.type](serverFilter);
+            getFilterByType[element.type](serverFilter, element);
 
         return value ? { ...acc, [serverFilter.attribute]: value } : acc;
     }, {});

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/convertToTEIFilterQuery.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/convertToTEIFilterQuery.js
@@ -42,7 +42,7 @@ export const convertToTEIFilterAttributes = ({
 
             return {
                 // $FlowFixMe I accept that not every type is listed, thats why I'm doing this test
-                ...getFilterByType[element.type](filter),
+                ...getFilterByType[element.type](filter, element),
                 attribute: key,
             };
         })

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/convertors.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/convertors.js
@@ -11,10 +11,11 @@ import {
 import type { ApiDataFilterBoolean, ApiDataFilterDateContents } from '../../../types';
 import { ADDITIONAL_FILTERS } from '../../../helpers';
 import { MAIN_FILTERS } from '../../../constants';
+import { type DataElement } from '../../../../../../metaData';
 
-const getTextFilter = (filter: TextFilterData) => ({
-    like: filter.value,
-});
+const getTextFilter = (filter: TextFilterData, dataElement?: DataElement) => (
+    dataElement?.unique ? { eq: filter.value } : { like: filter.value }
+);
 
 const getNumericFilter = (filter: NumericFilterData) => ({
     ge: filter.ge ? filter.ge.toString() : undefined,

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/types/apiTemplate.types.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/types/apiTemplate.types.js
@@ -3,6 +3,10 @@ export type ApiDataFilterText = {|
     like: string,
 |};
 
+export type ApiDataFilterTextUnique = {|
+    eq: string,
+|};
+
 export type ApiDataFilterNumeric = {|
     ge?: ?string,
     le?: ?string,
@@ -58,6 +62,7 @@ export type ApiTrackerQueryCriteria = {|
 
 export type ApiDataFilter = (
     | ApiDataFilterText
+    | ApiDataFilterTextUnique
     | ApiDataFilterNumeric
     | ApiDataFilterBoolean
     | ApiDataFilterTrueOnly

--- a/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/types/concept.types.js
+++ b/src/core_modules/capture-core/components/WorkingLists/TeiWorkingLists/types/concept.types.js
@@ -36,6 +36,7 @@ export type ColumnConfigBase = {|
     multiValueFilter?: boolean,
     filterHidden?: boolean,
     additionalColumn?: boolean,
+    unique?: boolean,
 |};
 export type MetadataColumnConfig = {
     ...ColumnConfigBase,

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/workingListsBase.types.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsBase/workingListsBase.types.js
@@ -46,6 +46,7 @@ export type ColumnConfig = {
     multiValueFilter?: boolean,
     filterHidden?: boolean,
     additionalColumn?: boolean,
+    unique?: boolean,
 };
 
 export type ColumnConfigs = Array<ColumnConfig>;

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/buildFilterQueryArgs.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/buildFilterQueryArgs.js
@@ -35,11 +35,12 @@ function convertFilter(
         storeId: string,
         isInit: boolean,
     },
+    unique?: boolean,
 ) {
     if (sourceValue && sourceValue.usingOptionSet) {
         return convertOptionSet(sourceValue, type);
     }
-    return mappersForTypes[type] ? mappersForTypes[type](sourceValue, meta.key, meta.storeId, meta.isInit) : sourceValue;
+    return mappersForTypes[type] ? mappersForTypes[type]({ sourceValue, meta, unique }) : sourceValue;
 }
 export const buildFilterQueryArgs = (
     filters: FiltersData, {
@@ -52,18 +53,21 @@ export const buildFilterQueryArgs = (
     .keys(filters)
     .filter(key => filters[key])
     .reduce((acc, key) => {
-        const { type } = columns.get(key) || (filtersOnly && filtersOnly.get(key)) || {};
+        const { type, unique } = columns.get(key) || (filtersOnly && filtersOnly.get(key)) || {};
         if (!type) {
             log.error(errorCreator('Could not get type for key')({ key, storeId }));
         } else {
             const sourceValue = filters[key];
             const queryArgValue = convertFilter(
                 sourceValue,
-                type, {
+                type,
+                {
                     key,
                     storeId,
                     isInit,
-                });
+                },
+                unique,
+            );
             acc[key] = queryArgValue;
         }
         return acc;

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/assigneeConverter.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/assigneeConverter.js
@@ -3,7 +3,7 @@ import { featureAvailable, FEATURES } from 'capture-core-utils';
 import type { AssigneeFilterData } from '../../../../../ListView';
 
 export function convertAssignee(
-    sourceValue: AssigneeFilterData,
+    { sourceValue }: { sourceValue: AssigneeFilterData },
 ) {
     const assignedUsersQueryParam: string = featureAvailable(FEATURES.newEntityFilterQueryParam)
         ? 'assignedUsers'

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/booleanConverter.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/booleanConverter.js
@@ -7,7 +7,7 @@ const booleanFilterValues = {
     false: 'false',
 };
 
-export function convertBoolean(filter: BooleanFilterData) {
+export function convertBoolean({ sourceValue }: { sourceValue: BooleanFilterData }) {
     return pipe(
         values => values.map(filterValue => booleanFilterValues[filterValue]),
         values =>
@@ -16,5 +16,5 @@ export function convertBoolean(filter: BooleanFilterData) {
                 { valueString: values[0], single: true }
             ),
         ({ valueString, single }) => (single ? `eq:${valueString}` : `in:${valueString}`),
-    )(filter.values);
+    )(sourceValue.values);
 }

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/dateConverter.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/dateConverter.js
@@ -159,12 +159,13 @@ function convertAbsoluteDate(sourceValue: AbsoluteDateFilterData) {
     return requestData?.join(':');
 }
 
-export function convertDate(
+export function convertDate({
+    sourceValue,
+    meta: { key, storeId, isInit },
+}: {
     sourceValue: DateFilterData,
-    key: string,
-    storeId: string,
-    isInit: boolean,
-) {
+    meta: { key: string, storeId: string, isInit: boolean },
+}) {
     if (sourceValue.type === 'ABSOLUTE') {
         return convertAbsoluteDate(sourceValue);
     }

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/numericConverter.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/numericConverter.js
@@ -1,14 +1,14 @@
 // @flow
 import type { NumericFilterData } from '../../../../../ListView';
 
-export function convertNumeric(filter: NumericFilterData) {
+export function convertNumeric({ sourceValue }: { sourceValue: NumericFilterData }) {
     const requestData = [];
 
-    if (filter.ge || filter.ge === 0) {
-        requestData.push(`ge:${filter.ge}`);
+    if (sourceValue.ge || sourceValue.ge === 0) {
+        requestData.push(`ge:${sourceValue.ge}`);
     }
-    if (filter.le || filter.le === 0) {
-        requestData.push(`le:${filter.le}`);
+    if (sourceValue.le || sourceValue.le === 0) {
+        requestData.push(`le:${sourceValue.le}`);
     }
 
     return requestData.join(':');

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/textConverter.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/textConverter.js
@@ -3,5 +3,6 @@ import type { TextFilterData } from '../../../../../ListView';
 import { escapeString } from '../../../../../../utils/escapeString';
 
 export function convertText({ sourceValue, unique }: { sourceValue: TextFilterData, unique?: boolean }): string {
-    return unique ? `eq:${escapeString(sourceValue.value)}` : `like:${escapeString(sourceValue.value)}`;
+    const operator = unique ? 'eq' : 'like';
+    return `${operator}:${escapeString(sourceValue.value)}`;
 }

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/textConverter.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/textConverter.js
@@ -2,6 +2,6 @@
 import type { TextFilterData } from '../../../../../ListView';
 import { escapeString } from '../../../../../../utils/escapeString';
 
-export function convertText(filter: TextFilterData) {
-    return `like:${escapeString(filter.value)}`;
+export function convertText({ sourceValue, unique }: { sourceValue: TextFilterData, unique?: boolean }): string {
+    return unique ? `eq:${escapeString(sourceValue.value)}` : `like:${escapeString(sourceValue.value)}`;
 }

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/trueOnlyConverter.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/trueOnlyConverter.js
@@ -1,7 +1,7 @@
 // @flow
 import type { TrueOnlyFilterData } from '../../../../../ListView';
 
-export function convertTrueOnly(filter: TrueOnlyFilterData) {
+export function convertTrueOnly({ sourceValue }: { sourceValue: TrueOnlyFilterData }) {
     // $FlowFixMe[incompatible-type] automated comment
-    return `eq:${filter.value}`;
+    return `eq:${sourceValue.value}`;
 }


### PR DESCRIPTION
[DHIS2-19694](https://dhis2.atlassian.net/browse/DHIS2-19694)

**Tech summary**
- use the `eq` operator when filtering by unique TEA in the Tracker programs working lists
- use the `eq` operator for [POST and PUT requests](https://github.com/dhis2/capture-app/pull/4129/files#diff-74c4f09afc76fe06368d5b756d4a3a7dd9255fb01ecdc5ca1fad46629a6d4c3dR17) to the `/trackedEntityInstanceFilters` and `/programStageWorkingLists` endpoints
- maintain backward compatibility for previously stored Tracker WL templates, by supporting [both eq and like](https://github.com/dhis2/capture-app/pull/4129/files#diff-c6cd17ddf4d6c3ba3c3925fa71b2fb5251036ea8874adadcc4d6fba63081400fR34) for unique TEAs 

[DHIS2-19694]: https://dhis2.atlassian.net/browse/DHIS2-19694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ