### PR TITLE
fix: [DHIS2-8814] Table in custom form overflows container with no scrollbar

### DIFF
--- a/src/core_modules/capture-core/components/D2Form/D2CustomForm/D2CustomForm.component.tsx
+++ b/src/core_modules/capture-core/components/D2Form/D2CustomForm/D2CustomForm.component.tsx
@@ -232,7 +232,7 @@ export class D2CustomForm extends React.Component<Props> {
     render() {
         const customFormElement = this.transform();
         return (
-            <div>
+            <div style={{ overflowX: 'auto' }}>
                 {customFormElement}
             </div>
         );


### PR DESCRIPTION
## What is the fix?

Applies `overflowX: 'auto'` to the `D2CustomForm` wrapper div in `D2CustomForm.component.tsx` instead of the broader `D2Section` wrapper.

## Why this approach?

A previous fix (PR #3655) added `overflowX: 'scroll'` to `D2Section`, which caused a dropdown clipping regression in the registration form (DHIS2-17736, PR #3710) and was reverted. That regression occurred because `D2Section` is shared by all form types including the registration form, and setting `overflow` on it clipped absolutely-positioned dropdown menus.

`D2CustomForm` is only rendered for custom forms, so scoping the fix here means:
- Registration form and all standard forms are completely unaffected
- `auto` is used instead of `scroll` so the scrollbar only appears when content actually overflows

## Test plan
- [ ] Open a program stage with a custom form containing a wide table
- [ ] Resize browser window to be narrower than the table
- [ ] Verify dropdown/select fields in registration form still open correctly (no clipping regression)
- [ ] Verify dropdown/select fields inside custom forms still open correctly

Fixes https://dhis2.atlassian.net/browse/DHIS2-8814

Generated with [Claude Code](https://claude.com/claude-code)