### PR TITLE
fix: [DHIS2-21567] String without spaces overflows form

### DIFF
--- a/src/core_modules/capture-ui/HOC/withLabel.module.css
+++ b/src/core_modules/capture-ui/HOC/withLabel.module.css
@@ -11,6 +11,7 @@
 .labelContainer {
     padding-inline-end: 16px;
     min-width: 40%;
+    word-break: break-word;
 }
 
 .labelContainerVertical {
@@ -19,5 +20,7 @@
 
 .inputContainer {
     flex-grow: 1;
-    flex-shrink: 0;
+    flex-shrink: 1;
+    min-width: 0;
+    word-break: break-word;
 }


### PR DESCRIPTION
[DHIS2-21567](https://dhis2.atlassian.net/browse/DHIS2-21567)


### Value column
The shared `withLabel` layout pinned the input with `flex-shrink: 0` and kept the default `min-width: auto`, so an unbreakable string's min-content forced the box wider than its column (and below ~150px it overflowed on narrow screens). 

### Label and value column
No word-break meant long strings spilled out instead of wrapping.

[DHIS2-21567]: https://dhis2.atlassian.net/browse/DHIS2-21567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ