### PR TITLE
fix: [DHIS2-16364] Stage selection still shown with only one available stage

### DIFF
--- a/cypress/e2e/EnrollmentAddEventPage/ProgramStageSelector/ProgramStageSelector.feature
+++ b/cypress/e2e/EnrollmentAddEventPage/ProgramStageSelector/ProgramStageSelector.feature
@@ -1,15 +1,22 @@
-Feature: User is able to select program stage when navigating to EnrollmentEventNew without stageId
+Feature: Program stage selector when navigating to EnrollmentEventNew without stageId
 
   Scenario: User can select stage when not present
-    Given you land on the EnrollmentEventNew-page without a stageId
-    When the user clicks the Baby Postnatal-button
-    Then the URL should contain stageId
+    Given user lands on the EnrollmentEventNew-page without a stageId by typing #/enrollmentEventNew?enrollmentId=PAHlrkHc40G&orgUnitId=DiszpKrYNg8&programId=WSGAb5XwJ3Y&teiId=H0YmvIuKqv0
+    When the user clicks the Care at birth program stage button
+    Then the URL should contain stageId PFDfvmGpsR3
 
-  Scenario: The stage-button should be disabled when non-repeatable & event > 0
-    Given you land on the EnrollmentEventNew-page without a stageId
-    Then the stage-button should be disabled
+  Scenario: Non-repeatable stages should not be displayed in the stage selector
+    Given user lands on the Enrollment dashboard page by typing #/enrollment?enrollmentId=PAHlrkHc40G&orgUnitId=DiszpKrYNg8&programId=WSGAb5XwJ3Y&teiId=H0YmvIuKqv0
+    And there are four program stages
+    And one of the program stages is non-repeatable
+    When user lands on the EnrollmentEventNew-page without a stageId by typing #/enrollmentEventNew?enrollmentId=PAHlrkHc40G&orgUnitId=DiszpKrYNg8&programId=WSGAb5XwJ3Y&teiId=H0YmvIuKqv0
+    Then only three program stages are displayed in the stage selector widget
+
+  Scenario: Program stage should be auto selected when only one stage is available
+    Given user lands on the EnrollmentEventNew-page without a stageId by typing #/enrollmentEventNew?enrollmentId=RiNIt1yJoge&orgUnitId=DiszpKrYNg8&programId=IpHINAT79UW&teiId=x2kJgpb0XQC
+    Then the URL should contain stageId ZzYYXq4fJie
 
   @user:trackerAutoTestRestricted
-  Scenario: The stage-button should be disabled when no data write access
-    Given you open the enrollment page by typing #enrollmentEventNew?enrollmentId=WKPoiZxZxNG&orgUnitId=DiszpKrYNg8&programId=WSGAb5XwJ3Y&teiId=PgmUFEQYZdt
-    Then the stage-button should be disabled
+  Scenario: Stages buttons should not be displayed when no data write access
+    Given user lands on the Enrollment dashboard page by typing #/enrollmentEventNew?enrollmentId=X7g83OFRALm&orgUnitId=DiszpKrYNg8&programId=WSGAb5XwJ3Y&teiId=YsKjdOcl9Cd
+    Then the New event quick action button is disabled

--- a/cypress/e2e/EnrollmentAddEventPage/ProgramStageSelector/ProgramStageSelector.js
+++ b/cypress/e2e/EnrollmentAddEventPage/ProgramStageSelector/ProgramStageSelector.js
@@ -1,26 +1,44 @@
 import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
 
-Given(/^you open the enrollment page by typing (.*)$/, url =>
+Given(/^user lands on the Enrollment dashboard page by typing (.*)$/, url =>
     cy.visit(url),
 );
 
-Given('you land on the EnrollmentEventNew-page without a stageId', () => {
-    cy.visit('/#/enrollmentEventNew?programId=IpHINAT79UW&orgUnitId=DiszpKrYNg8&teiId=x2kJgpb0XQC&enrollmentId=RiNIt1yJoge');
+Given(/^user lands on the EnrollmentEventNew-page without a stageId by typing (.*)$/, url =>
+    cy.visit(url),
+);
+
+Given('there are four program stages', () => {
+    cy.get('[data-test=stage-content]').should('have.length', 4);
 });
 
-When('the user clicks the Baby Postnatal-button', () => {
+Given('one of the program stages is non-repeatable', () => {
+    cy.get('[data-test=create-new-button]').should('have.length', 4);
+    cy.get('[data-test=create-new-button]').eq(1).should('be.disabled');
+});
+
+When('the user clicks the Care at birth program stage button', () => {
     cy.get('[data-test=program-stage-selector-button]')
-        .eq(1)
+        .eq(2)
+        .should('contain', 'Care at birth')
         .click();
 });
 
-Then('the URL should contain stageId', () => {
+Then(/^the URL should contain stageId (.*)$/, stageId =>
     cy.url()
-        .should('include', 'stageId=ZzYYXq4fJie');
-});
+        .should('include', stageId),
+);
 
 Then('the stage-button should be disabled', () => {
     cy.get('[data-test=program-stage-selector-button]')
         .eq(0)
         .should('be.disabled');
+});
+
+Then('only three program stages are displayed in the stage selector widget', () => {
+    cy.get('[data-test=program-stage-selector-button]').should('have.length', 3);
+});
+
+Then('the New event quick action button is disabled', () => {
+    cy.get('[data-test=quick-action-button-report]').should('be.disabled');
 });

--- a/cypress/e2e/EnrollmentPage/HiddenProgramStage/HiddenProgramStage.js
+++ b/cypress/e2e/EnrollmentPage/HiddenProgramStage/HiddenProgramStage.js
@@ -54,5 +54,5 @@ Then('the Postpartum care visit button is disabled in the enrollmentEventNew pag
 
     cy.get('[data-test=profile-widget]').contains('Person profile');
     cy.get('[data-test="enrollment-newEvent-page"]').contains('Choose a stage for a new event').should('exist');
-    cy.get('[data-test="program-stage-selector-button"]').contains('Postpartum care visit').should('be.disabled');
+    cy.get('[data-test="program-stage-selector-button"]').contains('Postpartum care visit').should('not.exist');
 });

--- a/cypress/e2e/ScopeSelector/ScopeSelector.feature
+++ b/cypress/e2e/ScopeSelector/ScopeSelector.feature
@@ -220,12 +220,12 @@ Feature: User uses the ScopeSelector to navigate
     Then you see message explaining you need to select an enrollment
 
   Scenario: Enrollment event new page > resetting the event
-    Given you land on a enrollment page domain by having typed /#/enrollmentEventNew?programId=IpHINAT79UW&orgUnitId=UgYg0YW7ZIh&teiId=fhFQhO0xILJ&enrollmentId=gPDueU02tn8&stageId=A03MvHHogjR
+    Given you land on a enrollment page domain by having typed /#/enrollmentEventNew?enrollmentId=Aemr3Q02aqV&orgUnitId=DiszpKrYNg8&programId=ur1Edk5Oe2n&stageId=EPEcjy3FWmI&tab=REPORT&teiId=eUTmQGull6H
     When you reset the stage selection
     Then you see the enrollment event New page but there is no stage id in the url
 
   Scenario: Enrollment event new page > resetting the stage
-    Given you land on a enrollment page domain by having typed /#/enrollmentEventNew?programId=IpHINAT79UW&orgUnitId=UgYg0YW7ZIh&teiId=fhFQhO0xILJ&enrollmentId=gPDueU02tn8&stageId=A03MvHHogjR
+    Given you land on a enrollment page domain by having typed /#/enrollmentEventNew?enrollmentId=Aemr3Q02aqV&orgUnitId=DiszpKrYNg8&programId=ur1Edk5Oe2n&stageId=EPEcjy3FWmI&tab=REPORT&teiId=eUTmQGull6H
     When you reset the event selection
     Then you see the enrollment event New page but there is no stage id in the url
 

--- a/cypress/e2e/ScopeSelector/ScopeSelector.js
+++ b/cypress/e2e/ScopeSelector/ScopeSelector.js
@@ -286,7 +286,7 @@ And('you see the enrollment event Edit page but there is no org unit id in the u
 });
 
 And('you see the enrollment event New page but there is no stage id in the url', () => {
-    cy.url().should('eq', `${Cypress.config().baseUrl}/#/enrollmentEventNew?enrollmentId=gPDueU02tn8&orgUnitId=UgYg0YW7ZIh&programId=IpHINAT79UW&teiId=fhFQhO0xILJ`);
+    cy.url().should('eq', `${Cypress.config().baseUrl}/#/enrollmentEventNew?enrollmentId=Aemr3Q02aqV&orgUnitId=DiszpKrYNg8&programId=ur1Edk5Oe2n&teiId=eUTmQGull6H`);
     cy.contains('Choose a stage for a new event');
 });
 

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-07-07T08:21:16.395Z\n"
-"PO-Revision-Date: 2025-07-07T08:21:16.395Z\n"
+"POT-Creation-Date: 2025-07-31T10:50:59.068Z\n"
+"PO-Revision-Date: 2025-07-31T10:50:59.068Z\n"
 
 msgid "Choose one or more dates..."
 msgstr "Choose one or more dates..."
@@ -620,9 +620,6 @@ msgstr "No indicator output for this enrollment yet"
 
 msgid "Quick actions"
 msgstr "Quick actions"
-
-msgid "New Event"
-msgstr "New Event"
 
 msgid "Schedule an event"
 msgstr "Schedule an event"

--- a/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/EnrollmentQuickActions/EnrollmentQuickActions.component.js
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/EnrollmentQuickActions/EnrollmentQuickActions.component.js
@@ -68,7 +68,7 @@ const EnrollmentQuickActionsComponent = ({ stages, events, ruleEffects, classes 
                 >
                     <QuickActionButton
                         icon={<IconAdd24 color={colors.grey700} />}
-                        label={i18n.t('New Event')}
+                        label={i18n.t('New event')}
                         onClickAction={() => onNavigationFromQuickActions(tabMode.REPORT)}
                         dataTest={'quick-action-button-report'}
                         disable={noStageAvailable}

--- a/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/ProgramStageSelector/ProgramStageSelector.component.js
+++ b/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/ProgramStageSelector/ProgramStageSelector.component.js
@@ -27,7 +27,9 @@ const ProgramStageSelectorComponentPlain = ({ programStages, onSelectProgramStag
     <div className={classes.container}>
         {programStages.map((programStage) => {
             const disableStage =
-                !programStage.dataAccess.write || (!programStage.repeatable && programStage.eventCount > 0) || programStage.hiddenProgramStage;
+                !programStage.dataAccess.write
+                || (!programStage.repeatable && programStage.eventCount > 0)
+                || programStage.hiddenProgramStage;
             return (
                 <div
                     key={programStage.id}

--- a/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/ProgramStageSelector/ProgramStageSelector.container.js
+++ b/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/ProgramStageSelector/ProgramStageSelector.container.js
@@ -91,10 +91,13 @@ export const ProgramStageSelector = ({ programId, orgUnitId, teiId, enrollmentId
     }, [programStages]);
 
     useEffect(() => {
+        if (programStages && !availableStages.length) {
+            onCancel();
+        }
         if (availableStages.length === 1) {
             onSelectProgramStage(availableStages[0].id);
         }
-    }, [availableStages, onSelectProgramStage]);
+    }, [availableStages, onSelectProgramStage, onCancel, programStages]);
 
     return (
         <>

--- a/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/ProgramStageSelector/ProgramStageSelector.container.js
+++ b/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/ProgramStageSelector/ProgramStageSelector.container.js
@@ -78,20 +78,23 @@ export const ProgramStageSelector = ({ programId, orgUnitId, teiId, enrollmentId
         navigate(`enrollment?${buildUrlQueryString({ programId, orgUnitId, teiId, enrollmentId })}`),
     [navigate, programId, orgUnitId, teiId, enrollmentId]);
 
-    useEffect(() => {
-        if (Array.isArray(programStages) && programStages.length) {
-            const availableStages = programStages.filter((stage) => {
-                const isStageDisabled = !stage.dataAccess.write ||
-                    (!stage.repeatable && stage.eventCount > 0) ||
-                    stage.hiddenProgramStage;
-                return !isStageDisabled;
-            });
-
-            if (availableStages.length === 1) {
-                onSelectProgramStage(availableStages[0].id);
-            }
+    const availableStages = useMemo(() => {
+        if (!Array.isArray(programStages) || !programStages.length) {
+            return [];
         }
-    }, [programStages, onSelectProgramStage]);
+        return programStages.filter((stage) => {
+            const isStageDisabled = !stage.dataAccess.write ||
+                (!stage.repeatable && stage.eventCount > 0) ||
+                stage.hiddenProgramStage;
+            return !isStageDisabled;
+        });
+    }, [programStages]);
+
+    useEffect(() => {
+        if (availableStages.length === 1) {
+            onSelectProgramStage(availableStages[0].id);
+        }
+    }, [availableStages, onSelectProgramStage]);
 
     return (
         <>
@@ -101,7 +104,7 @@ export const ProgramStageSelector = ({ programId, orgUnitId, teiId, enrollmentId
                     noncollapsible
                 >
                     <ProgramStageSelectorComponent
-                        programStages={programStages || []}
+                        programStages={availableStages}
                         onSelectProgramStage={onSelectProgramStage}
                         onCancel={onCancel}
                     />

--- a/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/ProgramStageSelector/ProgramStageSelector.container.js
+++ b/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/ProgramStageSelector/ProgramStageSelector.container.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useCallback } from 'react';
 import i18n from '@dhis2/d2-i18n';
 import log from 'loglevel';
 import { ProgramStageSelectorComponent } from './ProgramStageSelector.component';
@@ -16,7 +16,11 @@ import { useTrackerProgram } from '../../../../hooks/useTrackerProgram';
 export const ProgramStageSelector = ({ programId, orgUnitId, teiId, enrollmentId }: Props) => {
     const { navigate } = useNavigate();
     const { tab } = useLocationQuery();
-    const { error: enrollmentsError, enrollment, attributeValues } = useCommonEnrollmentDomainData(teiId, enrollmentId, programId);
+    const { error: enrollmentsError, enrollment, attributeValues } = useCommonEnrollmentDomainData(
+        teiId,
+        enrollmentId,
+        programId,
+    );
     const {
         program,
         isLoading: programLoading,
@@ -60,7 +64,7 @@ export const ProgramStageSelector = ({ programId, orgUnitId, teiId, enrollmentId
         return accStage;
     }, []), [enrollment?.events, program?.programStages, programLoading, ruleEffects]);
 
-    const onSelectProgramStage = (newStageId: string) =>
+    const onSelectProgramStage = useCallback((newStageId: string) =>
         navigate(`enrollmentEventNew?${buildUrlQueryString({
             programId,
             orgUnitId,
@@ -68,10 +72,26 @@ export const ProgramStageSelector = ({ programId, orgUnitId, teiId, enrollmentId
             enrollmentId,
             stageId: newStageId,
             tab,
-        })}`);
+        })}`), [navigate, programId, orgUnitId, teiId, enrollmentId, tab]);
 
-    const onCancel = () =>
-        navigate(`enrollment?${buildUrlQueryString({ programId, orgUnitId, teiId, enrollmentId })}`);
+    const onCancel = useCallback(() =>
+        navigate(`enrollment?${buildUrlQueryString({ programId, orgUnitId, teiId, enrollmentId })}`),
+    [navigate, programId, orgUnitId, teiId, enrollmentId]);
+
+    useEffect(() => {
+        if (Array.isArray(programStages) && programStages.length) {
+            const availableStages = programStages.filter((stage) => {
+                const isStageDisabled = !stage.dataAccess.write ||
+                    (!stage.repeatable && stage.eventCount > 0) ||
+                    stage.hiddenProgramStage;
+                return !isStageDisabled;
+            });
+
+            if (availableStages.length === 1) {
+                onSelectProgramStage(availableStages[0].id);
+            }
+        }
+    }, [programStages, onSelectProgramStage]);
 
     return (
         <>


### PR DESCRIPTION
[DHIS2-16364](https://dhis2.atlassian.net/browse/DHIS2-16364)

This pull request introduced a new `useEffect` hook in `ProgramStageSelector.container.js` to automatically select a program stage if only one is available.

In addition, non-selectable program stages are filtered away from the "Choose a stage for a new event" widget.


[DHIS2-16364]: https://dhis2.atlassian.net/browse/DHIS2-16364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ