### PR TITLE
fix: [DHIS2-19784] send ISO-formatted enrollment date to rule engine

### DIFF
--- a/src/core_modules/capture-core/components/DataEntries/Enrollment/actions/open.actionBatchs.js
+++ b/src/core_modules/capture-core/components/DataEntries/Enrollment/actions/open.actionBatchs.js
@@ -72,7 +72,6 @@ export const openDataEntryForNewEnrollmentBatchAsync = async ({
     const formId = getDataEntryKey(dataEntryId, itemId);
     const addFormDataActions = addFormData(`${dataEntryId}-${itemId}`, formValues);
     const firstStageDataEntryPropsToInclude = firstStage && getDataEntryPropsToInclude(firstStage);
-    const defaultDataEntryValues = { enrolledAt: convertDateObjectToDateFormatString(new Date()) };
     const dataEntryPropsToInclude = [
         ...enrollmentDataEntryPropsToInclude,
         ...extraDataEntryProps,
@@ -90,7 +89,7 @@ export const openDataEntryForNewEnrollmentBatchAsync = async ({
                 dataEntryId,
                 itemId,
                 dataEntryPropsToInclude,
-                defaultDataEntryValues,
+                { enrolledAt: convertDateObjectToDateFormatString(new Date()) },
             );
 
     const effects = getApplicableRuleEffectsForTrackerProgram({
@@ -98,7 +97,7 @@ export const openDataEntryForNewEnrollmentBatchAsync = async ({
         orgUnit,
         stage: firstStage,
         attributeValues: clientValues,
-        enrollmentData: defaultDataEntryValues,
+        enrollmentData: { enrolledAt: new Date().toISOString() },
         formFoundation,
     });
 


### PR DESCRIPTION
[DHIS2-19784](https://dhis2.atlassian.net/browse/DHIS2-19784)

The rule engine prefers ISO-formatted enrollment dates.

This PR is basically just a rewrite of the solution in https://github.com/dhis2/capture-app/pull/3475, but the result is not identical; now the output date is always in the format `YYYY-MM-DD`, whereas before it had the system format.

I'll make this PR a draft until we've investigated whether the system format can still be used.

EDIT:
There is no sensible way to automatically output dates in the system date format, so keeping it as it currently is.

[DHIS2-19784]: https://dhis2.atlassian.net/browse/DHIS2-19784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ