### PR TITLE
fix: [DHIS2-20985] Username field selects first suggestion instead of clicked user

### DIFF
--- a/src/core_modules/capture-core/components/FormFields/UserField/Input.component.tsx
+++ b/src/core_modules/capture-core/components/FormFields/UserField/Input.component.tsx
@@ -17,20 +17,16 @@ type Props = {
     placeholder?: string | null;
 };
 
-const hasSuggestionAttribute = (element: any, suggestionName: string) =>
-    element?.getAttribute?.('data-suggestion-name') === suggestionName;
+const hasDataSuggestionName = (element: EventTarget | null, suggestionName: string): boolean =>
+    element instanceof HTMLElement && element.dataset.suggestionName === suggestionName;
 
-const isSuggestionBlurTarget = (target: any, suggestionName: string) => {
-    if (hasSuggestionAttribute(target, suggestionName)) {
+const isSuggestionBlurTarget = (relatedTarget: EventTarget | null, suggestionName: string): boolean => {
+    if (hasDataSuggestionName(relatedTarget, suggestionName)) {
         return true;
     }
 
-    const parentElement = target?.parentElement;
-    if (!parentElement) {
-        return false;
-    }
-
-    return hasSuggestionAttribute(parentElement, suggestionName);
+    const parentElement = relatedTarget instanceof Node ? relatedTarget.parentElement : null;
+    return hasDataSuggestionName(parentElement, suggestionName);
 };
 
 export const Input = (props: Props) => {

--- a/src/core_modules/capture-core/components/FormFields/UserField/Input.component.tsx
+++ b/src/core_modules/capture-core/components/FormFields/UserField/Input.component.tsx
@@ -17,17 +17,20 @@ type Props = {
     placeholder?: string | null;
 };
 
+const hasSuggestionAttribute = (element: any, suggestionName: string) =>
+    element?.getAttribute?.('data-suggestion-name') === suggestionName;
+
 const isSuggestionBlurTarget = (target: any, suggestionName: string) => {
-    if (target.getAttribute('name') === suggestionName) {
+    if (hasSuggestionAttribute(target, suggestionName)) {
         return true;
     }
 
-    const parentElement = target.parentElement;
+    const parentElement = target?.parentElement;
     if (!parentElement) {
         return false;
     }
 
-    return (parentElement.getAttribute('name') === suggestionName);
+    return hasSuggestionAttribute(parentElement, suggestionName);
 };
 
 export const Input = (props: Props) => {

--- a/src/core_modules/capture-core/components/FormFields/UserField/SearchSuggestion.component.tsx
+++ b/src/core_modules/capture-core/components/FormFields/UserField/SearchSuggestion.component.tsx
@@ -35,7 +35,7 @@ function match(text: string, query: string) {
 }
 
 function isInternalTarget(target: any, suggestionName: string, inputName: string) {
-    if (target.getAttribute('name') === suggestionName ||
+    if (target.getAttribute('data-suggestion-name') === suggestionName ||
         target.getAttribute('name') === inputName) {
         return true;
     }
@@ -45,7 +45,7 @@ function isInternalTarget(target: any, suggestionName: string, inputName: string
         return false;
     }
 
-    return (parentElement.getAttribute('name') === suggestionName);
+    return (parentElement.getAttribute('data-suggestion-name') === suggestionName);
 }
 
 export const SearchSuggestion = (props: Props) => {
@@ -89,6 +89,10 @@ export const SearchSuggestion = (props: Props) => {
         event.stopPropagation();
     }, [onSelect, user]);
 
+    const handleMouseDown = React.useCallback((event: any) => {
+        event.preventDefault();
+    }, []);
+
     const handleBlur = React.useCallback((event: any) => {
         if (!event.relatedTarget || !isInternalTarget(event.relatedTarget, suggestionName, inputName)) {
             onExitSearch();
@@ -98,11 +102,13 @@ export const SearchSuggestion = (props: Props) => {
         <div
             role="button"
             tabIndex={-1}
+            data-suggestion-name={suggestionName}
             ref={handleRef}
             className={useUpwardList ?
                 cx(defaultClasses.suggestion, defaultClasses.suggestionInUpList) :
                 defaultClasses.suggestion}
             onKeyDown={handleKeyDown}
+            onMouseDown={handleMouseDown}
             onClick={handleClick}
             onBlur={handleBlur}
         >

--- a/src/core_modules/capture-core/components/FormFields/UserField/SearchSuggestion.component.tsx
+++ b/src/core_modules/capture-core/components/FormFields/UserField/SearchSuggestion.component.tsx
@@ -34,18 +34,18 @@ function match(text: string, query: string) {
     ];
 }
 
-function isInternalTarget(target: any, suggestionName: string, inputName: string) {
-    if (target.getAttribute('data-suggestion-name') === suggestionName ||
-        target.getAttribute('name') === inputName) {
-        return true;
+function isInternalTarget(relatedTarget: EventTarget | null, suggestionName: string, inputName: string): boolean {
+    if (relatedTarget instanceof HTMLElement) {
+        if (relatedTarget.dataset.suggestionName === suggestionName) {
+            return true;
+        }
+        if (relatedTarget.getAttribute('name') === inputName) {
+            return true;
+        }
     }
 
-    const parentElement = target.parentElement;
-    if (!parentElement) {
-        return false;
-    }
-
-    return (parentElement.getAttribute('data-suggestion-name') === suggestionName);
+    const parentElement = relatedTarget instanceof Node ? relatedTarget.parentElement : null;
+    return parentElement instanceof HTMLElement && parentElement.dataset.suggestionName === suggestionName;
 }
 
 export const SearchSuggestion = (props: Props) => {
@@ -91,7 +91,9 @@ export const SearchSuggestion = (props: Props) => {
 
     const handleMouseDown = React.useCallback((event: any) => {
         event.preventDefault();
-    }, []);
+        onSelect(user);
+        event.stopPropagation();
+    }, [onSelect, user]);
 
     const handleBlur = React.useCallback((event: any) => {
         if (!event.relatedTarget || !isInternalTarget(event.relatedTarget, suggestionName, inputName)) {

--- a/src/core_modules/capture-core/components/FormFields/UserField/SearchSuggestion.component.tsx
+++ b/src/core_modules/capture-core/components/FormFields/UserField/SearchSuggestion.component.tsx
@@ -34,18 +34,19 @@ function match(text: string, query: string) {
     ];
 }
 
+const hasDataSuggestionName = (element: EventTarget | null, suggestionName: string): boolean =>
+    element instanceof HTMLElement && element.dataset.suggestionName === suggestionName;
+
 function isInternalTarget(relatedTarget: EventTarget | null, suggestionName: string, inputName: string): boolean {
-    if (relatedTarget instanceof HTMLElement) {
-        if (relatedTarget.dataset.suggestionName === suggestionName) {
-            return true;
-        }
-        if (relatedTarget.getAttribute('name') === inputName) {
-            return true;
-        }
+    if (hasDataSuggestionName(relatedTarget, suggestionName)) {
+        return true;
+    }
+    if (relatedTarget instanceof HTMLElement && relatedTarget.getAttribute('name') === inputName) {
+        return true;
     }
 
     const parentElement = relatedTarget instanceof Node ? relatedTarget.parentElement : null;
-    return parentElement instanceof HTMLElement && parentElement.dataset.suggestionName === suggestionName;
+    return hasDataSuggestionName(parentElement, suggestionName);
 }
 
 export const SearchSuggestion = (props: Props) => {
@@ -91,9 +92,7 @@ export const SearchSuggestion = (props: Props) => {
 
     const handleMouseDown = React.useCallback((event: any) => {
         event.preventDefault();
-        onSelect(user);
-        event.stopPropagation();
-    }, [onSelect, user]);
+    }, []);
 
     const handleBlur = React.useCallback((event: any) => {
         if (!event.relatedTarget || !isInternalTarget(event.relatedTarget, suggestionName, inputName)) {

--- a/src/core_modules/capture-core/components/FormFields/UserField/searchSuggestions.module.css
+++ b/src/core_modules/capture-core/components/FormFields/UserField/searchSuggestions.module.css
@@ -6,6 +6,7 @@
     position: absolute;
     max-height: 200px;
     width: calc(100% - 6px);
+    min-width: fit-content;
     z-index: 500;
     background-color: white;
     overflow-y: auto;

--- a/src/core_modules/capture-core/components/FormFields/UserField/selected.module.css
+++ b/src/core_modules/capture-core/components/FormFields/UserField/selected.module.css
@@ -3,24 +3,11 @@
 }
 
 .chipContainer {
-    position: absolute;
-    padding-top: 1px;
-    z-index: 10;
-    top: 0;
-    inset-inline-start: 0;
-}
-
-.input:disabled {
-    background-color: inherit;
+    position: relative;
+    z-index: 1;
 }
 
 .inputContainer {
-    padding: 0px;
-}
-
-.inputContainer:focus {
-    outline: none;
-    box-shadow: inset 0 0 0 2px #147cd7;
-    border-color: #147cd7;
-    border-radius: 3px;
+    position: absolute;
+    inset: 0;
 }


### PR DESCRIPTION
[DHIS2-20985](https://dhis2.atlassian.net/browse/DHIS2-20985)

The UserField component has a search input with a suggestions dropdown. When focus leaves both the input and the suggestions, onExitSearch() is called to close the dropdown. This blur detection previously relied on checking getAttribute('name') on `<div>` elements, which is non-standard and fails when event.relatedTarget is a child element (e.g. inside <MenuItem>) that doesn't carry the name attribute.

This PR makes two fixes:
1. Switches to data-suggestion-name for identifying suggestion elements in blur handlers, checked via element.dataset.suggestionName,
2. Adds preventDefault() on mouseDown to prevent the classic blur-before-click race condition when clicking a suggestion.


Some existing bugs for long values are also been improved:

<img width="420" height="316" alt="bilde" src="https://github.com/user-attachments/assets/21439417-c001-4a58-a530-6ea6dc1db361" />

<img width="266" height="316" alt="Skjermbilde 2026-03-20 kl  19 55 06" src="https://github.com/user-attachments/assets/43a4c1f9-545e-4a81-a2db-30fef73f2548" />


[DHIS2-20985]: https://dhis2.atlassian.net/browse/DHIS2-20985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ