### PR TITLE
DHIS2-19820

### DIFF
--- a/src/core_modules/capture-core/components/D2Form/D2Form.component.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Form.component.js
@@ -4,7 +4,7 @@ import log from 'loglevel';
 import { errorCreator } from 'capture-core-utils';
 import { D2SectionContainer } from './D2Section.container';
 import type { Props, PropsForPureComponent } from './D2Form.types';
-import { Section } from '../../metaData';
+import type { Section } from '../../metaData';
 
 class D2Form extends React.PureComponent<PropsForPureComponent> {
     name: string;
@@ -121,9 +121,7 @@ class D2Form extends React.PureComponent<PropsForPureComponent> {
             getCustomContent,
             ...passOnProps
         } = this.props;
-        const metaDataSectionsAsArray = Array.from(formFoundation.sections.entries())
-            .map(entry => entry[1])
-            .filter(section => section.id !== Section.LEFTOVERS_SECTION_ID);
+        const metaDataSectionsAsArray = Array.from(formFoundation.sections.entries()).map(entry => entry[1]);
 
         const sections = metaDataSectionsAsArray.map(section => (
             passOnProps.formHorizontal

--- a/src/core_modules/capture-core/components/D2Form/D2Section.container.js
+++ b/src/core_modules/capture-core/components/D2Form/D2Section.container.js
@@ -1,7 +1,7 @@
 // @flow
 import { connect } from 'react-redux';
 import { D2Section } from './D2Section.component';
-import type { Section as MetaDataSection } from '../../metaData';
+import { Section as MetaDataSection } from '../../metaData';
 import { withApiUtils } from '../../HOC';
 
 const mapStateToProps = (state: Object, props: { sectionMetaData: MetaDataSection, formId: string }) => {
@@ -13,7 +13,10 @@ const mapStateToProps = (state: Object, props: { sectionMetaData: MetaDataSectio
         return { isHidden: !visibleFields.length };
     }
 
-    return { isHidden: !props.sectionMetaData.elements.size };
+    return {
+        isHidden: !props.sectionMetaData.elements.size ||
+            props.sectionMetaData.id === MetaDataSection.LEFTOVERS_SECTION_ID,
+    };
 };
 
 const mapDispatchToProps = () => ({});

--- a/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/hooks/useBuildEnrollmentPayload.js
+++ b/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/hooks/useBuildEnrollmentPayload.js
@@ -39,11 +39,6 @@ type DataEntryReduxConverterProps = {
     trackedEntityTypeId: string;
 };
 
-function getClientValuesForFormData(formValues: Object, formFoundation: RenderFoundation) {
-    const clientValues = formFoundation.convertValues(formValues, convertFormToClient);
-    return clientValues;
-}
-
 function getServerValuesForMainValues(
     values: Object,
     meta: Object,
@@ -99,7 +94,7 @@ export const useBuildEnrollmentPayload = ({
     } => {
         if (!formFoundation) throw Error('form foundation object not found');
         const firstStage = firstStageMetaData && firstStageMetaData.stage;
-        const clientValues = getClientValuesForFormData(formValues, formFoundation);
+        const clientValues = formFoundation.convertValues(formValues, convertFormToClient);
         const serverValuesForFormValues = formFoundation.convertAndGroupBySection(clientValues, convertClientToServer);
         const serverValuesForMainValues = getServerValuesForMainValues(
             dataEntryFieldValues,

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/DataEntry.container.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/DataEntry.container.js
@@ -53,6 +53,8 @@ export const DataEntry = ({
         itemId,
         geometry,
         dataEntryFormConfig,
+        querySingleResource,
+        onGetValidationContext,
     });
     const { formFoundation } = context;
     const { formValidated, errorsMessages, warningsMessages } = useFormValidations(dataEntryId, itemId, saveAttempted);

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/RenderFoundation.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/RenderFoundation.js
@@ -102,6 +102,52 @@ const buildMainSection = async ({
     return section;
 };
 
+const addLeftoversSection = async ({
+    renderFoundation,
+    programTrackedEntityAttributes,
+    trackedEntityAttributes,
+    optionSets,
+    querySingleResource,
+    minorServerVersion,
+}: {
+    renderFoundation: RenderFoundation,
+    programTrackedEntityAttributes: Array<ProgramTrackedEntityAttribute>,
+    trackedEntityAttributes: Array<TrackedEntityAttribute>,
+    optionSets: Array<OptionSet>,
+    querySingleResource: QuerySingleResource,
+    minorServerVersion: number,
+}) => {
+    if (!programTrackedEntityAttributes) return;
+
+    // Check if there exist attributes which are not assigned to a section
+    const attributesInSection = renderFoundation.getElements().reduce((acc, attribute) => {
+        acc.add(attribute.id);
+        return acc;
+    }, new Set());
+
+    const unassignedAttributes = programTrackedEntityAttributes
+        .filter(attribute => !attributesInSection.has(attribute.trackedEntityAttributeId));
+
+    if (unassignedAttributes.length === 0) return;
+
+    // Create a special section for the unassigned attributes
+    const section = new Section((o) => {
+        o.id = Section.LEFTOVERS_SECTION_ID;
+        o.group = Section.groups.ENROLLMENT;
+    });
+
+    await buildElementsForSection({
+        // $FlowIgnore
+        programTrackedEntityAttributes: unassignedAttributes,
+        trackedEntityAttributes,
+        optionSets,
+        section,
+        querySingleResource,
+        minorServerVersion,
+    });
+    renderFoundation.addSection(section);
+};
+
 const buildElementsForSection = async ({
     programTrackedEntityAttributes,
     trackedEntityAttributes,
@@ -322,6 +368,16 @@ export const buildFormFoundation = async (program: any, querySingleResource: Que
         });
         section && renderFoundation.addSection(section);
     }
+
+    await addLeftoversSection({
+        renderFoundation,
+        programTrackedEntityAttributes,
+        trackedEntityAttributes,
+        optionSets,
+        querySingleResource,
+        minorServerVersion,
+    });
+
     return renderFoundation;
 };
 

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/ProgramRules/getRulesActionsForTEI.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/ProgramRules/getRulesActionsForTEI.js
@@ -50,49 +50,6 @@ const getDataElementsForRulesExecution = (dataElements: ?DataElements) =>
         {},
     );
 
-export const getRulesActionsForTEI = ({
-    foundation,
-    formId,
-    orgUnit,
-    enrollmentData,
-    teiValues,
-    trackedEntityAttributes,
-    optionSets,
-    rulesContainer,
-    otherEvents,
-    dataElements,
-    userRoles,
-    programName,
-}: {
-    foundation: RenderFoundation,
-    formId: string,
-    orgUnit: OrgUnit,
-    enrollmentData?: EnrollmentData,
-    teiValues?: ?TEIValues,
-    trackedEntityAttributes: ?TrackedEntityAttributes,
-    optionSets: OptionSets,
-    rulesContainer: ProgramRulesContainer,
-    otherEvents?: ?EventsData,
-    dataElements: ?DataElements,
-    userRoles: Array<string>,
-    programName: string,
-}) => {
-    const effects: OutputEffects = ruleEngine().getProgramRuleEffects({
-        programRulesContainer: rulesContainer,
-        currentEvent: null,
-        otherEvents,
-        dataElements: getDataElementsForRulesExecution(dataElements),
-        trackedEntityAttributes,
-        selectedEnrollment: getEnrollmentForRulesExecution(enrollmentData, programName),
-        selectedEntity: teiValues,
-        selectedOrgUnit: orgUnit,
-        selectedUserRoles: userRoles,
-        optionSets,
-    });
-    const effectsHierarchy = buildEffectsHierarchy(postProcessRulesEffects(effects, foundation));
-    return updateRulesEffects(effectsHierarchy, formId);
-};
-
 export const getRulesActionsForTEIAsync = async ({
     foundation,
     formId,

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/ProgramRules/index.js
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/ProgramRules/index.js
@@ -1,3 +1,3 @@
 // @flow
 export { buildRulesContainer } from './rulesContainer';
-export { getRulesActionsForTEI, getRulesActionsForTEIAsync } from './getRulesActionsForTEI';
+export { getRulesActionsForTEIAsync } from './getRulesActionsForTEI';


### PR DESCRIPTION
[DHIS2-19820](https://dhis2.atlassian.net/browse/DHIS2-19820?actionerId=62285db459c0740069db67bd&sourceType=assign)

These changes targets **section forms** containing tracked entity attributes. The purpose is to enable program rule assignment of attributes that are part of the program, but not part of the section form. The technical solution here is to devise a special section for all such "rogue" elements, and have it be omitted from rendering (like in [DHIS2-19604](https://github.com/dhis2/capture-app/pull/4080)).

After implementing this, some issues with validation errors came up. The reason turned out to be twofold: First, there is a complete validation of the form itself when the form loads, and the new section did not take part in it. This was corrected by always making the section hidden rather than excluding it completely from rendering. Second, the rule engine runs once while the form is loading, but at the end of this execution it did not validate the assign effects. Consequently the assigned attributes were treated as invalid until the rule engine was run a second time, by making a change in the form.

While scrutinizing how the form-loading call to the rule engine was implemented in the profile widget, it turned out to get called more often than it was supposed to. Thus I added a simple stopping mechanism in `useLifecycle` as a remedy.