### PR TITLE
fix: [DHIS2-21348] Console log errors if a TEA associated with a optionSet is empty

### DIFF
--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/hooks/useDataSource.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/hooks/useDataSource.ts
@@ -61,15 +61,16 @@ export const useDataSource = (
                             // TODO: Need is equal comparer for types because `sourceValue` and `option` can be an object
                             // for example (for some data element types) and we can't do strict comparison.
                             const option = options.find(o => o.value === clientValue);
-                            if (!option) {
-                                log.error(
-                                    errorCreator(
-                                        'Missing value in options')(
-                                        { id, clientValue, options }),
-                                );
-                                acc[id] = convertClientToList(clientValue, type);
-                            } else {
+                            if (option) {
                                 acc[id] = option.text;
+                            } else {
+                                if (clientValue != null && clientValue !== '') {
+                                    log.error(
+                                        errorCreator('Missing value in options')(
+                                            { id, clientValue, options }),
+                                    );
+                                }
+                                acc[id] = convertClientToList(clientValue, type);
                             }
                         }
                     } else {


### PR DESCRIPTION
[DHIS2-21348](https://dhis2.atlassian.net/browse/DHIS2-21348)

Suppresses spurious error logs when a working list option value is null or empty.

Previously, the code logged an error for every missing option lookup—including when clientValue was `null` or `''`, which is expected and not an error. The logic is restructured to only log when a non-empty value genuinely has no matching option:

[DHIS2-21348]: https://dhis2.atlassian.net/browse/DHIS2-21348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ