### PR TITLE
fix: [DHIS2-21286] fix scrolling to first validation error in tracker/event forms

### DIFF
--- a/src/core_modules/capture-core/components/D2Form/D2Form.component.tsx
+++ b/src/core_modules/capture-core/components/D2Form/D2Form.component.tsx
@@ -5,7 +5,7 @@ import { D2SectionContainer } from './D2Section.container';
 import type { Props, PropsForPureComponent } from './D2Form.types';
 import { Section } from '../../metaData';
 
-class D2Form extends React.PureComponent<PropsForPureComponent> {
+export class D2Form extends React.PureComponent<PropsForPureComponent> {
     name: string;
     sectionInstances: Map<string, any>;
 
@@ -17,9 +17,14 @@ class D2Form extends React.PureComponent<PropsForPureComponent> {
 
     validateFormIncludeSectionFailedFields(options: any) {
         let failedFormFields: any[] = [];
+        // Evaluate every section without short-circuiting. A section's isValid() inspects the
+        // form-wide field UI state (keyed by formId), so a valid section can still report invalid
+        // when another section has a failing field. Short-circuiting on the first such section
+        // would drop the actual failing fields (collected per-section by getInvalidFields()),
+        // leaving failedFields empty and preventing the scroll-to-error.
         const isValid = Array.from(this.sectionInstances.entries())
             .map((entry: any) => entry[1])
-            .every((sectionInstance) => {
+            .map((sectionInstance) => {
                 const isHidden = sectionInstance.props.isHidden;
                 if (isHidden) {
                     return true;
@@ -44,7 +49,8 @@ class D2Form extends React.PureComponent<PropsForPureComponent> {
                     failedFormFields = [...failedFormFields, ...sectionFieldsInstance.getInvalidFields()];
                 }
                 return sectionIsValid;
-            });
+            })
+            .every(Boolean);
 
         return {
             isValid,
@@ -58,8 +64,12 @@ class D2Form extends React.PureComponent<PropsForPureComponent> {
             return true;
         }
 
-        const firstFailureInstance = failedFields.length > 0 ? failedFields[0].instance : null;
-        firstFailureInstance && firstFailureInstance.goto && firstFailureInstance.goto();
+        // Scroll to the first failed field that exposes a goto() method. Some fields (e.g. plugins)
+        // register no instance, so picking failedFields[0] blindly could no-op the scroll.
+        const firstFailureInstance = failedFields
+            .map(failedField => failedField.instance)
+            .find(instance => instance && instance.goto);
+        firstFailureInstance && firstFailureInstance.goto();
         return false;
     }
 

--- a/src/core_modules/capture-core/components/D2Form/__tests__/D2Form.validation.test.js
+++ b/src/core_modules/capture-core/components/D2Form/__tests__/D2Form.validation.test.js
@@ -1,0 +1,85 @@
+import { D2Form } from '../D2Form.component';
+
+// Mock the heavy/irrelevant imports so importing D2Form.component does not pull in the full
+// metadata + section module graph (which reaches untransformed node_modules ESM). These methods
+// under test use neither at runtime. jest hoists these above the import above.
+jest.mock('../D2Section.container', () => ({ D2SectionContainer: () => null }));
+jest.mock('../../../metaData', () => ({ Section: { LEFTOVERS_SECTION_ID: 'LEFTOVERS' } }));
+jest.mock('loglevel');
+
+const createSectionInstance = ({ isHidden = false, isValid, invalidFields = [] }) => ({
+    props: { isHidden },
+    sectionFieldsInstance: {
+        isValid: () => isValid,
+        getInvalidFields: jest.fn(() => invalidFields),
+    },
+});
+
+const createForm = (sections) => {
+    const form = new D2Form({});
+    form.sectionInstances = new Map(sections);
+    return form;
+};
+
+describe('D2Form scroll to first failed field', () => {
+    // Regression for DHIS2-21286: in a multi-section form, a section's isValid() inspects the
+    // form-wide field UI state, so an otherwise-valid section reports invalid when a *later*
+    // section has the failing field. The previous short-circuiting collection stopped at that
+    // first section (which owns no invalid fields), leaving nothing to scroll to.
+    it('collects the failing field from a later section even when an earlier section reports invalid', () => {
+        const goto = jest.fn();
+        const failingField = { instance: { goto } };
+        const form = createForm([
+            ['section1', createSectionInstance({ isValid: false, invalidFields: [] })],
+            ['section2', createSectionInstance({ isValid: false, invalidFields: [failingField] })],
+        ]);
+
+        const { isValid, failedFields } = form.validateFormIncludeSectionFailedFields({});
+
+        expect(isValid).toBe(false);
+        expect(failedFields).toEqual([failingField]);
+
+        expect(form.validateFormScrollToFirstFailedField({})).toBe(false);
+        expect(goto).toHaveBeenCalledTimes(1);
+    });
+
+    it('scrolls to the first failed field that exposes a goto method', () => {
+        const goto = jest.fn();
+        const form = createForm([
+            ['section1', createSectionInstance({
+                isValid: false,
+                invalidFields: [{ instance: undefined }, { instance: { goto } }],
+            })],
+        ]);
+
+        expect(form.validateFormScrollToFirstFailedField({})).toBe(false);
+        expect(goto).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not throw when no failed field exposes a goto method', () => {
+        const form = createForm([
+            ['section1', createSectionInstance({ isValid: false, invalidFields: [{ instance: undefined }] })],
+        ]);
+
+        expect(form.validateFormScrollToFirstFailedField({})).toBe(false);
+    });
+
+    it('returns valid and does not scroll when every section is valid', () => {
+        const goto = jest.fn();
+        const form = createForm([
+            ['section1', createSectionInstance({ isValid: true })],
+            ['section2', createSectionInstance({ isValid: true })],
+        ]);
+
+        expect(form.validateFormScrollToFirstFailedField({})).toBe(true);
+        expect(goto).not.toHaveBeenCalled();
+    });
+
+    it('ignores hidden sections', () => {
+        const hiddenSection = createSectionInstance({ isHidden: true, isValid: false, invalidFields: [] });
+        const form = createForm([['section1', hiddenSection]]);
+
+        expect(form.validateFormScrollToFirstFailedField({})).toBe(true);
+        expect(hiddenSection.sectionFieldsInstance.getInvalidFields).not.toHaveBeenCalled();
+    });
+});

--- a/src/core_modules/capture-core/components/DataEntry/dataEntryField/internal/DataEntryField.component.tsx
+++ b/src/core_modules/capture-core/components/DataEntry/dataEntryField/internal/DataEntryField.component.tsx
@@ -19,12 +19,7 @@ class DataEntryFieldPlain extends React.Component<Props> {
 
     goto() {
         if (this.gotoInstance) {
-            this.gotoInstance.scrollIntoView();
-
-            const scrolledY = window.scrollY;
-            if (scrolledY) {
-                window.scroll(0, scrolledY - 48);
-            }
+            this.gotoInstance.scrollIntoView({ block: 'start' });
         }
     }
 
@@ -60,6 +55,7 @@ class DataEntryFieldPlain extends React.Component<Props> {
                 ref={(gotoInstance) => { this.gotoInstance = gotoInstance; }}
                 key={propName}
                 data-test={`dataentry-field-${propName}`}
+                style={{ scrollMarginTop: '80px' }}
             >
                 <Component
                     onBlur={this.handleSet}

--- a/src/core_modules/capture-core/components/FormFields/New/HOC/withGotoInterface.tsx
+++ b/src/core_modules/capture-core/components/FormFields/New/HOC/withGotoInterface.tsx
@@ -1,38 +1,26 @@
-import React, { forwardRef } from 'react';
+import * as React from 'react';
 
 export const withGotoInterface = () =>
-    (InnerComponent: React.ComponentType<any>) => {
+    (InnerComponent: React.ComponentType<any>) =>
         class GotoFieldInterface extends React.Component<any> {
             gotoInstance: any;
 
             goto() {
                 if (this.gotoInstance) {
-                    this.gotoInstance.scrollIntoView();
-
-                    const scrolledY = window.scrollY;
-                    if (scrolledY) {
-                        // TODO: Set the modifier some other way (caused be the fixed header)
-                        window.scroll(0, scrolledY - 48);
-                    }
+                    this.gotoInstance.scrollIntoView({ block: 'start' });
                 }
             }
 
             render() {
-                const { forwardedRef, ...rest } = this.props;
                 return (
                     <div
                         ref={(gotoInstance) => { this.gotoInstance = gotoInstance; }}
+                        style={{ scrollMarginTop: '80px' }}
                     >
                         <InnerComponent
-                            ref={forwardedRef}
-                            {...rest}
+                            {...this.props}
                         />
                     </div>
                 );
             }
-        }
-
-        return forwardRef<any, any>((props, ref) => (
-            <GotoFieldInterface {...props} forwardedRef={ref} />
-        ));
-    };
+        };


### PR DESCRIPTION
## Summary

Fixes two bugs that caused the scroll-to-first-error on save to land in the wrong place. Affects every entry point that uses `withSaveHandler` (TE registration, enrollment registration, single-event registration, new event in enrollment, edit event) — i.e. both tracker and event programs.

- **B1 — D2Form section data elements never scrolled.** `withGotoInterface` was wrapped in `forwardRef` during the React 18 migration (09ed2839e). That redirected the parent's ref from `GotoFieldInterface` to the inner field component, which doesn't expose a `goto()` method, so `instance.goto && instance.goto()` in `D2Form.validateFormScrollToFirstFailedField` silently no-op'd for every section field. Drop the `forwardRef` wrapper — no consumer reads the forwarded ref. This explains the pre-fix asymmetry where save would scroll to OccurredAt (which uses `DataEntryField`'s own `goto()`) but not to a section mandatory DE.
- **B2 — top-of-form fields (e.g. OccurredAt) landed behind the sticky `ScopeSelector` bar.** Both `goto()` implementations did `scrollIntoView()` and then post-corrected with `window.scroll(0, scrolledY - 48)`. The `if (scrolledY)` guard skipped the correction when `scrolledY === 0` (which is exactly what happens when the field is near the top of the document), leaving the field flush with the viewport top — under the sticky `ScopeSelector`. Replace with `scrollIntoView({ block: 'start' })` + `scrollMarginTop: '80px'` on the wrapper so the browser lands the field 80px below the viewport top regardless of position. 48px covers the `SelectorBar` height, the remaining 32px is breathing room above the label.

Same fix pattern applied to both call sites (`withGotoInterface` for in-section data elements and `DataEntryField` for top-of-form fields).

## Test plan

Save is always at the bottom of the form, so the only scroll direction validation needs to drive is **up**.

- [ ] Tracker program stage, OccurredAt empty, click Save → page scrolls UP, OccurredAt label clear of `ScopeSelector` *(tests B2 via DataEntryField)*
- [ ] Tracker program stage, mandatory section data element empty, click Save → page scrolls UP, that field's label clear of `ScopeSelector` *(tests B1 — broken on master)*
- [ ] Event program (single-event registration), OccurredAt empty, Save → scrolls UP, label clear of `ScopeSelector`
- [ ] Event program (single-event registration), mandatory section DE empty, Save → scrolls UP, label clear of `ScopeSelector` *(tests B1 on the event-program path)*

AI Assisted
