### PR TITLE
fix: use rule engine's user roles as fallback

### DIFF
--- a/src/core_modules/capture-core/rules/RuleEngine/RuleEngine.ts
+++ b/src/core_modules/capture-core/rules/RuleEngine/RuleEngine.ts
@@ -57,7 +57,7 @@ export class RuleEngine {
         );
         const executionContext = inputBuilder.buildRuleEngineContext({
             programRulesContainer,
-            selectedUserRoles,
+            selectedUserRoles: selectedUserRoles || this.userRoles,
         });
         const enrollment = selectedEnrollment ?
             inputBuilder.buildEnrollment({


### PR DESCRIPTION
[DHIS2-20600](https://dhis2.atlassian.net/browse/DHIS2-20060?actionerId=61bcf639e399d700715e8abf&sourceType=assign)

The rule engine generally does not receive a user role array directly as input, and in this case it should use the one with which it was initialized.