### PR TITLE
fix: [DHIS2-21224] File upload fails in program stage

### DIFF
--- a/src/core_modules/capture-core/components/D2Form/FormBuilder/components/FormField.tsx
+++ b/src/core_modules/capture-core/components/D2Form/FormBuilder/components/FormField.tsx
@@ -61,9 +61,9 @@ export const FormField = React.memo(({
     const asyncProps = useMemo(() =>
         ((fieldProps.async) ? ({
             onCommitAsync: (callback: (...args: any[]) => any) =>
-                onUpdateFieldAsync(field.id, fieldProps.label, fieldProps.id, callback),
+                onUpdateFieldAsync(field.id, fieldProps.label, formId, callback),
             asyncUIState,
-        }) : {}), [field.id, fieldProps.async, fieldProps.label, fieldProps.id, asyncUIState, onUpdateFieldAsync]);
+        }) : {}), [field.id, fieldProps.async, fieldProps.label, formId, asyncUIState, onUpdateFieldAsync]);
 
     const commitEvent = field.commitEvent || 'onBlur';
     const commitPropObject = {


### PR DESCRIPTION
[DHIS2-21224](https://dhis2.atlassian.net/browse/DHIS2-21224)

The problem is that the we are using the wrong ID when updating validation after a file or image upload.

In `onCommitAsync`, it uses `fieldProps.id` as the `formBuilderId`. But this is incorrect — `formBuilderId` should come from the form itself (`formId`), not from the field. File and image fields don’t even have an `id` in their props, so `fieldProps.id` ends up being `undefined`.

Because of this, when the upload finishes and tries to mark the field as `valid: true`, it saves that update under the key `"undefined"` in Redux instead of the actual form’s key (like `"enrollmentEvent-newEvent"`).

So the real form state never gets updated, and the field stays marked as invalid even though the file upload worked.

[DHIS2-21224]: https://dhis2.atlassian.net/browse/DHIS2-21224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ