### PR TITLE
fix: [DHIS2-19744] return memoized component also on first render

### DIFF
--- a/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/EnrollmentPageLayout/renderPageComponents/renderPageComponents.js
+++ b/src/core_modules/capture-core/components/Pages/common/EnrollmentOverviewDomain/EnrollmentPageLayout/renderPageComponents/renderPageComponents.js
@@ -45,12 +45,10 @@ const renderComponent = (
     }
     const customSettings = getCustomSettings && getCustomSettings(settings);
 
-    let Widget = MemoizedWidgets[name];
-
-    if (!Widget) {
-        Widget = widgetConfig.Component;
-        MemoizedWidgets[name] = React.memo(Widget);
+    if (!MemoizedWidgets[name]) {
+        MemoizedWidgets[name] = React.memo(widgetConfig.Component);
     }
+    const Widget = MemoizedWidgets[name];
 
     return (
         <Widget


### PR DESCRIPTION
[DHIS2-19744](https://dhis2.atlassian.net/browse/DHIS2-19744)

The non-memoized version of the component got returned on the first render, which in turn led `WidgetRelatedStages` to make two identical queries to the backend.

[DHIS2-19744]: https://dhis2.atlassian.net/browse/DHIS2-19744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ