### PR TITLE
chore: setup Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
   open-pull-requests-limit: 5
   target-branch: master
   versioning-strategy: increase
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
Given the recent increase in supply chain attacks, which are often detected and fixed within hours/days, I propose that we prevent Dependbot from opening PRs for any packages published less than 7 days ago. 