### PR TITLE
fix: [DHIS2-13020] Remove sharing fields from working list update payloads

### DIFF
--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/templates.epics.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/templates.epics.ts
@@ -60,11 +60,6 @@ export const updateTemplateEpic = (
             template: {
                 id,
                 name,
-                externalAccess,
-                publicAccess,
-                user,
-                userGroupAccesses,
-                userAccesses,
             },
             criteria: eventQueryCriteria,
             programId,
@@ -78,11 +73,6 @@ export const updateTemplateEpic = (
                     ...restCriteria,
                     ...(occurredAt && { eventDate: occurredAt }),
                 },
-                externalAccess,
-                publicAccess,
-                user,
-                userGroupAccesses,
-                userAccesses,
             };
 
             const requestPromise = mutate({

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/templates.epics.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/templates.epics.ts
@@ -60,6 +60,10 @@ export const updateTemplateEpic = (
             template: {
                 id,
                 name,
+                externalAccess,
+                publicAccess,
+                userGroupAccesses,
+                userAccesses,
             },
             criteria: eventQueryCriteria,
             programId,
@@ -73,6 +77,10 @@ export const updateTemplateEpic = (
                     ...restCriteria,
                     ...(occurredAt && { eventDate: occurredAt }),
                 },
+                externalAccess,
+                publicAccess,
+                userGroupAccesses,
+                userAccesses,
             };
 
             const requestPromise = mutate({

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/programStageTemplates.epics.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/programStageTemplates.epics.ts
@@ -172,7 +172,7 @@ export const updateProgramStageTemplateEpic = (action$: EpicAction<any>, store: 
         ),
         concatMap((action) => {
             const {
-                template: { id, name, externalAccess, publicAccess, user, userGroupAccesses, userAccesses },
+                template: { id, name },
                 program,
                 programStage,
                 storeId,
@@ -198,11 +198,6 @@ export const updateProgramStageTemplateEpic = (action$: EpicAction<any>, store: 
                 name,
                 program,
                 programStage,
-                externalAccess,
-                publicAccess,
-                user,
-                userGroupAccesses,
-                userAccesses,
                 programStageQueryCriteria: {
                     displayColumnOrder,
                     order,

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/programStageTemplates.epics.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/programStageTemplates.epics.ts
@@ -172,7 +172,7 @@ export const updateProgramStageTemplateEpic = (action$: EpicAction<any>, store: 
         ),
         concatMap((action) => {
             const {
-                template: { id, name },
+                template: { id, name, externalAccess, publicAccess, userGroupAccesses, userAccesses },
                 program,
                 programStage,
                 storeId,
@@ -198,6 +198,10 @@ export const updateProgramStageTemplateEpic = (action$: EpicAction<any>, store: 
                 name,
                 program,
                 programStage,
+                externalAccess,
+                publicAccess,
+                userGroupAccesses,
+                userAccesses,
                 programStageQueryCriteria: {
                     displayColumnOrder,
                     order,

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/teiTemplates.epics.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/teiTemplates.epics.ts
@@ -153,7 +153,7 @@ export const updateTEITemplateEpic = (action$: EpicAction<any>, store: ReduxStor
         ),
         concatMap((action) => {
             const {
-                template: { id, name, externalAccess, publicAccess, user, userGroupAccesses, userAccesses },
+                template: { id, name },
                 program,
                 storeId,
                 criteria,
@@ -165,11 +165,6 @@ export const updateTEITemplateEpic = (action$: EpicAction<any>, store: ReduxStor
             const trackedEntityInstanceFilters = {
                 name,
                 program,
-                externalAccess,
-                publicAccess,
-                user,
-                userGroupAccesses,
-                userAccesses,
                 entityQueryCriteria: {
                     displayColumnOrder,
                     order,

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/teiTemplates.epics.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/teiTemplates.epics.ts
@@ -153,7 +153,7 @@ export const updateTEITemplateEpic = (action$: EpicAction<any>, store: ReduxStor
         ),
         concatMap((action) => {
             const {
-                template: { id, name },
+                template: { id, name, externalAccess, publicAccess, userGroupAccesses, userAccesses },
                 program,
                 storeId,
                 criteria,
@@ -165,6 +165,10 @@ export const updateTEITemplateEpic = (action$: EpicAction<any>, store: ReduxStor
             const trackedEntityInstanceFilters = {
                 name,
                 program,
+                externalAccess,
+                publicAccess,
+                userGroupAccesses,
+                userAccesses,
                 entityQueryCriteria: {
                     displayColumnOrder,
                     order,


### PR DESCRIPTION
## Fix 409 error when non-owner updates a shared working list view

### What is the problem?

When a user with **view and edit access** on a shared working list filter clicks **"Update view"**, they receive a `409 Conflict` error and the update fails.

### Root cause

The update API call (`PUT /api/eventFilters`, `/api/trackedEntityInstanceFilters`, `/api/programStageWorkingLists`) was sending a full replace payload that included the `user` field, which represents the **original owner** of the filter. When a non-owner makes the request, the backend detects a conflict between the authenticated user and the `user` field in the payload, and returns `409`.

### Fix

Remove the `user` field from the update payloads in all three working list update epics:

- `EventWorkingLists` — event filters
- `TrackerWorkingLists` (TEI) — tracked entity instance filters
- `TrackerWorkingLists` (program stage) — program stage working lists

All other sharing fields (`publicAccess`, `externalAccess`, `userAccesses`, `userGroupAccesses`) are preserved.

### Testing

1. Log in as admin, go to Capture, open a program and org unit
2. Save a working list view ("Test")
3. Share it with a tracker user with **view and edit** access, public access set to **No access**
4. Log in as the tracker user, load the "Test" view
5. Make a change (e.g. add/remove a column) until the `*` appears next to the filter name
6. Click **Update view** — it should now save successfully without a 409 error