### PR TITLE
fix: [DHIS2-18592] Not saving an option that starts or ends with a space

### DIFF
--- a/src/core_modules/capture-core/components/Pages/NewRelationship/TeiRelationship/SearchResults/TeiRelationshipSearchResults.component.tsx
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/TeiRelationship/SearchResults/TeiRelationshipSearchResults.component.tsx
@@ -124,7 +124,7 @@ class TeiRelationshipSearchResultsPlain extends React.Component<Props> {
             .filter(key => searchValues[key] !== null)
             .map((key) => {
                 const element = searchForm.getElement(key);
-                const value = convertFormToClient(searchValues[key], element.type);
+                const value = convertFormToClient(searchValues[key], element.type, element);
                 return { name: element.formName, value, id: element.id, type: element.type };
             });
     }

--- a/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchForm.container.ts
+++ b/src/core_modules/capture-core/components/SearchBox/SearchForm/SearchForm.container.ts
@@ -75,10 +75,11 @@ const collectCurrentSearchTerms = (
     const searchTerms = formsValues[formId] || {};
     return Object.keys(searchTerms)
         .reduce((accumulated: CurrentSearchTerms, attributeValueKey) => {
-            const { name, id, type } = attributeSearchForm.getElement(attributeValueKey);
+            const element = attributeSearchForm.getElement(attributeValueKey);
+            const { name, id, type } = element;
             const value = searchTerms[attributeValueKey];
             if (isValueContainingCharacter(value)) {
-                const convertedValue = convertFormToClient(value, type);
+                const convertedValue = convertFormToClient(value, type, element);
                 return [...accumulated, { name, value: convertedValue, id, type }];
             }
             return accumulated;

--- a/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/DataElement.tsx
+++ b/src/core_modules/capture-core/components/WidgetProfile/DataEntry/FormFoundation/DataElement.tsx
@@ -109,6 +109,7 @@ const buildDataElementUnique = (
             const serverValue = pipe(convertFormToClient, convertClientToServer)(
                 value,
                 trackedEntityAttribute.valueType,
+                dataElement,
             );
 
             if (contextProps.onGetUnsavedAttributeValues) {

--- a/src/core_modules/capture-core/converters/formToClient.ts
+++ b/src/core_modules/capture-core/converters/formToClient.ts
@@ -2,6 +2,7 @@ import moment from 'moment';
 import isString from 'd2-utilizr/lib/isString';
 import { parseNumber, parseTime } from 'capture-core-utils/parsers';
 import { dataElementTypes } from '../metaData';
+import type { DataElement } from '../metaData';
 import { convertLocalToIsoCalendar } from '../utils/converters/date';
 
 type DateTimeValue = {
@@ -85,16 +86,20 @@ const valueConvertersForType = {
     [dataElementTypes.AGE]: convertAge,
 };
 
-export function convertValue(value: any, type: keyof typeof dataElementTypes) {
+export function convertValue(value: any, type: keyof typeof dataElementTypes, element?: DataElement) {
     if (value == null) {
         return null;
     }
 
     let toConvertValue;
     if (isString(value)) {
-        toConvertValue = value.trim();
-        if (!toConvertValue) {
-            return null;
+        if (element?.optionSet) {
+            toConvertValue = value;
+        } else {
+            toConvertValue = value.trim();
+            if (!toConvertValue) {
+                return null;
+            }
         }
     } else {
         toConvertValue = value;

--- a/src/core_modules/capture-core/converters/formToClient.ts
+++ b/src/core_modules/capture-core/converters/formToClient.ts
@@ -97,9 +97,9 @@ export function convertValue(value: any, type: keyof typeof dataElementTypes, el
             toConvertValue = value;
         } else {
             toConvertValue = value.trim();
-            if (!toConvertValue) {
-                return null;
-            }
+        }
+        if (!toConvertValue) {
+            return null;
         }
     } else {
         toConvertValue = value;

--- a/src/core_modules/capture-core/converters/searchFormToServer.ts
+++ b/src/core_modules/capture-core/converters/searchFormToServer.ts
@@ -9,8 +9,7 @@ type FormValues = { [key: string]: any };
 const convertValuePipe = pipeD2(convertFormToClient, convertClientToServer);
 
 const convertString = (formValue: string, dataElement: DataElement, searchOperator: SearchOperator) => {
-    const skipTrim = dataElement.optionSet && dataElement.type !== dataElementTypes.MULTI_TEXT;
-    const sanitizedString = skipTrim ? formValue : formValue.trim();
+    const sanitizedString = dataElement.optionSet ? formValue : formValue.trim();
     const convertedString = dataElement.convertValue(sanitizedString, convertValuePipe);
     return `${dataElement.id}:${searchOperator.toLowerCase()}:${escapeString(convertedString)}`;
 };

--- a/src/core_modules/capture-core/converters/searchFormToServer.ts
+++ b/src/core_modules/capture-core/converters/searchFormToServer.ts
@@ -9,7 +9,8 @@ type FormValues = { [key: string]: any };
 const convertValuePipe = pipeD2(convertFormToClient, convertClientToServer);
 
 const convertString = (formValue: string, dataElement: DataElement, searchOperator: SearchOperator) => {
-    const sanitizedString = dataElement.optionSet ? formValue : formValue.trim();
+    const skipTrim = dataElement.optionSet && dataElement.type !== dataElementTypes.MULTI_TEXT;
+    const sanitizedString = skipTrim ? formValue : formValue.trim();
     const convertedString = dataElement.convertValue(sanitizedString, convertValuePipe);
     return `${dataElement.id}:${searchOperator.toLowerCase()}:${escapeString(convertedString)}`;
 };

--- a/src/core_modules/capture-core/converters/searchFormToServer.ts
+++ b/src/core_modules/capture-core/converters/searchFormToServer.ts
@@ -9,7 +9,7 @@ type FormValues = { [key: string]: any };
 const convertValuePipe = pipeD2(convertFormToClient, convertClientToServer);
 
 const convertString = (formValue: string, dataElement: DataElement, searchOperator: SearchOperator) => {
-    const sanitizedString = formValue.trim();
+    const sanitizedString = dataElement.optionSet ? formValue : formValue.trim();
     const convertedString = dataElement.convertValue(sanitizedString, convertValuePipe);
     return `${dataElement.id}:${searchOperator.toLowerCase()}:${escapeString(convertedString)}`;
 };

--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/enrollment/DataElementFactory.ts
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/programs/factory/enrollment/DataElementFactory.ts
@@ -129,7 +129,7 @@ export class DataElementFactory {
                 const serverValue = pipe(
                     convertFormToClient,
                     convertClientToServer,
-                )(value, cachedTrackedEntityAttribute.valueType);
+                )(value, cachedTrackedEntityAttribute.valueType, dataElement);
 
                 if (contextProps.onGetUnsavedAttributeValues) {
                     const unsavedAttributeValues = contextProps.onGetUnsavedAttributeValues(dataElement.id);

--- a/src/core_modules/capture-core/metaDataMemoryStoreBuilders/trackedEntityTypes/factory/TrackedEntityType/DataElementFactory.ts
+++ b/src/core_modules/capture-core/metaDataMemoryStoreBuilders/trackedEntityTypes/factory/TrackedEntityType/DataElementFactory.ts
@@ -136,7 +136,7 @@ export class DataElementFactory {
                     const serverValue = pipe(
                         convertFormToClient,
                         convertClientToServer,
-                    )(value, cachedAttribute.valueType);
+                    )(value, cachedAttribute.valueType, dataElement);
 
                     if (contextProps.onGetUnsavedAttributeValues) {
                         const unsavedAttributeValues = contextProps.onGetUnsavedAttributeValues(dataElement.id);


### PR DESCRIPTION
[DHIS2-18592](https://dhis2.atlassian.net/browse/DHIS2-18592)

Stop trimming option-set codes so values like " foo " round-trip and match correctly. Affects the create/edit form, the search page, and the profile widget's unique-attribute lookup.

## Behavior
- Option set, create/edit — don't trim; server stores the code verbatim.
- Option set, search — don't trim; stored value is verbatim, so the filter must include spaces.
- MULTI_TEXT, create/edit — don't trim; server splits and normalizes each segment on save.
- MULTI_TEXT, search — trim; stored segments are already normalized, so the filter must be the trimmed code.

[DHIS2-18592]: https://dhis2.atlassian.net/browse/DHIS2-18592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ