### PR TITLE
fix: [DHIS2-20029] Event changelog for single events does not work

### DIFF
--- a/cypress/e2e/Changelog/Changelog.feature
+++ b/cypress/e2e/Changelog/Changelog.feature
@@ -1,15 +1,17 @@
 Feature: The user interacts with the changelog widget
 
-  Background:
+  @v>=41
+  Scenario: The user can view an event changelog on the enrollment edit event
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
     And you select view changelog in the event overflow button
     Then the changelog modal should contain data
-  @v>=41
-  Scenario: The user can view an event changelog on the enrollment edit event
     Then the number of changelog table rows should be 9
 
   @v>=41
   Scenario: The user can change the changelog page size
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    And you select view changelog in the event overflow button
+    Then the changelog modal should contain data
     When you change the page size to 20
     Then the number of changelog table rows should be 19
     And you change the page size to 100
@@ -18,6 +20,9 @@ Feature: The user interacts with the changelog widget
 
   @v>=41
   Scenario: The user can navigate between pages in the changelog
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    And you select view changelog in the event overflow button
+    Then the changelog modal should contain data
     When you move to the next page
     Then the table footer should display page 2
     When you move to the previous page
@@ -25,12 +30,18 @@ Feature: The user interacts with the changelog widget
 
   @v>=42
   Scenario: The user can filter the changelog by data item
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    And you select view changelog in the event overflow button
+    Then the changelog modal should contain data
     When you select "Treatment card" from the data item filter flyout menu
     Then the filter pill should be visible with label "Treatment card"
     And only rows with Data item "Treatment card" should be displayed
 
   @v>=42
   Scenario: Only one filter can be applied at a time
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    And you select view changelog in the event overflow button
+    Then the changelog modal should contain data
     When you select "HIV testing done" from the data item filter flyout menu
     Then the filter pill should be visible with label "HIV testing done"
     When you select "Disease Classification" from the data item filter flyout menu
@@ -39,6 +50,9 @@ Feature: The user interacts with the changelog widget
 
   @v>=42
   Scenario: The filter remains active when sorting is applied
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    And you select view changelog in the event overflow button
+    Then the changelog modal should contain data
     When you select "Disease Classification" from the data item filter flyout menu
     When you click the sort Date icon
     Then only rows with Data item "Disease Classification" should be displayed
@@ -46,6 +60,9 @@ Feature: The user interacts with the changelog widget
 
   @v>=42
   Scenario: The user can remove the applied filter
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    And you select view changelog in the event overflow button
+    Then the changelog modal should contain data
     When you select "Disease Classification" from the data item filter flyout menu
     Then the filter pill should be visible with label "Disease Classification"
     And only rows with Data item "Disease Classification" should be displayed
@@ -54,18 +71,41 @@ Feature: The user interacts with the changelog widget
 
   @skip # Flaky test, fix in DHIS2-19814
   Scenario: The user can sort by Date
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    And you select view changelog in the event overflow button
+    Then the changelog modal should contain data
     When you click the sort Date icon
     Then the changelog modal should contain data
     And the changelog data is sorted on Date in ascending order
 
   @v>=42
   Scenario: The user can sort by User
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    And you select view changelog in the event overflow button
+    Then the changelog modal should contain data
     When you click the sort User icon
     Then the changelog modal should contain data
     And the changelog data is sorted on User in ascending order
 
   @v>=42
   Scenario: The user can sort by Data item
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    And you select view changelog in the event overflow button
+    Then the changelog modal should contain data
     When you click the sort Data item icon
     Then the changelog modal should contain data
     And the changelog data is sorted on Data item in ascending order
+
+  # Tests that need different navigation (no Background needed)
+  @v>=41
+  Scenario: The user can open tracked entity changelog from enrollment edit event page
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    When you open the tracked entity changelog
+    Then the changelog modal should be visible
+
+  @v>=41
+  Scenario: The user can open event program changelog from view event page
+    Given you land on the view event page by having typed /#/viewEvent?orgUnitId=DiszpKrYNg8&viewEventId=ohAH6BXIMad
+    When you open the event program changelog
+    Then the changelog modal should be visible
+

--- a/cypress/e2e/Changelog/Changelog.feature
+++ b/cypress/e2e/Changelog/Changelog.feature
@@ -99,13 +99,13 @@ Feature: The user interacts with the changelog widget
   # Tests that need different navigation (no Background needed)
   @v>=41
   Scenario: The user can open tracked entity changelog from enrollment edit event page
-    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
+    Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=Ni0yhZ7XhAP&orgUnitId=DiszpKrYNg8
     When you open the tracked entity changelog
     Then the changelog modal should be visible
 
   @v>=41
   Scenario: The user can open event program changelog from view event page
-    Given you land on the view event page by having typed /#/viewEvent?orgUnitId=DiszpKrYNg8&viewEventId=ohAH6BXIMad
+    Given you land on the view event page by having typed /#/viewEvent?orgUnitId=DiszpKrYNg8&viewEventId=a5e67163090
     When you open the event program changelog
     Then the changelog modal should be visible
 

--- a/cypress/e2e/Changelog/Changelog.feature
+++ b/cypress/e2e/Changelog/Changelog.feature
@@ -96,16 +96,15 @@ Feature: The user interacts with the changelog widget
     Then the changelog modal should contain data
     And the changelog data is sorted on Data item in ascending order
 
-  # Tests that need different navigation (no Background needed)
   @v>=41
   Scenario: The user can open tracked entity changelog from enrollment edit event page
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=Ni0yhZ7XhAP&orgUnitId=DiszpKrYNg8
     When you open the tracked entity changelog
-    Then the changelog modal should be visible
+    Then the changelog modal should contain data
 
   @v>=41
   Scenario: The user can open event program changelog from view event page
     Given you land on the view event page by having typed /#/viewEvent?orgUnitId=DiszpKrYNg8&viewEventId=a5e67163090
     When you open the event program changelog
-    Then the changelog modal should be visible
+    Then the changelog modal should contain data
 

--- a/cypress/e2e/Changelog/Changelog.feature
+++ b/cypress/e2e/Changelog/Changelog.feature
@@ -3,14 +3,14 @@ Feature: The user interacts with the changelog widget
   @v>=41
   Scenario: The user can view an event changelog on the enrollment edit event
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    And you select view changelog in the event overflow button
+    When you open the tracker program event changelog
     Then the changelog modal should contain data
     Then the number of changelog table rows should be 9
 
   @v>=41
   Scenario: The user can change the changelog page size
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    And you select view changelog in the event overflow button
+    When you open the tracker program event changelog
     Then the changelog modal should contain data
     When you change the page size to 20
     Then the number of changelog table rows should be 19
@@ -21,7 +21,7 @@ Feature: The user interacts with the changelog widget
   @v>=41
   Scenario: The user can navigate between pages in the changelog
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    And you select view changelog in the event overflow button
+    When you open the tracker program event changelog
     Then the changelog modal should contain data
     When you move to the next page
     Then the table footer should display page 2
@@ -31,7 +31,7 @@ Feature: The user interacts with the changelog widget
   @v>=42
   Scenario: The user can filter the changelog by data item
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    And you select view changelog in the event overflow button
+    When you open the tracker program event changelog
     Then the changelog modal should contain data
     When you select "Treatment card" from the data item filter flyout menu
     Then the filter pill should be visible with label "Treatment card"
@@ -40,7 +40,7 @@ Feature: The user interacts with the changelog widget
   @v>=42
   Scenario: Only one filter can be applied at a time
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    And you select view changelog in the event overflow button
+    When you open the tracker program event changelog
     Then the changelog modal should contain data
     When you select "HIV testing done" from the data item filter flyout menu
     Then the filter pill should be visible with label "HIV testing done"
@@ -51,7 +51,7 @@ Feature: The user interacts with the changelog widget
   @v>=42
   Scenario: The filter remains active when sorting is applied
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    And you select view changelog in the event overflow button
+    When you open the tracker program event changelog
     Then the changelog modal should contain data
     When you select "Disease Classification" from the data item filter flyout menu
     When you click the sort Date icon
@@ -61,7 +61,7 @@ Feature: The user interacts with the changelog widget
   @v>=42
   Scenario: The user can remove the applied filter
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    And you select view changelog in the event overflow button
+    When you open the tracker program event changelog
     Then the changelog modal should contain data
     When you select "Disease Classification" from the data item filter flyout menu
     Then the filter pill should be visible with label "Disease Classification"
@@ -72,7 +72,7 @@ Feature: The user interacts with the changelog widget
   @skip # Flaky test, fix in DHIS2-19814
   Scenario: The user can sort by Date
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    And you select view changelog in the event overflow button
+    When you open the tracker program event changelog
     Then the changelog modal should contain data
     When you click the sort Date icon
     Then the changelog modal should contain data
@@ -81,7 +81,7 @@ Feature: The user interacts with the changelog widget
   @v>=42
   Scenario: The user can sort by User
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    And you select view changelog in the event overflow button
+    When you open the tracker program event changelog
     Then the changelog modal should contain data
     When you click the sort User icon
     Then the changelog modal should contain data
@@ -90,7 +90,7 @@ Feature: The user interacts with the changelog widget
   @v>=42
   Scenario: The user can sort by Data item
     Given you land on the enrollment edit event page by having typed /#/enrollmentEventEdit?eventId=QsAhMiZtnl2&orgUnitId=DiszpKrYNg8
-    And you select view changelog in the event overflow button
+    When you open the tracker program event changelog
     Then the changelog modal should contain data
     When you click the sort Data item icon
     Then the changelog modal should contain data

--- a/cypress/e2e/Changelog/Changelog.js
+++ b/cypress/e2e/Changelog/Changelog.js
@@ -167,5 +167,7 @@ When('you open the event program changelog', () => {
 Then('the changelog modal should be visible', () => {
     getChangelogTableBody()
         .should('be.visible')
-        .and('contain', 'No changes to display')
+        .and('not.contain', 'No changes to display')
+        .and('not.have.class', 'loading');
+    cy.get('[data-test="changelog-data-table-body"] tr').should('have.length.gt', 0);
 });

--- a/cypress/e2e/Changelog/Changelog.js
+++ b/cypress/e2e/Changelog/Changelog.js
@@ -11,9 +11,25 @@ Given(/^you land on the view event page by having typed (.*)$/, (url) => {
     cy.visit(url);
 });
 
-Given('you select view changelog in the event overflow button', () => {
+When('you open the tracker program event changelog', () => {
     cy.get('[data-test="tracker-program-event-overflow-button"]').click();
-    cy.get('[data-test="tracker-program-event-changelog"] > a').click();
+    cy.get('[data-test="tracker-program-event-overflow-menu"]').within(() => {
+        cy.contains('View changelog').click();
+    });
+});
+
+When('you open the tracked entity changelog', () => {
+    cy.get('[data-test="tracked-entity-profile-overflow-button"]').click();
+        cy.get('[data-test="tracked-entity-profile-overflow-menu"]').within(() => {
+        cy.contains('View changelog').click();
+    });
+});
+
+When('you open the event program changelog', () => {
+    cy.get('[data-test="event-program-event-overflow-button"]').click();
+    cy.get('[data-test="event-program-event-overflow-menu"]').within(() => {
+    cy.contains('View changelog').click();
+    });
 });
 
 Then('the changelog modal should contain data', () => {
@@ -145,21 +161,5 @@ Then('the changelog data is sorted on Data item in ascending order', () => {
 
         const sorted = [...values].sort((a, b) => collator.compare(a, b));
         expect(values).to.deep.equal(sorted);
-    });
-});
-
-When('you open the tracked entity changelog', () => {
-    cy.get('[data-test="tracked-entity-profile-overflow-button"]').should('be.visible').click();
-        cy.get('[data-test="tracked-entity-profile-overflow-menu"]').should('be.visible');
-        cy.get('[data-test="tracked-entity-profile-overflow-menu"]').within(() => {
-        cy.contains('View changelog').click();
-    });
-});
-
-When('you open the event program changelog', () => {
-    cy.get('[data-test="event-program-event-overflow-button"]').should('be.visible').click();
-    cy.get('[data-test="event-program-event-overflow-menu"]').should('be.visible');
-    cy.get('[data-test="event-program-event-overflow-menu"]').within(() => {
-    cy.contains('View changelog').click();
     });
 });

--- a/cypress/e2e/Changelog/Changelog.js
+++ b/cypress/e2e/Changelog/Changelog.js
@@ -1,16 +1,19 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
-import '../sharedSteps';
 
 const getChangelogTableBody = () =>
     cy.get('[data-test="changelog-data-table-body"]');
 
-const getOverflowButton = () =>
-    cy.get('[data-test="widget-event-edit-overflow-button"]');
+Given(/^you land on the enrollment edit event page by having typed (.*)$/, (url) => {
+    cy.visit(url);
+});
 
+Given(/^you land on the view event page by having typed (.*)$/, (url) => {
+    cy.visit(url);
+});
 
 Given('you select view changelog in the event overflow button', () => {
-    getOverflowButton().click();
-    cy.get('[data-test="event-overflow-view-changelog"] > a').click();
+    cy.get('[data-test="tracker-program-event-overflow-button"]').click();
+    cy.get('[data-test="tracker-program-event-changelog"] > a').click();
 });
 
 Then('the changelog modal should contain data', () => {
@@ -145,3 +148,24 @@ Then('the changelog data is sorted on Data item in ascending order', () => {
     });
 });
 
+When('you open the tracked entity changelog', () => {
+    cy.get('[data-test="tracked-entity-profile-overflow-button"]').should('be.visible').click();
+        cy.get('[data-test="tracked-entity-profile-overflow-menu"]').should('be.visible');
+        cy.get('[data-test="tracked-entity-profile-overflow-menu"]').within(() => {
+        cy.contains('View changelog').click();
+    });
+});
+
+When('you open the event program changelog', () => {
+    cy.get('[data-test="event-program-event-overflow-button"]').should('be.visible').click();
+    cy.get('[data-test="event-program-event-overflow-menu"]').should('be.visible');
+    cy.get('[data-test="event-program-event-overflow-menu"]').within(() => {
+    cy.contains('View changelog').click();
+    });
+});
+
+Then('the changelog modal should be visible', () => {
+    getChangelogTableBody()
+        .should('be.visible')
+        .and('contain', 'No changes to display')
+});

--- a/cypress/e2e/Changelog/Changelog.js
+++ b/cypress/e2e/Changelog/Changelog.js
@@ -163,11 +163,3 @@ When('you open the event program changelog', () => {
     cy.contains('View changelog').click();
     });
 });
-
-Then('the changelog modal should be visible', () => {
-    getChangelogTableBody()
-        .should('be.visible')
-        .and('not.contain', 'No changes to display')
-        .and('not.have.class', 'loading');
-    cy.get('[data-test="changelog-data-table-body"] tr').should('have.length.gt', 0);
-});

--- a/cypress/e2e/NewPage/NewPage.js
+++ b/cypress/e2e/NewPage/NewPage.js
@@ -637,7 +637,7 @@ And('you delete the recently added tracked entity', () => {
     cy.get('[data-test="profile-widget"]')
         .contains('Person profile')
         .should('exist');
-    cy.get('[data-test="widget-profile-overflow-menu"]')
+    cy.get('[data-test="tracked-entity-profile-overflow-button"]')
         .click();
     cy.contains('Delete Person')
         .click();
@@ -656,7 +656,7 @@ And('you delete the recently added malaria entity', () => {
     cy.get('[data-test="profile-widget"]')
         .contains('Malaria Entity profile')
         .should('exist');
-    cy.get('[data-test="widget-profile-overflow-menu"]')
+    cy.get('[data-test="tracked-entity-profile-overflow-button"]')
         .click();
     cy.contains('Delete Malaria Entity')
         .click();

--- a/cypress/e2e/RelatedStages/RelatedStages.js
+++ b/cypress/e2e/RelatedStages/RelatedStages.js
@@ -220,7 +220,7 @@ And('you delete the recently added tracked entity', () => {
     cy.get('[data-test="profile-widget"]')
         .contains('Person profile')
         .should('exist');
-    cy.get('[data-test="widget-profile-overflow-menu"]')
+    cy.get('[data-test="tracked-entity-profile-overflow-button"]')
         .click();
     cy.contains('Delete Person')
         .click();

--- a/cypress/e2e/WidgetsForEnrollmentPages/WidgetProfile/index.js
+++ b/cypress/e2e/WidgetsForEnrollmentPages/WidgetProfile/index.js
@@ -45,7 +45,7 @@ Given('you add a new tracked entity in the Malaria focus investigation program',
 When('you open the overflow menu and click the "Delete Focus area" button', () => {
     cy.get('[data-test=profile-widget]').contains('Focus area profile');
 
-    cy.get('[data-test="widget-profile-overflow-menu"]')
+    cy.get('[data-test="tracked-entity-profile-overflow-button"]')
         .click();
     cy.contains('Delete Focus area')
         .click();

--- a/src/core_modules/capture-core/components/Pages/ViewEvent/EventDetailsSection/EventDetailsSection.component.tsx
+++ b/src/core_modules/capture-core/components/Pages/ViewEvent/EventDetailsSection/EventDetailsSection.component.tsx
@@ -166,11 +166,13 @@ const EventDetailsSectionPlain = (props: PlainProps & { classes: any }) => {
                     secondary
                     small
                     icon={<IconMore16 />}
+                    dataTest="event-program-event-overflow-button"
                     component={(
-                        <FlyoutMenu dense>
+                        <FlyoutMenu dense dataTest="event-program-event-overflow-menu">
                             <MenuItem
                                 label={i18n.t('View changelog')}
                                 suffix={null}
+                                data-test="event-program-event-changelog"
                                 onClick={() => {
                                     setChangeLogIsOpen(true);
                                     setActionsIsOpen(false);

--- a/src/core_modules/capture-core/components/Pages/ViewEvent/EventDetailsSection/EventDetailsSection.component.tsx
+++ b/src/core_modules/capture-core/components/Pages/ViewEvent/EventDetailsSection/EventDetailsSection.component.tsx
@@ -168,7 +168,7 @@ const EventDetailsSectionPlain = (props: PlainProps & { classes: any }) => {
                     icon={<IconMore16 />}
                     dataTest="event-program-event-overflow-button"
                     component={(
-                        <FlyoutMenu dense dataTest="event-program-event-overflow-menu">
+                        <FlyoutMenu dense maxWidth="250px">
                             <MenuItem
                                 label={i18n.t('View changelog')}
                                 suffix={null}

--- a/src/core_modules/capture-core/components/Pages/ViewEvent/EventDetailsSection/EventDetailsSection.component.tsx
+++ b/src/core_modules/capture-core/components/Pages/ViewEvent/EventDetailsSection/EventDetailsSection.component.tsx
@@ -168,11 +168,14 @@ const EventDetailsSectionPlain = (props: PlainProps & { classes: any }) => {
                     icon={<IconMore16 />}
                     dataTest="event-program-event-overflow-button"
                     component={(
-                        <FlyoutMenu dense maxWidth="250px">
+                        <FlyoutMenu
+                            dense
+                            maxWidth="250px"
+                            dataTest="event-program-event-overflow-menu"
+                        >
                             <MenuItem
                                 label={i18n.t('View changelog')}
                                 suffix={null}
-                                data-test="event-program-event-changelog"
                                 onClick={() => {
                                     setChangeLogIsOpen(true);
                                     setActionsIsOpen(false);

--- a/src/core_modules/capture-core/components/Pages/ViewEvent/EventDetailsSection/EventDetailsSection.types.ts
+++ b/src/core_modules/capture-core/components/Pages/ViewEvent/EventDetailsSection/EventDetailsSection.types.ts
@@ -1,9 +1,11 @@
+import { ProgramStage } from "capture-core/metaData";
+
 export type PlainProps = {
     showEditEvent?: boolean;
     eventId: string;
     eventData: any;
     onOpenEditEvent: (orgUnit: any, programCategory?: any) => void;
-    programStage: any;
+    programStage: ProgramStage;
     eventAccess: { read: boolean, write: boolean };
     programId: string;
     onBackToAllEvents: () => void;

--- a/src/core_modules/capture-core/components/Pages/ViewEvent/EventDetailsSection/EventDetailsSection.types.ts
+++ b/src/core_modules/capture-core/components/Pages/ViewEvent/EventDetailsSection/EventDetailsSection.types.ts
@@ -1,4 +1,4 @@
-import { ProgramStage } from "capture-core/metaData";
+import { ProgramStage } from 'capture-core/metaData';
 
 export type PlainProps = {
     showEditEvent?: boolean;

--- a/src/core_modules/capture-core/components/Pages/ViewEvent/ViewEventComponent/ViewEvent.component.tsx
+++ b/src/core_modules/capture-core/components/Pages/ViewEvent/ViewEventComponent/ViewEvent.component.tsx
@@ -83,7 +83,7 @@ export const ViewEventPlain = (props: Props & WithStyles<typeof getStyles>) => {
                 onBackToMainPage={onBackToAllEvents}
             />
             <div className={classes.contentContainer}>
-            <EventDetails
+                <EventDetails
                     eventAccess={eventAccess}
                     programStage={programStage}
                     onBackToViewEvent={onBackToViewEvent}

--- a/src/core_modules/capture-core/components/Pages/ViewEvent/ViewEventComponent/ViewEvent.component.tsx
+++ b/src/core_modules/capture-core/components/Pages/ViewEvent/ViewEventComponent/ViewEvent.component.tsx
@@ -83,7 +83,12 @@ export const ViewEventPlain = (props: Props & WithStyles<typeof getStyles>) => {
                 onBackToMainPage={onBackToAllEvents}
             />
             <div className={classes.contentContainer}>
-                <EventDetails eventAccess={eventAccess} onBackToAllEvents={onBackToAllEvents} />
+            <EventDetails
+                    eventAccess={eventAccess}
+                    programStage={programStage}
+                    onBackToViewEvent={onBackToViewEvent}
+                    onBackToAllEvents={onBackToAllEvents}
+                />
                 <RightColumnWrapper
                     eventAccess={eventAccess}
                     programStage={programStage}

--- a/src/core_modules/capture-core/components/WidgetEventEdit/WidgetHeader/WidgetHeader.container.tsx
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/WidgetHeader/WidgetHeader.container.tsx
@@ -124,12 +124,12 @@ const WidgetHeaderPlain = ({
                                 icon={<IconMore16 />}
                                 small
                                 secondary
-                                dataTest={'widget-event-edit-overflow-button'}
+                                dataTest={'tracker-program-event-overflow-button'}
                                 component={
-                                    <FlyoutMenu dense maxWidth="250px">
+                                    <FlyoutMenu dense maxWidth="250px" dataTest="tracker-program-event-overflow-menu">
                                         <MenuItem
                                             label={i18n.t('View changelog')}
-                                            dataTest={'event-overflow-view-changelog'}
+                                            dataTest={'tracker-program-event-changelog'}
                                             suffix=""
                                             onClick={() => {
                                                 setChangeLogIsOpen(true);

--- a/src/core_modules/capture-core/components/WidgetEventEdit/WidgetHeader/WidgetHeader.container.tsx
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/WidgetHeader/WidgetHeader.container.tsx
@@ -126,10 +126,13 @@ const WidgetHeaderPlain = ({
                                 secondary
                                 dataTest={'tracker-program-event-overflow-button'}
                                 component={
-                                    <FlyoutMenu dense maxWidth="250px">
+                                    <FlyoutMenu
+                                        dense
+                                        maxWidth="250px"
+                                        dataTest={'tracker-program-event-overflow-menu'}
+                                    >
                                         <MenuItem
                                             label={i18n.t('View changelog')}
-                                            dataTest={'tracker-program-event-changelog'}
                                             suffix=""
                                             onClick={() => {
                                                 setChangeLogIsOpen(true);

--- a/src/core_modules/capture-core/components/WidgetEventEdit/WidgetHeader/WidgetHeader.container.tsx
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/WidgetHeader/WidgetHeader.container.tsx
@@ -126,7 +126,7 @@ const WidgetHeaderPlain = ({
                                 secondary
                                 dataTest={'tracker-program-event-overflow-button'}
                                 component={
-                                    <FlyoutMenu dense maxWidth="250px" dataTest="tracker-program-event-overflow-menu">
+                                    <FlyoutMenu dense maxWidth="250px">
                                         <MenuItem
                                             label={i18n.t('View changelog')}
                                             dataTest={'tracker-program-event-changelog'}

--- a/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.component.tsx
+++ b/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.component.tsx
@@ -36,11 +36,14 @@ export const OverflowMenuComponent = ({
                 secondary
                 dataTest="tracked-entity-profile-overflow-button"
                 component={
-                    <FlyoutMenu dense>
+                    <FlyoutMenu
+                        dense
+                        maxWidth="250px"
+                        dataTest={'tracked-entity-profile-overflow-menu'}
+                    >
                         {displayChangelog && (
                             <MenuItem
                                 label={i18n.t('View changelog')}
-                                data-test="tracked-entity-profile-changelog"
                                 onClick={() => {
                                     setChangelogIsOpen(true);
                                     setActionsIsOpen(false);

--- a/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.component.tsx
+++ b/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.component.tsx
@@ -36,7 +36,7 @@ export const OverflowMenuComponent = ({
                 secondary
                 dataTest="tracked-entity-profile-overflow-button"
                 component={
-                    <FlyoutMenu dense dataTest="tracked-entity-profile-overflow-menu">
+                    <FlyoutMenu dense>
                         {displayChangelog && (
                             <MenuItem
                                 label={i18n.t('View changelog')}

--- a/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.component.tsx
+++ b/src/core_modules/capture-core/components/WidgetProfile/OverflowMenu/OverflowMenu.component.tsx
@@ -34,12 +34,13 @@ export const OverflowMenuComponent = ({
                 icon={<IconMore16 />}
                 small
                 secondary
-                dataTest="widget-profile-overflow-menu"
+                dataTest="tracked-entity-profile-overflow-button"
                 component={
-                    <FlyoutMenu dense>
+                    <FlyoutMenu dense dataTest="tracked-entity-profile-overflow-menu">
                         {displayChangelog && (
                             <MenuItem
                                 label={i18n.t('View changelog')}
+                                data-test="tracked-entity-profile-changelog"
                                 onClick={() => {
                                     setChangelogIsOpen(true);
                                     setActionsIsOpen(false);


### PR DESCRIPTION
[DHIS2-20029](https://dhis2.atlassian.net/browse/DHIS2-20029)

* Changed the type of the `programStage` prop in `EventDetailsSection.types.ts` from `any` to the `ProgramStage` type. 
* Updated the usage of the `EventDetails` component in `ViewEvent.component.tsx` to pass the `programStage` and new `onBackToViewEvent` props, ensuring the component receives the same props as before the conversion.*
* Added Cypress tests to check that all three types of Changelog show data (Tracker, Event, Tracked Entity).
* Update Demo DB: 
<img width="960" height="1042" alt="image" src="https://github.com/user-attachments/assets/4eb12d2a-f98e-4bcb-9e52-584ec74dadd0" />


[DHIS2-20029]: https://dhis2.atlassian.net/browse/DHIS2-20029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ