### PR TITLE
docs: update developer docs with new create command

### DIFF
--- a/docs/developer/develop-a-capture-plugin.md
+++ b/docs/developer/develop-a-capture-plugin.md
@@ -11,14 +11,14 @@ Developing a capture plugin is almost the same as developing a regular DHIS2 cus
 
 ## Step 1: Create a new DHIS2 custom app
 
-To create a new DHIS2 custom app, you can use the D2 CLI.
+To create a new DHIS2 custom app, you can use the `npm create @dhis2/app` command.
 
-The D2 CLI helps you with many things, such as setting up a new project, building your app, and deploying it to your DHIS2 instance.
+This will prompt you with a series of questions to help you set up your new app, and once completed, it will create all the necessary files and packages for you.
 
-Please read our documentation on the [D2 CLI](/docs/quickstart/quickstart-web) to learn more about how to use it. 
+Please read our documentation for details on how to use the command [here](/docs/cli/create-app). 
 
 ```sh
-d2 app scripts init my-form-field-plugin
+npm create @dhis2/app
 ```
 
 ## Step 2: Add a plugin entrypoint

--- a/docs/developer/form-field-plugins/developer-details.md
+++ b/docs/developer/form-field-plugins/developer-details.md
@@ -130,13 +130,14 @@ type SetContextFieldValueProps = {
 }
 
 export type IFormFieldPluginProps = {
+    orgUnitId: string;
     values: Record<string, any>;
     errors: Record<string, string[]>;
     warnings: Record<string, string[]>;
     fieldsMetadata: Record<string, fieldsMetadata>;
-    setFieldValue: (values: SetFieldValueProps) => void;
-    setContextFieldValue: (values: SetContextFieldValueProps) => void;
     viewMode: boolean;
     formSubmitted: boolean;
+    setFieldValue: (values: SetFieldValueProps) => void;
+    setContextFieldValue: (values: SetContextFieldValueProps) => void;
 }
 ```


### PR DESCRIPTION
Summary:

- Update develop-a-capture-plugin docs with the new create command instructions
- Clarify the initial app setup guidance for plugin creators
