### PR TITLE
fix: [DHIS2-19765] omit program indicators in profile widget rule execution

### DIFF
--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/ProgramRules/rulesContainer.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/ProgramRules/rulesContainer.js
@@ -1,9 +1,6 @@
 // @flow
-import log from 'loglevel';
-import { errorCreator } from 'capture-core-utils';
 import type { ProgramRulesContainer } from '@dhis2/rules-engine-javascript';
 import { getTrackedEntityAttributeId, getDataElementId, getProgramId, getProgramRuleActions, getProgramStageId } from '../helpers';
-import { getRulesAndVariablesFromProgramIndicators } from '../../../../metaDataMemoryStoreBuilders/programs/getRulesAndVariablesFromIndicators';
 
 const addProgramVariables = (program, programRuleVariables) => {
     program.programRuleVariables = programRuleVariables.map(programRulesVariable => ({
@@ -23,37 +20,6 @@ const addProgramRules = (program, programRules) => {
     }));
 };
 
-const addRulesAndVariablesFromProgramIndicators = (rulesContainer, programIndicators, programId) => {
-    const validProgramIndicators = programIndicators.filter((indicator) => {
-        if (!indicator.expression) {
-            log.error(
-                errorCreator('WidgetProfile: Program indicator is missing an expression and will be skipped.')(
-                    {
-                        method: 'addRulesAndVariablesFromProgramIndicators',
-                        object: indicator,
-                    },
-                ),
-            );
-            return false;
-        }
-        return true;
-    });
-
-    const indicators = validProgramIndicators.map(programIndicator => ({
-        ...programIndicator,
-        programId: getProgramId(programIndicator),
-    }));
-    const { rules, variables } = getRulesAndVariablesFromProgramIndicators(indicators, programId);
-
-    if (variables) {
-        rulesContainer.programRuleVariables = [...rulesContainer.programRuleVariables, ...variables];
-    }
-    if (rules) {
-        rulesContainer.programRules = [...rulesContainer.programRules, ...rules];
-    }
-};
-
-
 export const buildRulesContainer = async ({
     programAPI,
     programRules,
@@ -65,12 +31,11 @@ export const buildRulesContainer = async ({
     constants: Array<any>,
     setRulesContainer: (rulesContainer: ProgramRulesContainer) => void,
 }) => {
-    const { programRuleVariables, programIndicators } = programAPI;
+    const { programRuleVariables } = programAPI;
     const rulesContainer = {};
 
     programRuleVariables && addProgramVariables(rulesContainer, programRuleVariables);
     programRules && addProgramRules(rulesContainer, programRules);
-    programIndicators && addRulesAndVariablesFromProgramIndicators(rulesContainer, programIndicators, programAPI.id);
     rulesContainer.constants = constants;
 
     setRulesContainer(rulesContainer);

--- a/src/core_modules/capture-core/components/WidgetProfile/hooks/useApiProgram.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/hooks/useApiProgram.js
@@ -7,7 +7,6 @@ const fields =
     'access[*],' +
     'dataEntryForm[id,htmlCode],' +
     'categoryCombo[id,displayName,isDefault,categories[id,displayName]],' +
-    'programIndicators[id,displayName,code,shortName,style,displayInForm,expression,displayDescription,description,filter,program[id]],' +
     'programSections[id,displayFormName,displayDescription,sortOrder,trackedEntityAttributes],' +
     'programRuleVariables[id,displayName,programRuleVariableSourceType,valueType,program[id],programStage[id],dataElement[id],trackedEntityAttribute[id],useCodeForOptionSet],' +
     'programStages[id,access,autoGenerateEvent,openAfterEnrollment,generatedByEnrollmentDate,reportDateToUse,minDaysFromStart,displayName,description,executionDateLabel,formType,featureType,validationStrategy,enableUserAssignment,style,' +


### PR DESCRIPTION
[DHIS2-19765](https://dhis2.atlassian.net/browse/DHIS2-19765)

We don't need to evaluate program indicators in the profile widget, because they only generate `Display key/value pair` effects, which are not used by this widget.

[DHIS2-19665]: https://dhis2.atlassian.net/browse/DHIS2-19665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-19765]: https://dhis2.atlassian.net/browse/DHIS2-19765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ