### PR TITLE
fix: [DHIS2-20022] Always center map on org unit when opening map picker

### DIFF
--- a/src/core_modules/capture-core/components/FormFields/New/HOC/withCenterPoint.tsx
+++ b/src/core_modules/capture-core/components/FormFields/New/HOC/withCenterPoint.tsx
@@ -93,8 +93,8 @@ const getCenterPoint = (InnerComponent: ComponentType<any>) => ({ orgUnitId, ...
         return null;
     }, [data, orgUnitFetchId]);
 
-    const onOpenMap = (hasValue) => {
-        setFetchEnabled(!hasValue);
+    const onOpenMap = () => {
+        setFetchEnabled(true);
     };
 
     const onCloseMap = () => {


### PR DESCRIPTION
## What is the fix?

The `onOpenMap` callback in `withCenterPoint.tsx` previously only fetched the org unit geometry when the coordinate field had **no** existing value (`setFetchEnabled(!hasValue)`). When the field already had a value, the fetch was skipped and the map opened centered on the Leaflet default — London `[51.505, -0.09]`.

This fix always enables the org unit geometry fetch when the map opens, so the map is consistently centered on the org unit regardless of whether a coordinate value already exists.

**Changed file:** `src/core_modules/capture-core/components/FormFields/New/HOC/withCenterPoint.tsx`

## Test plan

- [ ] Open the profile widget for a TE that already has a coordinate set and verify it still opens where coordinate is set
- [ ] Verify that TEs enrolled in programs with no coordinate still open the map centered on the org unit (Geometry on enrollment)
- [ ] Verify that TEs created without program (So need Geometry on TET) still open the map centered on the org unit

[DHIS2-20022](https://dhis2.atlassian.net/browse/DHIS2-20022)

_Generated with [Claude Code](https://claude.com/claude-code)_

[DHIS2-20022]: https://dhis2.atlassian.net/browse/DHIS2-20022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ