### PR TITLE
fix: [DHIS2-20031] Font used in enrollment widget not the same for every field

### DIFF
--- a/src/core_modules/capture-core/components/WidgetEnrollment/WidgetEnrollment.component.tsx
+++ b/src/core_modules/capture-core/components/WidgetEnrollment/WidgetEnrollment.component.tsx
@@ -105,7 +105,7 @@ export const WidgetEnrollmentPlain = ({
                             <Status status={enrollment.status} />
                         </div>
 
-                        <span data-test="widget-enrollment-enrollment-date">
+                        <div className={classes.row} data-test="widget-enrollment-enrollment-date">
                             <Date
                                 date={enrollment.enrolledAt}
                                 dateLabel={getEnrollmentDateLabel(program)}
@@ -115,10 +115,10 @@ export const WidgetEnrollmentPlain = ({
                                 onSave={updateEnrollmentDate}
                                 allowFutureDate={program.selectEnrollmentDatesInFuture}
                             />
-                        </span>
+                        </div>
 
                         {program.displayIncidentDate && (
-                            <span data-test="widget-enrollment-incident-date">
+                            <div className={classes.row} data-test="widget-enrollment-incident-date">
                                 <Date
                                     date={enrollment.occurredAt}
                                     dateLabel={getIncidentDateLabel(program)}
@@ -128,7 +128,7 @@ export const WidgetEnrollmentPlain = ({
                                     onSave={updateIncidentDate}
                                     allowFutureDate={program.selectIncidentDatesInFuture}
                                 />
-                            </span>
+                            </div>
                         )}
 
                         <div className={classes.row} data-test="widget-enrollment-orgunit">


### PR DESCRIPTION
[DHIS2-20031](https://dhis2.atlassian.net/browse/DHIS2-20031)

fix: apply row styling on wrapper instead of passing parent classes to Date

The Date component has its own withStyles keys, so passing parent `classes` 
caused a TypeScript type conflict. We now style the wrapper with `className={classes.row}` instead.

[DHIS2-20031]: https://dhis2.atlassian.net/browse/DHIS2-20031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ