### PR TITLE
chore: [DHIS2-19014] Ensure moment format is using Western Arabic 

### DIFF
--- a/src/core_modules/capture-core-utils/date/date.utils.ts
+++ b/src/core_modules/capture-core-utils/date/date.utils.ts
@@ -14,8 +14,8 @@ import moment from 'moment';
  * @returns the formatted string with Western-Arabic numerals
  */
 export function formatMomentEn(
-    momentDate: moment.Moment,
+    input: moment.MomentInput,
     format = 'YYYY-MM-DD',
 ) {
-    return momentDate.clone().locale('en').format(format);
+    return moment(input).locale('en').format(format);
 }

--- a/src/core_modules/capture-core-utils/date/date.utils.ts
+++ b/src/core_modules/capture-core-utils/date/date.utils.ts
@@ -1,16 +1,21 @@
 import moment from 'moment';
 
 /**
- * Some locales are using numeral glyphs other than european. This method ensures the moment format method
- * returns a value in european glyphs
- * @param {*} momentDate: the moment instance
- * @param {string} format: the moment format
- * @returns {string} A formatted string with european glyphs
+ * Formats a moment instance using English (Western-Arabic) numerals,
+ * regardless of the currently active moment locale.
+ *
+ * Use this anywhere the output is treated as data — API payloads, query
+ * parameters, object keys, values parsed back into dates, or otherwise
+ * compared as strings — because locale-dependent numerals (e.g. Arabic's
+ * ٠١٢٣) break those consumers.
+ *
+ * @param momentDate the moment instance to format
+ * @param format the moment format string (defaults to 'YYYY-MM-DD')
+ * @returns the formatted string with Western-Arabic numerals
  */
-export function getFormattedStringFromMomentUsingEuropeanGlyphs(
+export function formatMomentEn(
     momentDate: moment.Moment,
     format = 'YYYY-MM-DD',
 ) {
-    const europeanMoment = momentDate.clone().locale('en');
-    return europeanMoment.format(format);
+    return momentDate.clone().locale('en').format(format);
 }

--- a/src/core_modules/capture-core-utils/date/index.ts
+++ b/src/core_modules/capture-core-utils/date/index.ts
@@ -1,4 +1,4 @@
-export { getFormattedStringFromMomentUsingEuropeanGlyphs } from './date.utils';
+export { formatMomentEn } from './date.utils';
 export { padWithZeros } from './padWithZeros';
 export { temporalToString } from './temporalToString';
 export { stringToTemporal } from './stringToTemporal';

--- a/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/helpers/deriveAutoGenerateEvents.ts
+++ b/src/core_modules/capture-core/components/DataEntries/EnrollmentRegistrationEntry/helpers/deriveAutoGenerateEvents.ts
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { dataElementTypes, ProgramStage } from '../../../../metaData';
 import { convertClientToServer } from '../../../../converters';
 import { convertCategoryOptionsToServer } from '../../../../converters/clientToServer';
@@ -60,7 +61,7 @@ export const deriveAutoGenerateEvents = ({
                 const scheduledAt = openAfterEnrollment
                     ? dateToUseInScheduleStatus
                     : convertClientToServer(
-                        moment(dateToUseInScheduleStatus).add(minDaysFromStart, 'days').format('YYYY-MM-DD'),
+                        formatMomentEn(moment(dateToUseInScheduleStatus).add(minDaysFromStart, 'days'), 'YYYY-MM-DD'),
                         dataElementTypes.DATE,
                     );
 

--- a/src/core_modules/capture-core/components/DataEntries/common/trackerEvent/withAskToCompleteEnrollment/CompleteModal/CompleteModal.container.tsx
+++ b/src/core_modules/capture-core/components/DataEntries/common/trackerEvent/withAskToCompleteEnrollment/CompleteModal/CompleteModal.container.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useCallback } from 'react';
 import moment from 'moment';
 import { useTimeZoneConversion } from '@dhis2/app-runtime';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { getTrackerProgramThrowIfNotFound } from '../../../../../../metaData';
 import { statusTypes } from '../../../../../../enrollment';
 import { statusTypes as eventStatuses } from '../../../../../../events/statusTypes';
@@ -55,7 +56,7 @@ export const CompleteModal = ({
     const onHandleCompleteEnrollmentAndEvents = useCallback(() => {
         const nowClient = fromClientDate(new Date());
         const nowServer = new Date(nowClient.getServerZonedISOString());
-        const updatedAt = moment(nowServer).locale('en').format('YYYY-MM-DDTHH:mm:ss');
+        const updatedAt = formatMomentEn(moment(nowServer), 'YYYY-MM-DDTHH:mm:ss');
         const eventsToComplete = events.reduce((acc: any, event: any) => {
             const { access } = programStages.find((p: any) => p.id === event.programStage) || {};
             const isCurrentEvent = eventId && event.event === eventId;

--- a/src/core_modules/capture-core/components/DataEntries/common/trackerEvent/withAskToCompleteEnrollment/CompleteModal/CompleteModal.container.tsx
+++ b/src/core_modules/capture-core/components/DataEntries/common/trackerEvent/withAskToCompleteEnrollment/CompleteModal/CompleteModal.container.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useCallback } from 'react';
-import moment from 'moment';
 import { useTimeZoneConversion } from '@dhis2/app-runtime';
 import { formatMomentEn } from 'capture-core-utils/date';
 import { getTrackerProgramThrowIfNotFound } from '../../../../../../metaData';
@@ -56,7 +55,7 @@ export const CompleteModal = ({
     const onHandleCompleteEnrollmentAndEvents = useCallback(() => {
         const nowClient = fromClientDate(new Date());
         const nowServer = new Date(nowClient.getServerZonedISOString());
-        const updatedAt = formatMomentEn(moment(nowServer), 'YYYY-MM-DDTHH:mm:ss');
+        const updatedAt = formatMomentEn(nowServer, 'YYYY-MM-DDTHH:mm:ss');
         const eventsToComplete = events.reduce((acc: any, event: any) => {
             const { access } = programStages.find((p: any) => p.id === event.programStage) || {};
             const isCurrentEvent = eventId && event.event === eventId;

--- a/src/core_modules/capture-core/components/FiltersForTypes/DateTime/DateTimeFilterManager.component.tsx
+++ b/src/core_modules/capture-core/components/FiltersForTypes/DateTime/DateTimeFilterManager.component.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import moment from 'moment';
 import { formatMomentEn } from 'capture-core-utils/date';
 import { convertIsoToLocalCalendar } from '../../../utils/converters/date';
 import { DateTimeFilter } from './DateTimeFilter.component';
@@ -20,7 +19,7 @@ function extractLocalDate(isoDatetime?: string | null): string | undefined {
     if (!isoDatetime) {
         return undefined;
     }
-    const localDateStr = formatMomentEn(moment(isoDatetime), 'YYYY-MM-DD');
+    const localDateStr = formatMomentEn(isoDatetime, 'YYYY-MM-DD');
     return convertIsoToLocalCalendar(localDateStr) || undefined;
 }
 
@@ -28,7 +27,7 @@ function extractTime(isoDatetime?: string | null): string | undefined {
     if (!isoDatetime) {
         return undefined;
     }
-    return formatMomentEn(moment(isoDatetime), 'HH:mm');
+    return formatMomentEn(isoDatetime, 'HH:mm');
 }
 
 export class DateTimeFilterManager extends React.Component<Props, State> {

--- a/src/core_modules/capture-core/components/FiltersForTypes/DateTime/DateTimeFilterManager.component.tsx
+++ b/src/core_modules/capture-core/components/FiltersForTypes/DateTime/DateTimeFilterManager.component.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import moment from 'moment';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { convertIsoToLocalCalendar } from '../../../utils/converters/date';
 import { DateTimeFilter } from './DateTimeFilter.component';
 import type { DateTimeFilterData } from './types/dateTime.types';
@@ -19,7 +20,7 @@ function extractLocalDate(isoDatetime?: string | null): string | undefined {
     if (!isoDatetime) {
         return undefined;
     }
-    const localDateStr = moment(isoDatetime).format('YYYY-MM-DD');
+    const localDateStr = formatMomentEn(moment(isoDatetime), 'YYYY-MM-DD');
     return convertIsoToLocalCalendar(localDateStr) || undefined;
 }
 
@@ -27,7 +28,7 @@ function extractTime(isoDatetime?: string | null): string | undefined {
     if (!isoDatetime) {
         return undefined;
     }
-    return moment(isoDatetime).format('HH:mm');
+    return formatMomentEn(moment(isoDatetime), 'HH:mm');
 }
 
 export class DateTimeFilterManager extends React.Component<Props, State> {

--- a/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/EnrollmentPageDefault.container.tsx
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/EnrollmentPageDefault.container.tsx
@@ -3,6 +3,7 @@ import i18n from '@dhis2/d2-i18n';
 import moment from 'moment';
 import log from 'loglevel';
 import { errorCreator } from 'capture-core-utils';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTimeZoneConversion } from '@dhis2/app-runtime';
 import type { ApiEnrollmentEvent } from 'capture-core-utils/types/api-types';
@@ -147,7 +148,7 @@ export const EnrollmentPageDefault = () => {
     const onUpdateEventStatus = useCallback((eventId: string, status: string) => {
         const nowClient = fromClientDate(new Date());
         const nowServer = new Date(nowClient.getServerZonedISOString());
-        const updatedAt = moment(nowServer).locale('en').format('YYYY-MM-DDTHH:mm:ss');
+        const updatedAt = formatMomentEn(moment(nowServer), 'YYYY-MM-DDTHH:mm:ss');
 
         dispatch(updateEnrollmentEventStatus(eventId, status, updatedAt));
     }, [dispatch, fromClientDate]);

--- a/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/EnrollmentPageDefault.container.tsx
+++ b/src/core_modules/capture-core/components/Pages/Enrollment/EnrollmentPageDefault/EnrollmentPageDefault.container.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import i18n from '@dhis2/d2-i18n';
-import moment from 'moment';
 import log from 'loglevel';
 import { errorCreator } from 'capture-core-utils';
 import { formatMomentEn } from 'capture-core-utils/date';
@@ -148,7 +147,7 @@ export const EnrollmentPageDefault = () => {
     const onUpdateEventStatus = useCallback((eventId: string, status: string) => {
         const nowClient = fromClientDate(new Date());
         const nowServer = new Date(nowClient.getServerZonedISOString());
-        const updatedAt = formatMomentEn(moment(nowServer), 'YYYY-MM-DDTHH:mm:ss');
+        const updatedAt = formatMomentEn(nowServer, 'YYYY-MM-DDTHH:mm:ss');
 
         dispatch(updateEnrollmentEventStatus(eventId, status, updatedAt));
     }, [dispatch, fromClientDate]);

--- a/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/EnrollmentAddEventPageDefault/EnrollmentAddEventPageDefault.container.tsx
+++ b/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/EnrollmentAddEventPageDefault/EnrollmentAddEventPageDefault.container.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import moment from 'moment';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTimeZoneConversion } from '@dhis2/app-runtime';
+import { formatMomentEn } from 'capture-core-utils/date';
 import i18n from '@dhis2/d2-i18n';
 import { NoticeBox } from '@dhis2/ui';
 import type { ReduxState } from '../../../App/withAppUrlSync.types';
@@ -72,7 +73,7 @@ export const EnrollmentAddEventPageDefault = ({
 
             const nowClient = fromClientDate(new Date());
             const nowServer = new Date(nowClient.getServerZonedISOString());
-            const updatedAt = moment(nowServer).locale('en').format('YYYY-MM-DDTHH:mm:ss');
+            const updatedAt = formatMomentEn(moment(nowServer), 'YYYY-MM-DDTHH:mm:ss');
 
             const eventsWithUpdatedDate = events.map((event: any) => ({
                 ...convertEventAttributeOptions(event),

--- a/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/EnrollmentAddEventPageDefault/EnrollmentAddEventPageDefault.container.tsx
+++ b/src/core_modules/capture-core/components/Pages/EnrollmentAddEvent/EnrollmentAddEventPageDefault/EnrollmentAddEventPageDefault.container.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo } from 'react';
-import moment from 'moment';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTimeZoneConversion } from '@dhis2/app-runtime';
 import { formatMomentEn } from 'capture-core-utils/date';
@@ -73,7 +72,7 @@ export const EnrollmentAddEventPageDefault = ({
 
             const nowClient = fromClientDate(new Date());
             const nowServer = new Date(nowClient.getServerZonedISOString());
-            const updatedAt = formatMomentEn(moment(nowServer), 'YYYY-MM-DDTHH:mm:ss');
+            const updatedAt = formatMomentEn(nowServer, 'YYYY-MM-DDTHH:mm:ss');
 
             const eventsWithUpdatedDate = events.map((event: any) => ({
                 ...convertEventAttributeOptions(event),

--- a/src/core_modules/capture-core/components/WidgetEnrollment/Actions/Complete/CompleteModal/CompleteModal.container.tsx
+++ b/src/core_modules/capture-core/components/WidgetEnrollment/Actions/Complete/CompleteModal/CompleteModal.container.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { useTimeZoneConversion } from '@dhis2/app-runtime';
 import moment from 'moment';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { CompleteModalComponent } from './CompleteModal.component';
 import { eventStatuses, plainStatus } from '../../../constants/status.const';
 import type { Props } from './completeModal.types';
@@ -43,7 +44,7 @@ export const CompleteModal = ({ enrollment, events, programStages, setOpenComple
     const onHandleCompleteEnrollmentAndEvents = useCallback(() => {
         const nowClient = fromClientDate(new Date());
         const nowServer = new Date(nowClient.getServerZonedISOString());
-        const updatedAt = moment(nowServer).locale('en').format('YYYY-MM-DDTHH:mm:ss');
+        const updatedAt = formatMomentEn(moment(nowServer), 'YYYY-MM-DDTHH:mm:ss');
         const eventsToComplete = events.reduce((acc, event) => {
             const { access } = programStages.find(p => p.id === event.programStage) || {} as any;
             if (event.status === eventStatuses.ACTIVE && access.data.write) {

--- a/src/core_modules/capture-core/components/WidgetEnrollment/Actions/Complete/CompleteModal/CompleteModal.container.tsx
+++ b/src/core_modules/capture-core/components/WidgetEnrollment/Actions/Complete/CompleteModal/CompleteModal.container.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
 import { useTimeZoneConversion } from '@dhis2/app-runtime';
-import moment from 'moment';
 import { formatMomentEn } from 'capture-core-utils/date';
 import { CompleteModalComponent } from './CompleteModal.component';
 import { eventStatuses, plainStatus } from '../../../constants/status.const';
@@ -44,7 +43,7 @@ export const CompleteModal = ({ enrollment, events, programStages, setOpenComple
     const onHandleCompleteEnrollmentAndEvents = useCallback(() => {
         const nowClient = fromClientDate(new Date());
         const nowServer = new Date(nowClient.getServerZonedISOString());
-        const updatedAt = formatMomentEn(moment(nowServer), 'YYYY-MM-DDTHH:mm:ss');
+        const updatedAt = formatMomentEn(nowServer, 'YYYY-MM-DDTHH:mm:ss');
         const eventsToComplete = events.reduce((acc, event) => {
             const { access } = programStages.find(p => p.id === event.programStage) || {} as any;
             if (event.status === eventStatuses.ACTIVE && access.data.write) {

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/getConvertedAddEvent.ts
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/getConvertedAddEvent.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { FEATURES, featureAvailable } from 'capture-core-utils';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { convertDataEntryToClientValues } from '../../DataEntry/common/convertDataEntryToClientValues';
 import { convertValue as convertToServerValue } from '../../../converters/clientToServer';
 import { convertMainEventClientToServer } from '../../../events/mainConverters';
@@ -32,7 +33,7 @@ export const getAddEventEnrollmentServerData = ({
     const mainDataServerValues: any = convertMainEventClientToServer(mainDataClientValues);
     const nowClient = fromClientDate(new Date());
     const nowServer = new Date(nowClient.getServerZonedISOString());
-    const updatedAt = moment(nowServer).locale('en').format('YYYY-MM-DDTHH:mm:ss');
+    const updatedAt = formatMomentEn(moment(nowServer), 'YYYY-MM-DDTHH:mm:ss');
 
     if (!mainDataServerValues.status) {
         mainDataServerValues.status = completed ? 'COMPLETED' : 'ACTIVE';

--- a/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/getConvertedAddEvent.ts
+++ b/src/core_modules/capture-core/components/WidgetEnrollmentEventNew/Validated/getConvertedAddEvent.ts
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { FEATURES, featureAvailable } from 'capture-core-utils';
 import { formatMomentEn } from 'capture-core-utils/date';
 import { convertDataEntryToClientValues } from '../../DataEntry/common/convertDataEntryToClientValues';
@@ -33,7 +32,7 @@ export const getAddEventEnrollmentServerData = ({
     const mainDataServerValues: any = convertMainEventClientToServer(mainDataClientValues);
     const nowClient = fromClientDate(new Date());
     const nowServer = new Date(nowClient.getServerZonedISOString());
-    const updatedAt = formatMomentEn(moment(nowServer), 'YYYY-MM-DDTHH:mm:ss');
+    const updatedAt = formatMomentEn(nowServer, 'YYYY-MM-DDTHH:mm:ss');
 
     if (!mainDataServerValues.status) {
         mainDataServerValues.status = completed ? 'COMPLETED' : 'ACTIVE';

--- a/src/core_modules/capture-core/components/WidgetEventSchedule/hooks/useDetermineSuggestedScheduleDate.ts
+++ b/src/core_modules/capture-core/components/WidgetEventSchedule/hooks/useDetermineSuggestedScheduleDate.ts
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { convertServerToClient, convertClientToForm } from '../../../converters';
 import { dataElementTypes } from '../../../metaData';
 
@@ -29,7 +30,7 @@ const getSuggestedDateByStandardInterval = (standardInterval: number, eventData:
         .sort(sortByMostRecentDate);
     if (!events.length) { return undefined; }
 
-    return moment(events[0].eventDate).add(standardInterval, 'days').format();
+    return formatMomentEn(moment(events[0].eventDate).add(standardInterval, 'days'), moment.defaultFormat);
 };
 
 type Props = {
@@ -67,9 +68,9 @@ const calculateSuggestedDateFromStart = ({
 }) => {
     let suggestedScheduleDate;
     if (generatedByEnrollmentDate || !displayIncidentDate) {
-        suggestedScheduleDate = moment(enrolledAt).add(minDaysFromStart, 'days').format();
+        suggestedScheduleDate = formatMomentEn(moment(enrolledAt).add(minDaysFromStart, 'days'), moment.defaultFormat);
     } else {
-        suggestedScheduleDate = moment(occurredAt).add(minDaysFromStart, 'days').format();
+        suggestedScheduleDate = formatMomentEn(moment(occurredAt).add(minDaysFromStart, 'days'), moment.defaultFormat);
     }
     return suggestedScheduleDate;
 };

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/helpers/eventFilters/clientConfigToApiEventFilterQueryCriteriaConverter/convertToEventFilterEventQueryCriteria.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/helpers/eventFilters/clientConfigToApiEventFilterQueryCriteriaConverter/convertToEventFilterEventQueryCriteria.ts
@@ -1,6 +1,7 @@
 import log from 'loglevel';
 import { errorCreator, pipe } from 'capture-core-utils';
 import moment from 'moment';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { dataElementTypes } from '../../../../../../metaData';
 import { getApiOptionSetFilter } from './optionSet';
 
@@ -73,8 +74,7 @@ const getTrueOnlyFilter = (): ApiDataFilterTrueOnly => ({
 
 const convertDate = (rawValue: string): string => {
     const momentDate = moment(rawValue);
-    momentDate.locale('en');
-    return momentDate.format('YYYY-MM-DD');
+    return formatMomentEn(momentDate, 'YYYY-MM-DD');
 };
 
 const getDateFilter = (dateFilter: DateFilterData): ApiDataFilterDate => {

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/helpers/eventFilters/clientConfigToApiEventFilterQueryCriteriaConverter/convertToEventFilterEventQueryCriteria.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/helpers/eventFilters/clientConfigToApiEventFilterQueryCriteriaConverter/convertToEventFilterEventQueryCriteria.ts
@@ -1,6 +1,5 @@
 import log from 'loglevel';
 import { errorCreator, pipe } from 'capture-core-utils';
-import moment from 'moment';
 import { formatMomentEn } from 'capture-core-utils/date';
 import { dataElementTypes } from '../../../../../../metaData';
 import { getApiOptionSetFilter } from './optionSet';
@@ -72,10 +71,8 @@ const getTrueOnlyFilter = (): ApiDataFilterTrueOnly => ({
     eq: 'true',
 });
 
-const convertDate = (rawValue: string): string => {
-    const momentDate = moment(rawValue);
-    return formatMomentEn(momentDate, 'YYYY-MM-DD');
-};
+const convertDate = (rawValue: string): string =>
+    formatMomentEn(rawValue, 'YYYY-MM-DD');
 
 const getDateFilter = (dateFilter: DateFilterData): ApiDataFilterDate => {
     const apiDateFilterContents = dateFilter.type === dateFilterTypes.RELATIVE ? {

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/helpers/eventFilters/clientConfigToApiEventFilterQueryCriteriaConverter/optionSet.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/helpers/eventFilters/clientConfigToApiEventFilterQueryCriteriaConverter/optionSet.ts
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { dataElementTypes } from '../../../../../../metaData';
 import type {
     ApiDataFilterOptionSet,
@@ -11,8 +12,7 @@ const stringifyNumber = (rawValue: number) => rawValue.toString();
 
 const convertDate = (rawValue: string): string => {
     const momentDate = moment(rawValue);
-    momentDate.locale('en');
-    return momentDate.format('YYYY-MM-DD');
+    return formatMomentEn(momentDate, 'YYYY-MM-DD');
 };
 
 const converterByType: any = {

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/helpers/eventFilters/clientConfigToApiEventFilterQueryCriteriaConverter/optionSet.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/helpers/eventFilters/clientConfigToApiEventFilterQueryCriteriaConverter/optionSet.ts
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { formatMomentEn } from 'capture-core-utils/date';
 import { dataElementTypes } from '../../../../../../metaData';
 import type {
@@ -10,10 +9,8 @@ import type {
 
 const stringifyNumber = (rawValue: number) => rawValue.toString();
 
-const convertDate = (rawValue: string): string => {
-    const momentDate = moment(rawValue);
-    return formatMomentEn(momentDate, 'YYYY-MM-DD');
-};
+const convertDate = (rawValue: string): string =>
+    formatMomentEn(rawValue, 'YYYY-MM-DD');
 
 const converterByType: any = {
     [dataElementTypes.NUMBER]: stringifyNumber,

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/getEventListData/getScheduledDateQueryArgs.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/getEventListData/getScheduledDateQueryArgs.ts
@@ -1,8 +1,8 @@
 import moment from 'moment';
-import { getFormattedStringFromMomentUsingEuropeanGlyphs } from 'capture-core-utils/date';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { statusTypes } from 'capture-core/events/statusTypes';
 
 export const getScheduledDateQueryArgs = (queryArgs: any) =>
     (queryArgs.status === statusTypes.SCHEDULE && !queryArgs.hasOwnProperty('scheduledAfter')
-        ? { ...queryArgs, scheduledAfter: getFormattedStringFromMomentUsingEuropeanGlyphs(moment()) }
+        ? { ...queryArgs, scheduledAfter: formatMomentEn(moment()) }
         : queryArgs);

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/getEventListData/getScheduledDateQueryArgs.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/helpers/getEventListData/getScheduledDateQueryArgs.ts
@@ -1,8 +1,7 @@
-import moment from 'moment';
 import { formatMomentEn } from 'capture-core-utils/date';
 import { statusTypes } from 'capture-core/events/statusTypes';
 
 export const getScheduledDateQueryArgs = (queryArgs: any) =>
     (queryArgs.status === statusTypes.SCHEDULE && !queryArgs.hasOwnProperty('scheduledAfter')
-        ? { ...queryArgs, scheduledAfter: formatMomentEn(moment()) }
+        ? { ...queryArgs, scheduledAfter: formatMomentEn(new Date()) }
         : queryArgs);

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/convertors.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/convertors.ts
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { formatMomentEn } from 'capture-core-utils/date';
 import {
     type BooleanFilterData,
     type DateFilterData,
@@ -46,8 +47,7 @@ const getAssigneeFilter = (filter: any) => ({
 
 const convertDate = (rawValue: string): string => {
     const momentDate = moment(rawValue);
-    momentDate.locale('en');
-    return momentDate.format('YYYY-MM-DD');
+    return formatMomentEn(momentDate, 'YYYY-MM-DD');
 };
 
 export const getDateFilter = (dateFilter: DateFilterData) => {

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/convertors.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/convertors.ts
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { formatMomentEn } from 'capture-core-utils/date';
 import {
     type BooleanFilterData,
@@ -45,10 +44,8 @@ const getAssigneeFilter = (filter: any) => ({
     assignedUsers: filter.assignedUser ? [filter.assignedUser.id] : undefined,
 });
 
-const convertDate = (rawValue: string): string => {
-    const momentDate = moment(rawValue);
-    return formatMomentEn(momentDate, 'YYYY-MM-DD');
-};
+const convertDate = (rawValue: string): string =>
+    formatMomentEn(rawValue, 'YYYY-MM-DD');
 
 export const getDateFilter = (dateFilter: DateFilterData) => {
     const apiDateFilterContents =

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/optionSet.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/optionSet.ts
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { dataElementTypes } from '../../../../../../metaData';
 import type { ApiDataFilterOptionSet } from '../../../types';
 import type { OptionSetFilterData } from '../../../../WorkingListsBase';
@@ -7,8 +8,7 @@ const stringifyNumber = (rawValue: number) => rawValue.toString();
 
 const convertDate = (rawValue: string): string => {
     const momentDate = moment(rawValue);
-    momentDate.locale('en');
-    return momentDate.format('YYYY-MM-DD');
+    return formatMomentEn(momentDate, 'YYYY-MM-DD');
 };
 
 const converterByType = {

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/optionSet.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/helpers/TEIFilters/clientConfigToApiTEIFilterQueryConverter/optionSet.ts
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { formatMomentEn } from 'capture-core-utils/date';
 import { dataElementTypes } from '../../../../../../metaData';
 import type { ApiDataFilterOptionSet } from '../../../types';
@@ -6,10 +5,8 @@ import type { OptionSetFilterData } from '../../../../WorkingListsBase';
 
 const stringifyNumber = (rawValue: number) => rawValue.toString();
 
-const convertDate = (rawValue: string): string => {
-    const momentDate = moment(rawValue);
-    return formatMomentEn(momentDate, 'YYYY-MM-DD');
-};
+const convertDate = (rawValue: string): string =>
+    formatMomentEn(rawValue, 'YYYY-MM-DD');
 
 const converterByType = {
     [dataElementTypes.NUMBER]: stringifyNumber,

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/dateConverter.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/dateConverter.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import moment from 'moment';
-import { getFormattedStringFromMomentUsingEuropeanGlyphs } from 'capture-core-utils/date';
+import { formatMomentEn } from 'capture-core-utils/date';
 
 import type {
     DateFilterData,
@@ -29,8 +29,8 @@ const relativeConvertersForPeriods = {
         const endDate = startDate;
 
         return [
-            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
-            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
+            `ge:${formatMomentEn(startDate)}`,
+            `le:${formatMomentEn(endDate)}`,
         ];
     },
     [periods.THIS_WEEK]: () => {
@@ -38,8 +38,8 @@ const relativeConvertersForPeriods = {
         const endDate = moment().endOf('week');
 
         return [
-            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
-            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
+            `ge:${formatMomentEn(startDate)}`,
+            `le:${formatMomentEn(endDate)}`,
         ];
     },
     [periods.THIS_MONTH]: () => {
@@ -47,8 +47,8 @@ const relativeConvertersForPeriods = {
         const endDate = moment().endOf('month');
 
         return [
-            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
-            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
+            `ge:${formatMomentEn(startDate)}`,
+            `le:${formatMomentEn(endDate)}`,
         ];
     },
     [periods.THIS_YEAR]: () => {
@@ -56,8 +56,8 @@ const relativeConvertersForPeriods = {
         const endDate = moment().endOf('year');
 
         return [
-            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
-            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
+            `ge:${formatMomentEn(startDate)}`,
+            `le:${formatMomentEn(endDate)}`,
         ];
     },
     [periods.LAST_WEEK]: () => {
@@ -65,8 +65,8 @@ const relativeConvertersForPeriods = {
         const endDate = moment().subtract(1, 'weeks').endOf('week');
 
         return [
-            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
-            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
+            `ge:${formatMomentEn(startDate)}`,
+            `le:${formatMomentEn(endDate)}`,
         ];
     },
     [periods.LAST_MONTH]: () => {
@@ -74,8 +74,8 @@ const relativeConvertersForPeriods = {
         const endDate = moment().subtract(1, 'months').endOf('month');
 
         return [
-            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
-            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
+            `ge:${formatMomentEn(startDate)}`,
+            `le:${formatMomentEn(endDate)}`,
         ];
     },
     [periods.LAST_3_MONTHS]: () => {
@@ -83,8 +83,8 @@ const relativeConvertersForPeriods = {
         const endDate = moment().subtract(1, 'months').endOf('month');
 
         return [
-            `ge:${getFormattedStringFromMomentUsingEuropeanGlyphs(startDate)}`,
-            `le:${getFormattedStringFromMomentUsingEuropeanGlyphs(endDate)}`,
+            `ge:${formatMomentEn(startDate)}`,
+            `le:${formatMomentEn(endDate)}`,
         ];
     },
 };
@@ -114,13 +114,13 @@ function convertCustomRelativeDate(sourceValue: RelativeDateFilterData) {
 
     if (startBuffer || startBuffer === 0) {
         const startDate = moment().add(startBuffer, 'days');
-        const startBufferFilterRequest = getFormattedStringFromMomentUsingEuropeanGlyphs(startDate);
+        const startBufferFilterRequest = formatMomentEn(startDate);
         requestData.push(`ge:${startBufferFilterRequest}`);
     }
 
     if (endBuffer || endBuffer === 0) {
         const endDate = moment().add(endBuffer, 'days');
-        const endBufferFilterRequest = getFormattedStringFromMomentUsingEuropeanGlyphs(endDate);
+        const endBufferFilterRequest = formatMomentEn(endDate);
         requestData.push(`le:${endBufferFilterRequest}`);
     }
     return requestData;
@@ -147,12 +147,12 @@ function convertRelativeDate(
 function convertAbsoluteDate(sourceValue: AbsoluteDateFilterData) {
     const requestData: string[] = [];
     if (sourceValue.ge) {
-        const fromFilterRequest = getFormattedStringFromMomentUsingEuropeanGlyphs(moment(sourceValue.ge));
+        const fromFilterRequest = formatMomentEn(moment(sourceValue.ge));
         requestData.push(`ge:${fromFilterRequest}`);
     }
 
     if (sourceValue.le) {
-        const toFilterRequest = getFormattedStringFromMomentUsingEuropeanGlyphs(moment(sourceValue.le));
+        const toFilterRequest = formatMomentEn(moment(sourceValue.le));
         requestData.push(`le:${toFilterRequest}`);
     }
     return requestData?.join(':');

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/optionSet/basicDataTypeConverters.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/optionSet/basicDataTypeConverters.ts
@@ -1,12 +1,12 @@
 import moment from 'moment';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { dataElementTypes } from '../../../../../../../metaData';
 
 const stringifyNumber = (rawValue: number) => rawValue.toString();
 
 function convertDate(isoString: string): string {
     const momentDate = moment(isoString);
-    momentDate.locale('en');
-    return momentDate.format('YYYY-MM-DD');
+    return formatMomentEn(momentDate, 'YYYY-MM-DD');
 }
 
 const valueConvertersForType = {

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/optionSet/basicDataTypeConverters.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/buildFilterQueryArgs/filterConverters/optionSet/basicDataTypeConverters.ts
@@ -1,12 +1,10 @@
-import moment from 'moment';
 import { formatMomentEn } from 'capture-core-utils/date';
 import { dataElementTypes } from '../../../../../../../metaData';
 
 const stringifyNumber = (rawValue: number) => rawValue.toString();
 
 function convertDate(isoString: string): string {
-    const momentDate = moment(isoString);
-    return formatMomentEn(momentDate, 'YYYY-MM-DD');
+    return formatMomentEn(isoString, 'YYYY-MM-DD');
 }
 
 const valueConvertersForType = {

--- a/src/core_modules/capture-core/converters/clientToForm.ts
+++ b/src/core_modules/capture-core/converters/clientToForm.ts
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { convertIsoToLocalCalendar } from '../utils/converters/date';
 import { dataElementTypes } from '../metaData';
 
@@ -27,7 +28,7 @@ function convertDateForEdit(rawValue: string): string {
 
 function convertDateTimeForEdit(rawValue: string): DateTimeFormValue {
     const dateTime = moment(rawValue);
-    const timeString = dateTime.format('HH:mm');
+    const timeString = formatMomentEn(dateTime, 'HH:mm');
     return {
         date: convertIsoToLocalCalendar(rawValue),
         time: timeString,
@@ -36,7 +37,7 @@ function convertDateTimeForEdit(rawValue: string): DateTimeFormValue {
 
 function convertTimeForEdit(rawValue: string) {
     const momentTime = moment(rawValue, 'HH:mm', true);
-    return momentTime.format('HH:mm');
+    return formatMomentEn(momentTime, 'HH:mm');
 }
 
 function convertAgeForEdit(rawValue: string): AgeFormValue {

--- a/src/core_modules/capture-core/converters/clientToForm.ts
+++ b/src/core_modules/capture-core/converters/clientToForm.ts
@@ -27,11 +27,9 @@ function convertDateForEdit(rawValue: string): string {
 }
 
 function convertDateTimeForEdit(rawValue: string): DateTimeFormValue {
-    const dateTime = moment(rawValue);
-    const timeString = formatMomentEn(dateTime, 'HH:mm');
     return {
         date: convertIsoToLocalCalendar(rawValue),
-        time: timeString,
+        time: formatMomentEn(rawValue, 'HH:mm'),
     };
 }
 

--- a/src/core_modules/capture-core/converters/clientToList.tsx
+++ b/src/core_modules/capture-core/converters/clientToList.tsx
@@ -15,7 +15,7 @@ function convertDateForListDisplay(rawValue: string): string {
 }
 
 function convertDateTimeForListDisplay(rawValue: string): string {
-    const momentDate = moment(rawValue).locale('en');
+    const momentDate = moment(rawValue);
     const timeString = momentDate.format('HH:mm');
     const localDate = convertIsoToLocalCalendar(rawValue);
     return `${localDate} ${timeString}`;

--- a/src/core_modules/capture-core/converters/clientToList.tsx
+++ b/src/core_modules/capture-core/converters/clientToList.tsx
@@ -11,13 +11,12 @@ import { MinimalCoordinates, PolygonCoordinates } from '../components/Coordinate
 import { TooltipOrgUnit } from '../components/Tooltips/TooltipOrgUnit';
 
 function convertDateForListDisplay(rawValue: string): string {
-    return convertIsoToLocalCalendar(rawValue);
+    return moment.localeData().postformat(convertIsoToLocalCalendar(rawValue));
 }
 
 function convertDateTimeForListDisplay(rawValue: string): string {
-    const momentDate = moment(rawValue);
-    const timeString = momentDate.format('HH:mm');
-    const localDate = convertIsoToLocalCalendar(rawValue);
+    const timeString = moment(rawValue).format('HH:mm');
+    const localDate = moment.localeData().postformat(convertIsoToLocalCalendar(rawValue));
     return `${localDate} ${timeString}`;
 }
 
@@ -97,9 +96,9 @@ const valueConvertersForType = {
     [dataElementTypes.BOOLEAN]: (rawValue: boolean) => (rawValue ? i18n.t('Yes') : i18n.t('No')),
     [dataElementTypes.COORDINATE]: MinimalCoordinates,
     [dataElementTypes.DATE]: convertDateForListDisplay,
-    [dataElementTypes.DATE_RANGE]: value => convertRangeForDisplay(convertIsoToLocalCalendar, value),
+    [dataElementTypes.DATE_RANGE]: value => convertRangeForDisplay(convertDateForListDisplay, value),
     [dataElementTypes.DATETIME]: convertDateTimeForListDisplay,
-    [dataElementTypes.DATETIME_RANGE]: value => convertRangeForDisplay(convertIsoToLocalCalendar, value),
+    [dataElementTypes.DATETIME_RANGE]: value => convertRangeForDisplay(convertDateForListDisplay, value),
     [dataElementTypes.FILE_RESOURCE]: convertFileForDisplay,
     [dataElementTypes.IMAGE]: convertImageForDisplay,
     [dataElementTypes.INTEGER]: stringifyNumber,

--- a/src/core_modules/capture-core/converters/clientToList.tsx
+++ b/src/core_modules/capture-core/converters/clientToList.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import moment from 'moment';
 import i18n from '@dhis2/d2-i18n';
 import { Tag } from '@dhis2/ui';
 import { PreviewImage } from 'capture-ui';
+import { formatMomentEn } from 'capture-core-utils/date';
 import type { DataElement } from '../metaData';
 import { dataElementTypes } from '../metaData';
 import { convertIsoToLocalCalendar } from '../utils/converters/date';
@@ -15,8 +15,7 @@ function convertDateForListDisplay(rawValue: string): string {
 }
 
 function convertDateTimeForListDisplay(rawValue: string): string {
-    const momentDate = moment(rawValue).locale('en');
-    const timeString = momentDate.format('HH:mm');
+    const timeString = formatMomentEn(rawValue, 'HH:mm');
     const localDate = convertIsoToLocalCalendar(rawValue);
     return `${localDate} ${timeString}`;
 }

--- a/src/core_modules/capture-core/converters/clientToList.tsx
+++ b/src/core_modules/capture-core/converters/clientToList.tsx
@@ -11,12 +11,13 @@ import { MinimalCoordinates, PolygonCoordinates } from '../components/Coordinate
 import { TooltipOrgUnit } from '../components/Tooltips/TooltipOrgUnit';
 
 function convertDateForListDisplay(rawValue: string): string {
-    return moment.localeData().postformat(convertIsoToLocalCalendar(rawValue));
+    return convertIsoToLocalCalendar(rawValue);
 }
 
 function convertDateTimeForListDisplay(rawValue: string): string {
-    const timeString = moment(rawValue).format('HH:mm');
-    const localDate = moment.localeData().postformat(convertIsoToLocalCalendar(rawValue));
+    const momentDate = moment(rawValue).locale('en');
+    const timeString = momentDate.format('HH:mm');
+    const localDate = convertIsoToLocalCalendar(rawValue);
     return `${localDate} ${timeString}`;
 }
 
@@ -96,9 +97,9 @@ const valueConvertersForType = {
     [dataElementTypes.BOOLEAN]: (rawValue: boolean) => (rawValue ? i18n.t('Yes') : i18n.t('No')),
     [dataElementTypes.COORDINATE]: MinimalCoordinates,
     [dataElementTypes.DATE]: convertDateForListDisplay,
-    [dataElementTypes.DATE_RANGE]: value => convertRangeForDisplay(convertDateForListDisplay, value),
+    [dataElementTypes.DATE_RANGE]: value => convertRangeForDisplay(convertIsoToLocalCalendar, value),
     [dataElementTypes.DATETIME]: convertDateTimeForListDisplay,
-    [dataElementTypes.DATETIME_RANGE]: value => convertRangeForDisplay(convertDateForListDisplay, value),
+    [dataElementTypes.DATETIME_RANGE]: value => convertRangeForDisplay(convertIsoToLocalCalendar, value),
     [dataElementTypes.FILE_RESOURCE]: convertFileForDisplay,
     [dataElementTypes.IMAGE]: convertImageForDisplay,
     [dataElementTypes.INTEGER]: stringifyNumber,

--- a/src/core_modules/capture-core/converters/clientToServer.ts
+++ b/src/core_modules/capture-core/converters/clientToServer.ts
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { FEATURES, featureAvailable } from 'capture-core-utils';
 import { formatMomentEn } from 'capture-core-utils/date';
 import type { ApiAssignedUser } from 'capture-core-utils/types/api-types';
@@ -19,9 +18,7 @@ type Assignee = {
 };
 
 function convertDate(rawValue: string): string {
-    const editedDate = rawValue;
-    const momentDate = moment(editedDate);
-    return formatMomentEn(momentDate, 'YYYY-MM-DD');
+    return formatMomentEn(rawValue, 'YYYY-MM-DD');
 }
 
 function convertRange(parser: (value: any) => any, rangeValue: RangeValue) {

--- a/src/core_modules/capture-core/converters/clientToServer.ts
+++ b/src/core_modules/capture-core/converters/clientToServer.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { FEATURES, featureAvailable } from 'capture-core-utils';
+import { formatMomentEn } from 'capture-core-utils/date';
 import type { ApiAssignedUser } from 'capture-core-utils/types/api-types';
 import { dataElementTypes } from '../metaData';
 import { stringifyNumber } from './common/stringifyNumber';
@@ -20,8 +21,7 @@ type Assignee = {
 function convertDate(rawValue: string): string {
     const editedDate = rawValue;
     const momentDate = moment(editedDate);
-    momentDate.locale('en');
-    return momentDate.format('YYYY-MM-DD');
+    return formatMomentEn(momentDate, 'YYYY-MM-DD');
 }
 
 function convertRange(parser: (value: any) => any, rangeValue: RangeValue) {

--- a/src/core_modules/capture-core/converters/clientToView.tsx
+++ b/src/core_modules/capture-core/converters/clientToView.tsx
@@ -14,7 +14,7 @@ function convertDateForView(rawValue: string): string {
     return convertIsoToLocalCalendar(rawValue);
 }
 function convertDateTimeForView(rawValue: string): string {
-    const momentDate = moment(rawValue).locale('en');
+    const momentDate = moment(rawValue);
     const timeString = momentDate.format('HH:mm');
 
     const localDate = convertIsoToLocalCalendar(rawValue);

--- a/src/core_modules/capture-core/converters/clientToView.tsx
+++ b/src/core_modules/capture-core/converters/clientToView.tsx
@@ -11,13 +11,11 @@ import { TooltipOrgUnit } from '../components/Tooltips/TooltipOrgUnit';
 
 
 function convertDateForView(rawValue: string): string {
-    return convertIsoToLocalCalendar(rawValue);
+    return moment.localeData().postformat(convertIsoToLocalCalendar(rawValue));
 }
 function convertDateTimeForView(rawValue: string): string {
-    const momentDate = moment(rawValue);
-    const timeString = momentDate.format('HH:mm');
-
-    const localDate = convertIsoToLocalCalendar(rawValue);
+    const timeString = moment(rawValue).format('HH:mm');
+    const localDate = moment.localeData().postformat(convertIsoToLocalCalendar(rawValue));
     return `${localDate} ${timeString}`;
 }
 

--- a/src/core_modules/capture-core/converters/clientToView.tsx
+++ b/src/core_modules/capture-core/converters/clientToView.tsx
@@ -11,11 +11,13 @@ import { TooltipOrgUnit } from '../components/Tooltips/TooltipOrgUnit';
 
 
 function convertDateForView(rawValue: string): string {
-    return moment.localeData().postformat(convertIsoToLocalCalendar(rawValue));
+    return convertIsoToLocalCalendar(rawValue);
 }
 function convertDateTimeForView(rawValue: string): string {
-    const timeString = moment(rawValue).format('HH:mm');
-    const localDate = moment.localeData().postformat(convertIsoToLocalCalendar(rawValue));
+    const momentDate = moment(rawValue).locale('en');
+    const timeString = momentDate.format('HH:mm');
+
+    const localDate = convertIsoToLocalCalendar(rawValue);
     return `${localDate} ${timeString}`;
 }
 

--- a/src/core_modules/capture-core/converters/clientToView.tsx
+++ b/src/core_modules/capture-core/converters/clientToView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import i18n from '@dhis2/d2-i18n';
 import { PreviewImage } from 'capture-ui';
+import { formatMomentEn } from 'capture-core-utils/date';
 import type { DataElement } from '../metaData';
 import { dataElementTypes } from '../metaData';
 import { convertIsoToLocalCalendar } from '../utils/converters/date';
@@ -14,9 +15,7 @@ function convertDateForView(rawValue: string): string {
     return convertIsoToLocalCalendar(rawValue);
 }
 function convertDateTimeForView(rawValue: string): string {
-    const momentDate = moment(rawValue).locale('en');
-    const timeString = momentDate.format('HH:mm');
-
+    const timeString = formatMomentEn(rawValue, 'HH:mm');
     const localDate = convertIsoToLocalCalendar(rawValue);
     return `${localDate} ${timeString}`;
 }

--- a/src/core_modules/capture-core/converters/formToClient.ts
+++ b/src/core_modules/capture-core/converters/formToClient.ts
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import isString from 'd2-utilizr/lib/isString';
 import { parseNumber, parseTime } from 'capture-core-utils/parsers';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { dataElementTypes } from '../metaData';
 import { convertLocalToIsoCalendar } from '../utils/converters/date';
 
@@ -46,8 +47,7 @@ function convertTime(timeValue: string) {
     const parsedTime = parseTime(timeValue);
     if (!parsedTime.isValid) return null;
     const momentTime = parsedTime.momentTime;
-    momentTime.locale('en');
-    return momentTime.format('HH:mm');
+    return formatMomentEn(momentTime, 'HH:mm');
 }
 
 function convertAge(ageValue: any) {

--- a/src/core_modules/capture-core/rules/converters/dateUtils.ts
+++ b/src/core_modules/capture-core/rules/converters/dateUtils.ts
@@ -1,7 +1,7 @@
 /* eslint-disable class-methods-use-this */
 import moment from 'moment';
 import type { IDateUtils } from '@dhis2/rules-engine-javascript';
-import { getFormattedStringFromMomentUsingEuropeanGlyphs } from 'capture-core-utils/date';
+import { formatMomentEn } from 'capture-core-utils/date';
 
 const momentFormat = 'YYYY-MM-DD';
 const momentRegex = /^\d{4}-\d{2}-\d{2}$/g;
@@ -15,7 +15,7 @@ function rulesDateToMoment(rulesEngineValue: string | null): any {
     return moment(rulesEngineValue, momentFormat);
 }
 function momentToRulesDate(momentObject: any): string {
-    return getFormattedStringFromMomentUsingEuropeanGlyphs(momentObject);
+    return formatMomentEn(momentObject);
 }
 function between(unit: string, firstRulesDate: string | null, secondRulesDate: string | null): number {
     const firstDate = rulesDateToMoment(firstRulesDate);

--- a/src/core_modules/capture-core/rules/converters/inputConverter.ts
+++ b/src/core_modules/capture-core/rules/converters/inputConverter.ts
@@ -1,6 +1,5 @@
 /* eslint-disable class-methods-use-this */
 import log from 'loglevel';
-import moment from 'moment';
 import type { IConvertInputRulesValue } from '@dhis2/rules-engine-javascript';
 import { formatMomentEn } from 'capture-core-utils/date';
 
@@ -23,8 +22,7 @@ export const inputConverter: IConvertInputRulesValue = {
         if (!value) {
             return null;
         }
-        const momentObject = moment(value);
-        return formatMomentEn(momentObject, dateMomentFormat);
+        return formatMomentEn(value, dateMomentFormat);
     },
     convertDateTime: convertStringValue,
     convertTime: convertStringValue,

--- a/src/core_modules/capture-core/rules/converters/inputConverter.ts
+++ b/src/core_modules/capture-core/rules/converters/inputConverter.ts
@@ -2,6 +2,7 @@
 import log from 'loglevel';
 import moment from 'moment';
 import type { IConvertInputRulesValue } from '@dhis2/rules-engine-javascript';
+import { formatMomentEn } from 'capture-core-utils/date';
 
 const dateMomentFormat = 'YYYY-MM-DD';
 
@@ -23,8 +24,7 @@ export const inputConverter: IConvertInputRulesValue = {
             return null;
         }
         const momentObject = moment(value);
-        momentObject.locale('en');
-        return momentObject.format(dateMomentFormat);
+        return formatMomentEn(momentObject, dateMomentFormat);
     },
     convertDateTime: convertStringValue,
     convertTime: convertStringValue,

--- a/src/core_modules/capture-core/rules/converters/outputConverter.ts
+++ b/src/core_modules/capture-core/rules/converters/outputConverter.ts
@@ -2,6 +2,7 @@
 import log from 'loglevel';
 import moment from 'moment';
 import type { IConvertOutputRulesEffectsValue } from '@dhis2/rules-engine-javascript';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { convertMomentToDateFormatString } from '../../utils/converters/date';
 
 
@@ -26,7 +27,7 @@ export const outputConverter: IConvertOutputRulesEffectsValue = {
         const momentDateTime = moment(value);
         return {
             date: convertMomentToDateFormatString(momentDateTime),
-            time: momentDateTime.format('HH:mm'),
+            time: formatMomentEn(momentDateTime, 'HH:mm'),
         };
     },
     convertTime: (value: string): string => value,

--- a/src/core_modules/capture-core/utils/converters/date/convertIsoToLocalCalendar.ts
+++ b/src/core_modules/capture-core/utils/converters/date/convertIsoToLocalCalendar.ts
@@ -3,7 +3,7 @@ import {
     convertFromIso8601,
 } from '@dhis2/multi-calendar-dates';
 import { systemSettingsStore } from 'capture-core/metaDataMemoryStores';
-import { padWithZeros } from 'capture-core-utils/date';
+import { formatMomentEn, padWithZeros } from 'capture-core-utils/date';
 
 /**
  * Converts a date from ISO calendar to local calendar
@@ -17,12 +17,12 @@ export function convertIsoToLocalCalendar(isoDate: string | null | undefined): s
         return '';
     }
 
-    const momentDate = moment(isoDate).locale('en');
+    const momentDate = moment(isoDate);
     if (!momentDate.isValid()) {
         return '';
     }
 
-    const formattedIsoDate = momentDate.format('YYYY-MM-DD');
+    const formattedIsoDate = formatMomentEn(momentDate, 'YYYY-MM-DD');
 
     const calendar = systemSettingsStore.get().calendar;
     const dateFormat = systemSettingsStore.get().dateFormat;

--- a/src/core_modules/capture-core/utils/converters/date/dateObjectToDateFormatString.ts
+++ b/src/core_modules/capture-core/utils/converters/date/dateObjectToDateFormatString.ts
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { formatMomentEn } from 'capture-core-utils/date';
 import { convertIsoToLocalCalendar } from './convertIsoToLocalCalendar';
 
@@ -9,7 +8,6 @@ import { convertIsoToLocalCalendar } from './convertIsoToLocalCalendar';
  * @returns {string}
  */
 export function convertDateObjectToDateFormatString(dateValue: Date | any) {
-    const momentDate = moment(dateValue);
-    const dateString = formatMomentEn(momentDate, 'YYYY-MM-DD');
+    const dateString = formatMomentEn(dateValue, 'YYYY-MM-DD');
     return convertIsoToLocalCalendar(dateString);
 }

--- a/src/core_modules/capture-core/utils/converters/date/dateObjectToDateFormatString.ts
+++ b/src/core_modules/capture-core/utils/converters/date/dateObjectToDateFormatString.ts
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { formatMomentEn } from 'capture-core-utils/date';
 import { convertIsoToLocalCalendar } from './convertIsoToLocalCalendar';
 
 /**
@@ -9,6 +10,6 @@ import { convertIsoToLocalCalendar } from './convertIsoToLocalCalendar';
  */
 export function convertDateObjectToDateFormatString(dateValue: Date | any) {
     const momentDate = moment(dateValue);
-    const dateString = momentDate.format('YYYY-MM-DD');
+    const dateString = formatMomentEn(momentDate, 'YYYY-MM-DD');
     return convertIsoToLocalCalendar(dateString);
 }

--- a/src/core_modules/capture-core/utils/converters/date/momentToDateFormatString.ts
+++ b/src/core_modules/capture-core/utils/converters/date/momentToDateFormatString.ts
@@ -1,3 +1,4 @@
+import { formatMomentEn } from 'capture-core-utils/date';
 import { systemSettingsStore } from '../../../metaDataMemoryStores';
 
 /**
@@ -8,6 +9,5 @@ import { systemSettingsStore } from '../../../metaDataMemoryStores';
  */
 export function convertMomentToDateFormatString(moment: any) {
     const dateFormat = systemSettingsStore.get().dateFormat;
-    const formattedDateString = moment.format(dateFormat);
-    return formattedDateString;
+    return formatMomentEn(moment, dateFormat);
 }


### PR DESCRIPTION
[DHIS2-19014](https://dhis2.atlassian.net/browse/DHIS2-19014)

This PR renames the date-formatting utility and broadens its signature, then migrates every call site across the codebase.

## Core change

```ts
// Before
getFormattedStringFromMomentUsingEuropeanGlyphs(
  momentDate: Moment,
  format?: string
)

// After
formatMomentEn(
  input: MomentInput,
  format?: string
)
```

The new function accepts any `MomentInput` (not just a `Moment` instance), constructs the moment internally, and forces the `en` locale.

## Two categories of call-site changes

### 1. Bug fixes
Several sites used bare `moment().format()` without `.locale('en')`, which would produce locale-dependent numerals (e.g. Arabic `٠١٢٣`). These now go through `formatMomentEn`.

### 2. Mechanical renames
Sites that already called the old helper or manually did `.locale('en').format()` are consolidated to the new one-liner.


[DHIS2-19014]: https://dhis2.atlassian.net/browse/DHIS2-19014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ