### PR TITLE
fix: use 'en' as fallback in `localeCompareStrings`

### DIFF
--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/hooks/sortFunctions.js
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/hooks/sortFunctions.js
@@ -5,6 +5,7 @@ import { getCachedOrgUnitName } from 'capture-core/metadataRetrieval/orgUnitName
 import moment from 'moment';
 import { dataElementTypes } from '../../../../../../metaData';
 import { SORT_DIRECTION } from './constants';
+import { localeCompareStrings } from '../../../../../../utils/localeCompareStrings';
 
 
 const sortNumber = (clientValueA: Object, clientValueB: Object, direction: string, options: Object) => {
@@ -41,7 +42,7 @@ const sortText = (clientValueA: Object, clientValueB: Object, direction: string,
         if (!clientValueB) return -1;
 
         if (clientValueA !== clientValueB) {
-            return clientValueB.localeCompare(clientValueA);
+            return localeCompareStrings(clientValueB, clientValueA);
         }
 
         return moment(eventDateB).unix() - moment(eventDateA).unix();
@@ -50,7 +51,7 @@ const sortText = (clientValueA: Object, clientValueB: Object, direction: string,
         if (!clientValueB) return 1;
 
         if (clientValueA !== clientValueB) {
-            return clientValueA.localeCompare(clientValueB);
+            return localeCompareStrings(clientValueA, clientValueB);
         }
 
         return moment(eventDateB).unix() - moment(eventDateA).unix();

--- a/src/core_modules/capture-core/utils/localeCompareStrings/localeCompareStrings.js
+++ b/src/core_modules/capture-core/utils/localeCompareStrings/localeCompareStrings.js
@@ -1,4 +1,10 @@
 // @flow
 import i18n from '@dhis2/d2-i18n';
 
-export const localeCompareStrings = (a: string, b: string) => a.localeCompare(b, i18n.language);
+export const localeCompareStrings = (a: string, b: string) => {
+    try {
+        return a.localeCompare(b, i18n.language);
+    } catch {
+        return a.localeCompare(b, 'en');
+    }
+};


### PR DESCRIPTION
Slack thread:
https://dhis2.slack.com/archives/C45MWQ1QS/p1750422050038479