### PR TITLE
fix: [DHIS2-20032] Update "Last updated" in enrollment widget on change

### DIFF
--- a/src/core_modules/capture-core/components/WidgetEnrollment/WidgetEnrollment.component.tsx
+++ b/src/core_modules/capture-core/components/WidgetEnrollment/WidgetEnrollment.component.tsx
@@ -72,7 +72,6 @@ export const WidgetEnrollmentPlain = ({
 }: PlainProps & WithStyles<typeof styles>) => {
     const [open, setOpenStatus] = useState(true);
     const { fromServerDate } = useTimeZoneConversion();
-    const localDateTime: string = convertValue(enrollment?.updatedAt, dataElementTypes.DATETIME);
     const geometryType = getGeometryType(enrollment?.geometry?.type);
     const { displayName: orgUnitName, ancestors } = useOrgUnitNameWithAncestors(enrollment?.orgUnit);
     const { displayName: ownerOrgUnitName, ancestors: ownerAncestors } = useOrgUnitNameWithAncestors(ownerOrgUnit?.id);
@@ -156,7 +155,7 @@ export const WidgetEnrollmentPlain = ({
                                 <IconClock16 color={colors.grey600} />
                             </span>
                             {i18n.t('Last updated')}
-                            <Tooltip content={localDateTime}>
+                            <Tooltip content={fromServerDate(enrollment.updatedAt).toLocaleString()}>
                                 {moment(fromServerDate(enrollment.updatedAt)).fromNow()}
                             </Tooltip>
                         </div>

--- a/src/core_modules/capture-core/components/WidgetEnrollment/WidgetEnrollment.component.tsx
+++ b/src/core_modules/capture-core/components/WidgetEnrollment/WidgetEnrollment.component.tsx
@@ -72,6 +72,9 @@ export const WidgetEnrollmentPlain = ({
 }: PlainProps & WithStyles<typeof styles>) => {
     const [open, setOpenStatus] = useState(true);
     const { fromServerDate } = useTimeZoneConversion();
+    const updatedAtDateTime: string = convertValue(
+        fromServerDate(enrollment?.updatedAt).toISOString(), dataElementTypes.DATETIME,
+    );
     const geometryType = getGeometryType(enrollment?.geometry?.type);
     const { displayName: orgUnitName, ancestors } = useOrgUnitNameWithAncestors(enrollment?.orgUnit);
     const { displayName: ownerOrgUnitName, ancestors: ownerAncestors } = useOrgUnitNameWithAncestors(ownerOrgUnit?.id);
@@ -155,7 +158,7 @@ export const WidgetEnrollmentPlain = ({
                                 <IconClock16 color={colors.grey600} />
                             </span>
                             {i18n.t('Last updated')}
-                            <Tooltip content={fromServerDate(enrollment.updatedAt).toLocaleString()}>
+                            <Tooltip content={updatedAtDateTime}>
                                 {moment(fromServerDate(enrollment.updatedAt)).fromNow()}
                             </Tooltip>
                         </div>

--- a/src/core_modules/capture-core/components/WidgetEnrollment/hooks/useUpdateEnrollment.ts
+++ b/src/core_modules/capture-core/components/WidgetEnrollment/hooks/useUpdateEnrollment.ts
@@ -31,8 +31,8 @@ export const useUpdateEnrollment = ({
     const [updateEnrollmentMutation] = useDataMutation(enrollmentUpdate, {
         onError: (e) => {
             setEnrollment(prevEnrollment.current);
-            updateHandler && updateHandler(prevEnrollment.current[propertyName]);
-            onError && onError(processErrorReports(e));
+            updateHandler?.(prevEnrollment.current[propertyName]);
+            onError?.(processErrorReports(e));
         },
     });
 
@@ -43,6 +43,6 @@ export const useUpdateEnrollment = ({
         updatedEnrollment.updatedAt = fromClientDate(new Date()).getServerZonedISOString();
         setEnrollment(updatedEnrollment);
         updateEnrollmentMutation(updatedEnrollment);
-        updateHandler && updateHandler(value);
+        updateHandler?.(value);
     }, [enrollment, setEnrollment, propertyName, updateHandler, updateEnrollmentMutation, fromClientDate]);
 };

--- a/src/core_modules/capture-core/components/WidgetEnrollment/hooks/useUpdateEnrollment.ts
+++ b/src/core_modules/capture-core/components/WidgetEnrollment/hooks/useUpdateEnrollment.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useDataMutation, useTimeZoneConversion } from '@dhis2/app-runtime';
 import type { Mutation } from 'capture-core-utils/types/app-runtime';
 import { processErrorReports } from '../processErrorReports';
@@ -27,15 +27,17 @@ export const useUpdateEnrollment = ({
     onError,
 }: UseUpdateEnrollmentProps) => {
     const { fromClientDate } = useTimeZoneConversion();
+    const prevEnrollment = useRef(enrollment);
     const [updateEnrollmentMutation] = useDataMutation(enrollmentUpdate, {
         onError: (e) => {
-            setEnrollment(enrollment);
-            updateHandler && updateHandler(enrollment[propertyName]);
+            setEnrollment(prevEnrollment.current);
+            updateHandler && updateHandler(prevEnrollment.current[propertyName]);
             onError && onError(processErrorReports(e));
         },
     });
 
     return useCallback((value: string) => {
+        prevEnrollment.current = enrollment;
         const updatedEnrollment = { ...enrollment };
         updatedEnrollment[propertyName] = value;
         updatedEnrollment.updatedAt = fromClientDate(new Date()).getServerZonedISOString();

--- a/src/core_modules/capture-core/components/WidgetEnrollment/hooks/useUpdateEnrollment.ts
+++ b/src/core_modules/capture-core/components/WidgetEnrollment/hooks/useUpdateEnrollment.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useDataMutation } from '@dhis2/app-runtime';
+import { useDataMutation, useTimeZoneConversion } from '@dhis2/app-runtime';
 import type { Mutation } from 'capture-core-utils/types/app-runtime';
 import { processErrorReports } from '../processErrorReports';
 
@@ -26,6 +26,7 @@ export const useUpdateEnrollment = ({
     updateHandler,
     onError,
 }: UseUpdateEnrollmentProps) => {
+    const { fromClientDate } = useTimeZoneConversion();
     const [updateEnrollmentMutation] = useDataMutation(enrollmentUpdate, {
         onError: (e) => {
             setEnrollment(enrollment);
@@ -37,8 +38,9 @@ export const useUpdateEnrollment = ({
     return useCallback((value: string) => {
         const updatedEnrollment = { ...enrollment };
         updatedEnrollment[propertyName] = value;
+        updatedEnrollment.updatedAt = fromClientDate(new Date()).getServerZonedISOString();
         setEnrollment(updatedEnrollment);
         updateEnrollmentMutation(updatedEnrollment);
         updateHandler && updateHandler(value);
-    }, [enrollment, setEnrollment, propertyName, updateHandler, updateEnrollmentMutation]);
+    }, [enrollment, setEnrollment, propertyName, updateHandler, updateEnrollmentMutation, fromClientDate]);
 };


### PR DESCRIPTION
[DHIS2-20032](https://dhis2.atlassian.net/browse/DHIS2-20032)

This PR also includes a fix for a pre-existing stale closure issue in the onError handler. `useDataMutation` may capture the callback only once, so if the enrollment state changes between mutation and error, the rollback (`setEnrollment(enrollment)`) could restore a stale state. This is solved by using a `useRef` to snapshot the enrollment right before each mutation — the same pattern used in [WidgetAssignee.container.tsx](https://github.com/dhis2/capture-app/blob/master/src/core_modules/capture-core/components/WidgetAssignee/WidgetAssignee.container.tsx). While not introduced by this PR, the optimistic `updatedAt` update makes it slightly more impactful, so it made sense to address it here.

[DHIS2-20032]: https://dhis2.atlassian.net/browse/DHIS2-20032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ