### PR TITLE
fix: [DHIS2-19877] filter rule engine values containing undefined

### DIFF
--- a/src/core_modules/capture-core/rules/RuleEngine/helpers/InputBuilder.js
+++ b/src/core_modules/capture-core/rules/RuleEngine/helpers/InputBuilder.js
@@ -256,7 +256,7 @@ export class InputBuilder {
         const dataValues = Object
             .keys(eventData)
             .filter(key => !eventMainKeys.has(key))
-            .filter(key => eventData[key] ?? false)
+            .filter(key => (eventData[key] ?? null) !== null)
             .map(key =>
                 new RuleDataValue(
                     key,
@@ -340,7 +340,7 @@ export class InputBuilder {
 
         const attributeValues = selectedEntity ? Object
             .keys(selectedEntity)
-            .filter(key => selectedEntity[key] ?? false)
+            .filter(key => (selectedEntity[key] ?? null) !== null)
             .map(key => new RuleAttributeValue(
                 key,
                 this.convertTrackedEntityAttributeValue(key, selectedEntity[key]),

--- a/src/core_modules/capture-core/rules/RuleEngine/helpers/InputBuilder.js
+++ b/src/core_modules/capture-core/rules/RuleEngine/helpers/InputBuilder.js
@@ -256,7 +256,7 @@ export class InputBuilder {
         const dataValues = Object
             .keys(eventData)
             .filter(key => !eventMainKeys.has(key))
-            .filter(key => eventData[key] !== null)
+            .filter(key => eventData[key] ?? false)
             .map(key =>
                 new RuleDataValue(
                     key,
@@ -340,7 +340,7 @@ export class InputBuilder {
 
         const attributeValues = selectedEntity ? Object
             .keys(selectedEntity)
-            .filter(key => selectedEntity[key] !== null)
+            .filter(key => selectedEntity[key] ?? false)
             .map(key => new RuleAttributeValue(
                 key,
                 this.convertTrackedEntityAttributeValue(key, selectedEntity[key]),


### PR DESCRIPTION
[DHIS2-19877](https://dhis2.atlassian.net/browse/DHIS2-19877)

Attributes and data elements containing the value `undefined` become converted to `'undefined'` in the rule engine. We had the same issue before with `null` getting converted to `'null'`, and the solution was to filter out all form values containing `null`. This PR extends the solution to form values containing `undefined`.