### PR TITLE
fix: [DHIS2-21741] Failed event deletion is not rolled back in the UI

### DIFF
--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/EventRow/DeleteActionModal/DeleteActionModal.tsx
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/EventRow/DeleteActionModal/DeleteActionModal.tsx
@@ -3,17 +3,14 @@ import log from 'loglevel';
 import i18n from '@dhis2/d2-i18n';
 import { Button, ButtonStrip, Modal, ModalActions, ModalContent, ModalTitle } from '@dhis2/ui';
 import { useAlert, useDataEngine } from '@dhis2/app-runtime';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { errorCreator } from 'capture-core-utils';
 import type { ApiEnrollmentEvent } from 'capture-core-utils/types/api-types';
-import { ReactQueryAppNamespace } from '../../../../../../../utils/reactQueryHelpers';
 
 type Props = {
     eventId: string;
     pendingApiResponse: boolean;
-    teiId: string;
-    programId: string;
-    enrollmentId: string;
+    eventDetails: ApiEnrollmentEvent;
     onDeleteEvent: (eventId: string) => void;
     onRollbackDeleteEvent: (eventToRollbackOnFail: ApiEnrollmentEvent) => void;
     setDeleteModalOpen: (open: boolean) => void;
@@ -23,9 +20,7 @@ export const DeleteActionModal = ({
     setDeleteModalOpen,
     pendingApiResponse,
     eventId,
-    teiId,
-    programId,
-    enrollmentId,
+    eventDetails,
     onDeleteEvent,
     onRollbackDeleteEvent,
 }: Props) => {
@@ -36,15 +31,6 @@ export const DeleteActionModal = ({
         },
     );
     const dataEngine = useDataEngine();
-    const queryClient = useQueryClient();
-    const enrollmentDomainQueryKey = [
-        ReactQueryAppNamespace,
-        'stages&event',
-        'enrollmentData',
-        teiId,
-        programId,
-        enrollmentId,
-    ];
 
     const { mutate } = useMutation(
         () => dataEngine.mutate({
@@ -60,21 +46,14 @@ export const DeleteActionModal = ({
         }),
         {
             onMutate: () => {
-                const previousData = queryClient
-                    .getQueryData(enrollmentDomainQueryKey) as {
-                        enrollments?: Array<{
-                            events?: Array<ApiEnrollmentEvent>;
-                        }>;
-                    };
-                const eventToRollbackOnFail = previousData
-                    ?.enrollments
-                    ?.flatMap(enrollment => enrollment.events || [])
-                    ?.find(event => event.event === eventId);
+                // Capture the event before the optimistic removal so it can be restored
+                // from the same source of truth (the rendered redux event) if the delete fails.
+                const eventToRollbackOnFail = eventDetails;
 
                 onDeleteEvent(eventId);
                 return eventToRollbackOnFail;
             },
-            onError: (apiError: unknown, payload: unknown, eventToRollbackOnFail?: any) => {
+            onError: (apiError: unknown, payload: unknown, eventToRollbackOnFail?: ApiEnrollmentEvent) => {
                 showError({ message: i18n.t('An error occurred while deleting the event') });
                 log.error(errorCreator('An error occurred while deleting the event')({ apiError, payload }));
 

--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/EventRow/EventRow.tsx
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/EventRow/EventRow.tsx
@@ -41,9 +41,7 @@ const EventRowPlain = ({
     onDeleteEvent,
     onRollbackDeleteEvent,
     onUpdateEventStatus,
-    teiId,
     programId,
-    enrollmentId,
     classes,
 }: EventRowProps & WithStyles<typeof styles>) => {
     const [actionsOpen, setActionsOpen] = useState(false);
@@ -100,9 +98,7 @@ const EventRowPlain = ({
                             <DeleteActionModal
                                 eventId={id}
                                 pendingApiResponse={pendingApiResponse}
-                                teiId={teiId}
-                                programId={programId}
-                                enrollmentId={enrollmentId}
+                                eventDetails={eventDetails}
                                 onDeleteEvent={onDeleteEvent}
                                 onRollbackDeleteEvent={onRollbackDeleteEvent}
                                 setDeleteModalOpen={setDeleteModalOpen}

--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/EventRow/EventRow.types.ts
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/EventRow/EventRow.types.ts
@@ -13,7 +13,5 @@ export type EventRowProps = {
     onRollbackDeleteEvent: (event: ApiEnrollmentEvent) => void;
     stageWriteAccess: boolean;
     programStage?: ProgramStage | null;
-    teiId: string;
     programId: string;
-    enrollmentId: string;
 };

--- a/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/StageDetail.component.tsx
+++ b/src/core_modules/capture-core/components/WidgetStagesAndEvents/Stages/Stage/StageDetail/StageDetail.component.tsx
@@ -221,11 +221,9 @@ const StageDetailPlain = (props: Props & WithStyles<typeof styles>) => {
                         id={row.id as string}
                         pendingApiResponse={row.pendingApiResponse as boolean}
                         eventDetails={eventDetails}
-                        teiId={eventDetails.trackedEntity}
                         stageWriteAccess={stageWriteAccess}
                         programStage={stage}
                         programId={programId}
-                        enrollmentId={eventDetails.enrollment}
                         cells={cells}
                         onEventClick={onEventClick}
                         onDeleteEvent={onDeleteEvent}


### PR DESCRIPTION
[DHIS2-21741](https://dhis2.atlassian.net/browse/DHIS2-21741)

Simplifies the delete-event rollback mechanism in `DeleteActionModal` by replacing the React Query cache lookup with a direct prop.

The delete removes the event from Redux, but the rollback previously read the event data from a separate React Query cache. That cache can be stale, and newly created in-session events are not always present there, which meant rollback could be skipped on delete failure.

Previously, on mutation start the component reconstructed a query key from `teiId`, `programId`, and `enrollmentId`, then dug into the cached enrollment data to find the event for rollback. Now, the already-rendered `eventDetails` object from `EventRow` is passed in as a prop and used directly:

```diff
- queryClient.getQueryData(key)
-   ?.enrollments
-   ?.flatMap(...)
-   ?.find(e => e.event === eventId)
+ const eventToRollbackOnFail = eventDetails;
```

This ensures the event is always available for rollback and restored on failure, including newly created in-session events.

This also removes the `useQueryClient` hook, the `ReactQueryAppNamespace` import, and three individual ID props in favor of a single typed `eventDetails: ApiEnrollmentEvent` prop.

[DHIS2-21741]: https://dhis2.atlassian.net/browse/DHIS2-21741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ