### PR TITLE
fix: [DHIS2-12281] Misleading text when creating new TEI through creation of relationship 

### DIFF
--- a/src/core_modules/capture-core/components/DataEntries/TeiRegistrationEntry/TeiRegistrationEntry.component.tsx
+++ b/src/core_modules/capture-core/components/DataEntries/TeiRegistrationEntry/TeiRegistrationEntry.component.tsx
@@ -17,7 +17,11 @@ import { withDuplicateCheckOnSave } from '../common/TEIAndEnrollment/DuplicateCh
 import { defaultDialogProps } from '../../Dialogs/DiscardDialog.constants';
 import { useMetadataForRegistrationForm } from '../common/TEIAndEnrollment/useMetadataForRegistrationForm';
 
-const translatedTextWithStylesForTei = (trackedEntityName: string, orgUnitName?: string, hideProgramSelectionMessage?: boolean) =>
+const translatedTextWithStylesForTei = (
+    trackedEntityName: string,
+    orgUnitName?: string,
+    hideProgramSelectionMessage?: boolean,
+) =>
     (<>
         {i18n.t('Saving a {{trackedEntityName}}', {
             trackedEntityName, interpolation: { escapeValue: false } })
@@ -106,7 +110,9 @@ const TeiRegistrationEntryPlain =
                           </Button>
                       </div>
                       <InfoIconText>
-                          {translatedTextWithStylesForTei(trackedEntityName.toLowerCase(), orgUnitName, hideProgramSelectionMessage)}
+                          {translatedTextWithStylesForTei(
+                              trackedEntityName.toLowerCase(), orgUnitName, hideProgramSelectionMessage,
+                          )}
                       </InfoIconText>
 
                       <DiscardDialog

--- a/src/core_modules/capture-core/components/DataEntries/TeiRegistrationEntry/TeiRegistrationEntry.component.tsx
+++ b/src/core_modules/capture-core/components/DataEntries/TeiRegistrationEntry/TeiRegistrationEntry.component.tsx
@@ -17,13 +17,13 @@ import { withDuplicateCheckOnSave } from '../common/TEIAndEnrollment/DuplicateCh
 import { defaultDialogProps } from '../../Dialogs/DiscardDialog.constants';
 import { useMetadataForRegistrationForm } from '../common/TEIAndEnrollment/useMetadataForRegistrationForm';
 
-const translatedTextWithStylesForTei = (trackedEntityName: string, orgUnitName?: string, hideEnrollmentHint?: boolean) =>
+const translatedTextWithStylesForTei = (trackedEntityName: string, orgUnitName?: string, hideProgramSelectionMessage?: boolean) =>
     (<>
         {i18n.t('Saving a {{trackedEntityName}}', {
             trackedEntityName, interpolation: { escapeValue: false } })
         } <b>{i18n.t('without')}</b> {i18n.t('enrollment')}
         {orgUnitName && <>{' '}{i18n.t('in')} <b>{orgUnitName}</b></>}.{' '}
-        {!hideEnrollmentHint && i18n.t('Enroll in a program by selecting a program from the top bar.')}
+        {!hideProgramSelectionMessage && i18n.t('Enroll in a program by selecting a program from the top bar.')}
     </>);
 
 const styles: Readonly<any> = {
@@ -47,7 +47,7 @@ const TeiRegistrationEntryPlain =
       isUserInteractionInProgress,
       isSavingInProgress,
       onCancel,
-      hideEnrollmentHint,
+      hideProgramSelectionMessage,
       ...rest
   }: PlainProps & WithStyles<typeof styles>) => {
       const [showWarning, setShowWarning] = useState(false);
@@ -106,7 +106,7 @@ const TeiRegistrationEntryPlain =
                           </Button>
                       </div>
                       <InfoIconText>
-                          {translatedTextWithStylesForTei(trackedEntityName.toLowerCase(), orgUnitName, hideEnrollmentHint)}
+                          {translatedTextWithStylesForTei(trackedEntityName.toLowerCase(), orgUnitName, hideProgramSelectionMessage)}
                       </InfoIconText>
 
                       <DiscardDialog

--- a/src/core_modules/capture-core/components/DataEntries/TeiRegistrationEntry/TeiRegistrationEntry.component.tsx
+++ b/src/core_modules/capture-core/components/DataEntries/TeiRegistrationEntry/TeiRegistrationEntry.component.tsx
@@ -17,13 +17,13 @@ import { withDuplicateCheckOnSave } from '../common/TEIAndEnrollment/DuplicateCh
 import { defaultDialogProps } from '../../Dialogs/DiscardDialog.constants';
 import { useMetadataForRegistrationForm } from '../common/TEIAndEnrollment/useMetadataForRegistrationForm';
 
-const translatedTextWithStylesForTei = (trackedEntityName: string, orgUnitName?: string) =>
+const translatedTextWithStylesForTei = (trackedEntityName: string, orgUnitName?: string, hideEnrollmentHint?: boolean) =>
     (<>
         {i18n.t('Saving a {{trackedEntityName}}', {
             trackedEntityName, interpolation: { escapeValue: false } })
         } <b>{i18n.t('without')}</b> {i18n.t('enrollment')}
         {orgUnitName && <>{' '}{i18n.t('in')} <b>{orgUnitName}</b></>}.{' '}
-        {i18n.t('Enroll in a program by selecting a program from the top bar.')}
+        {!hideEnrollmentHint && i18n.t('Enroll in a program by selecting a program from the top bar.')}
     </>);
 
 const styles: Readonly<any> = {
@@ -47,6 +47,7 @@ const TeiRegistrationEntryPlain =
       isUserInteractionInProgress,
       isSavingInProgress,
       onCancel,
+      hideEnrollmentHint,
       ...rest
   }: PlainProps & WithStyles<typeof styles>) => {
       const [showWarning, setShowWarning] = useState(false);
@@ -105,7 +106,7 @@ const TeiRegistrationEntryPlain =
                           </Button>
                       </div>
                       <InfoIconText>
-                          {translatedTextWithStylesForTei(trackedEntityName.toLowerCase(), orgUnitName)}
+                          {translatedTextWithStylesForTei(trackedEntityName.toLowerCase(), orgUnitName, hideEnrollmentHint)}
                       </InfoIconText>
 
                       <DiscardDialog

--- a/src/core_modules/capture-core/components/DataEntries/TeiRegistrationEntry/TeiRegistrationEntry.types.ts
+++ b/src/core_modules/capture-core/components/DataEntries/TeiRegistrationEntry/TeiRegistrationEntry.types.ts
@@ -17,7 +17,7 @@ export type OwnProps = {
     duplicatesReviewPageSize: number;
     isSavingInProgress?: boolean;
     inheritedAttributes?: Array<InputAttribute>;
-    hideEnrollmentHint?: boolean;
+    hideProgramSelectionMessage?: boolean;
     renderDuplicatesCardActions?: RenderCustomCardActions;
     renderDuplicatesDialogActions?: (onCancel: () => void, onSave: (payload: TeiPayload) => void) => ReactNode;
     ExistingUniqueValueDialogActions: ExistingUniqueValueDialogActionsComponent;

--- a/src/core_modules/capture-core/components/DataEntries/TeiRegistrationEntry/TeiRegistrationEntry.types.ts
+++ b/src/core_modules/capture-core/components/DataEntries/TeiRegistrationEntry/TeiRegistrationEntry.types.ts
@@ -17,6 +17,7 @@ export type OwnProps = {
     duplicatesReviewPageSize: number;
     isSavingInProgress?: boolean;
     inheritedAttributes?: Array<InputAttribute>;
+    hideEnrollmentHint?: boolean;
     renderDuplicatesCardActions?: RenderCustomCardActions;
     renderDuplicatesDialogActions?: (onCancel: () => void, onSave: (payload: TeiPayload) => void) => ReactNode;
     ExistingUniqueValueDialogActions: ExistingUniqueValueDialogActionsComponent;

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/TrackedEntityInstance/DataEntryTrackedEntityInstance.component.tsx
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/TrackedEntityInstance/DataEntryTrackedEntityInstance.component.tsx
@@ -45,7 +45,7 @@ const RelationshipTrackedEntityInstancePlain =
                 renderDuplicatesCardActions={renderDuplicatesCardActions}
                 ExistingUniqueValueDialogActions={ExistingUniqueValueDialogActions}
                 orgUnit={{ id: orgUnitId }}
-                hideEnrollmentHint
+                hideProgramSelectionMessage
             />
         );
     };

--- a/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/TrackedEntityInstance/DataEntryTrackedEntityInstance.component.tsx
+++ b/src/core_modules/capture-core/components/Pages/NewRelationship/RegisterTei/DataEntry/TrackedEntityInstance/DataEntryTrackedEntityInstance.component.tsx
@@ -45,6 +45,7 @@ const RelationshipTrackedEntityInstancePlain =
                 renderDuplicatesCardActions={renderDuplicatesCardActions}
                 ExistingUniqueValueDialogActions={ExistingUniqueValueDialogActions}
                 orgUnit={{ id: orgUnitId }}
+                hideEnrollmentHint
             />
         );
     };

--- a/src/core_modules/capture-core/components/Pages/common/TEIRelationshipsWidget/RegisterTei/DataEntry/TrackedEntityInstance/DataEntryTrackedEntityInstance.tsx
+++ b/src/core_modules/capture-core/components/Pages/common/TEIRelationshipsWidget/RegisterTei/DataEntry/TrackedEntityInstance/DataEntryTrackedEntityInstance.tsx
@@ -46,7 +46,7 @@ const RelationshipTrackedEntityInstancePlain =
                 renderDuplicatesDialogActions={renderDuplicatesDialogActions}
                 renderDuplicatesCardActions={renderDuplicatesCardActions}
                 ExistingUniqueValueDialogActions={ExistingUniqueValueDialogActions}
-                hideEnrollmentHint
+                hideProgramSelectionMessage
             />
         );
     };

--- a/src/core_modules/capture-core/components/Pages/common/TEIRelationshipsWidget/RegisterTei/DataEntry/TrackedEntityInstance/DataEntryTrackedEntityInstance.tsx
+++ b/src/core_modules/capture-core/components/Pages/common/TEIRelationshipsWidget/RegisterTei/DataEntry/TrackedEntityInstance/DataEntryTrackedEntityInstance.tsx
@@ -46,6 +46,7 @@ const RelationshipTrackedEntityInstancePlain =
                 renderDuplicatesDialogActions={renderDuplicatesDialogActions}
                 renderDuplicatesCardActions={renderDuplicatesCardActions}
                 ExistingUniqueValueDialogActions={ExistingUniqueValueDialogActions}
+                hideEnrollmentHint
             />
         );
     };


### PR DESCRIPTION
Bug: When creating a new TEI via the relationship flow, the registration page showed the message "Enroll in a program by
   selecting a program from the top bar." — but the top bar already has the originating program locked in and can't be    
  changed, making the instruction impossible to follow.                                                                 

  Fix: Added an optional hideEnrollmentHint prop to TeiRegistrationEntry and passed it from both relationship registration
   entry points (NewRelationship and TEIRelationshipsWidget). The hint is suppressed in the relationship context but
  remains visible on the standard standalone TEI registration page.                                                       
                                                         