### PR TITLE
fix: [DHIS2-16363] Navigate to Schedule tab when creating event after stage complete

### DIFF
--- a/src/core_modules/capture-core/components/WidgetEventEdit/EditEventDataEntry/editEventDataEntry.epics.ts
+++ b/src/core_modules/capture-core/components/WidgetEventEdit/EditEventDataEntry/editEventDataEntry.epics.ts
@@ -231,7 +231,8 @@ export const startCreateNewAfterCompletingEpic = (
 
             if (isCreateNew) {
                 const finalParams = availableProgramStages.length === 1 ?
-                    { ...params, stageId: availableProgramStages[0].id } : params;
+                    { ...params, stageId: availableProgramStages[0].id, tab: 'SCHEDULE' } :
+                    { ...params, tab: 'SCHEDULE' };
 
                 setTimeout(() => {
                     navigate(`/enrollmentEventNew?${buildUrlQueryString(finalParams)}`);


### PR DESCRIPTION
When a stage with "Ask user to create new event when stage is complete" is completed and the user
  confirms they want to create a new event, they are navigated to the Report tab of the new event
  workspace. The expected behaviour (per DHIS2-13801) is to land on the Schedule tab, since most users
  want to schedule the follow-up rather than report immediately.
  
What is the fix?

In startCreateNewAfterCompletingEpic, tab: 'SCHEDULE' is added to the URL params when navigating to
/enrollmentEventNew. The NewEventWorkspace component already reads this param and initialises to the
correct tab — it was just never being passed.

Steps to verify

1. Open a tracked entity enrolled in a program where a stage has "Ask user to create new event when
 stage is complete" enabled (e.g. WHO RMNCH).
2. Create and complete an event in that stage. Confirm "Yes" on the modal.
3. Select a stage if prompted.
4. Verify the new event workspace opens on the Schedule tab, not the Report tab.

AI Assisted