### PR TITLE
fix: [DHIS2-21508] Fix priority typo in storeProgramRules

### DIFF
--- a/src/core_modules/capture-core/metaDataStoreLoaders/programs/quickStoreOperations/storeProgramRules.ts
+++ b/src/core_modules/capture-core/metaDataStoreLoaders/programs/quickStoreOperations/storeProgramRules.ts
@@ -40,7 +40,7 @@ const convert = (() => {
             optionGroupId: getOptionGroupId(apiProgramRuleAction),
             optionId: getOptionId(apiProgramRuleAction),
             legendSetId: getLegendSetId(apiProgramRuleAction),
-            prioriy: getPriority(apiProgramRuleAction),
+            priority: getPriority(apiProgramRuleAction),
         }));
     };
 


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-21508

Fixes a typo where `prioriy` was written instead of `priority` when storing program rule actions to IndexedDB. The typo was introduced in https://github.com/dhis2/capture-app/pull/4456/

AI Assisted