### PR TITLE
docs: [DHIS2-18603] fix the bulk data entry docs runtime error

### DIFF
--- a/docs/developer/bulk-data-entry-plugin/manual-setup.mdx
+++ b/docs/developer/bulk-data-entry-plugin/manual-setup.mdx
@@ -75,7 +75,7 @@ Each configuration object requires the following fields:
 |-------|----------|-------------|
 | `configKey` | Yes | An identifier for the configuration. Must be unique per `programId`. Will be passed to the plugin. |  
 | `programId` | Yes |  The identifier of the program where this bulk data entry will be available. |
-| `pluginSource` | Yes | The URL of the plugin. Must point to a valid plugin installed on the instance and follow the pattern: https://{instance-url}/api/apps/{plugin-name}/plugin.html. |
+| `pluginSource` | Yes | The URL of the plugin. Must point to a valid plugin installed on the instance and follow the pattern: `https://{instance-url}/api/apps/{plugin-name}/plugin.html`. |
 | `title` | Yes | The display title of the configuration. Supports multiple languages using locale codes (e.g., "en", "es"). |
 | `subtitle` | No | An optional subtitle for the configuration. Supports multiple languages using locale codes. |
 | `dataKey` | No | An optional identifier that is not used internally by the app but is passed through to the plugin. This property is intended for advanced usage and can be used by the plugin to maintain separate in-progress caches for a given `configKey`. |


### PR DESCRIPTION
[DHIS2-18603](https://dhis2.atlassian.net/browse/DHIS2-18603)

This PR fixes the `instance is not defined` error introduced in [#4066](https://github.com/dhis2/capture-app/pull/4066). Additionally, please review [dhis2/developer-portal#188](https://github.com/dhis2/developer-portal/pull/188) which adds the corresponding docs to the sidebar.

<img width="1399" height="659" alt="Screenshot 2025-10-29 at 12 50 02" src="https://github.com/user-attachments/assets/bc557709-cbe4-4089-b3dd-a3ea9077fcec" />


[DHIS2-18603]: https://dhis2.atlassian.net/browse/DHIS2-18603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ