### PR TITLE
fix: [DHIS2-21061] Clear coordinate validation error when map picker sets value

### DIFF
--- a/src/core_modules/capture-ui/CoordinateField/CoordinateField.component.tsx
+++ b/src/core_modules/capture-ui/CoordinateField/CoordinateField.component.tsx
@@ -48,6 +48,7 @@ export class CoordinateField extends React.Component<PlainProps, State> {
             latitude: position[0],
             longitude: position[1],
         } : null;
+        this.props.onChange?.(value);
         this.props.onBlur(value);
         this.setState({ showMap: false });
     }


### PR DESCRIPTION
## What is the fix?

When a user typed an invalid coordinate (triggering a validation error) and then selected a valid coordinate via the map picker, the error message was not cleared.

The `onSetCoordinate` handler only called `onBlur(value)`, which runs validation but does not clear any prior error state. Adding `onChange?.(value)` before `onBlur` ensures the field value is updated and stale error state is reset before re-validation runs.

**Changed file:** `src/core_modules/capture-ui/CoordinateField/CoordinateField.component.tsx`

## Test plan

- [ ] Type an invalid coordinate in the latitude or longitude field — verify an error message appears
- [ ] Open the map picker and select a valid location
- [ ] Verify the error message is cleared after confirming the map selection

[DHIS2-21061](https://dhis2.atlassian.net/browse/DHIS2-21061)

_Generated with [Claude Code](https://claude.com/claude-code)_

[DHIS2-21061]: https://dhis2.atlassian.net/browse/DHIS2-21061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ