### PR TITLE
ci: verified signatures for dhis2-bot commits

### DIFF
--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -228,6 +228,7 @@ jobs:
       - uses: dhis2/action-commit-signing@v1
         with:
           ssh-signing-key: ${{ secrets.DHIS2_BOT_SSH_SIGNING_KEY }}
+          ssh-signing-key-passphrase: ${{ secrets.DHIS2_BOT_SSH_SIGNING_PASSPHRASE }}
 
       - uses: dhis2/action-semantic-release@use-yarn-version-prepare
         with:

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -225,6 +225,10 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
+      - uses: dhis2/action-commit-signing@v1
+        with:
+          ssh-signing-key: ${{ secrets.DHIS2_BOT_SSH_SIGNING_KEY }}
+
       - uses: dhis2/action-semantic-release@use-yarn-version-prepare
         with:
           publish-apphub: true


### PR DESCRIPTION
Makes dhis2-bot commits verified (Prerequisites: v1 of https://github.com/dhis2/action-commit-signing must be released, the DHIS2_BOT_SSH_SIGNING_KEY secret must be available and the dhis2_bot account must know its public key)