### PR TITLE
fix: [DHIS2-21871] preserve working-list view sharing on update

### DIFF
--- a/cypress/e2e/WorkingLists/EventWorkingLists/EventWorkingListsUser/EventWorkingListsUser.js
+++ b/cypress/e2e/WorkingLists/EventWorkingLists/EventWorkingListsUser/EventWorkingListsUser.js
@@ -480,7 +480,7 @@ When(/^you update the view with the name (.+)$/, (_name) => {
     cy.get('[data-test="list-view-menu-button"]')
         .click();
 
-    cy.intercept('PUT', '**/eventFilters/**').as('updateEventFilter');
+    cy.intercept('PATCH', '**/eventFilters/**').as('updateEventFilter');
     cy.contains('Update view')
         .click();
     cy.wait('@updateEventFilter', { timeout: 30000 });

--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerWorkingListsUser/TrackerWorkingListsUser.js
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerWorkingListsUser/TrackerWorkingListsUser.js
@@ -485,7 +485,7 @@ When('you update the list with the name My custom list', () => {
     cy.get('[data-test="list-view-menu-button"]')
         .click();
 
-    cy.intercept('PUT', '**/trackedEntityInstanceFilters/**').as('editTrackedEntityInstanceFilters');
+    cy.intercept('PATCH', '**/trackedEntityInstanceFilters/**').as('editTrackedEntityInstanceFilters');
     cy.contains('Update view')
         .click();
     cy.wait('@editTrackedEntityInstanceFilters', { timeout: 30000 });
@@ -493,14 +493,14 @@ When('you update the list with the name My custom list', () => {
 
 When(/^you update the tracker tei view with the name (.+)$/, (_name) => {
     cy.get('[data-test="list-view-menu-button"]').click();
-    cy.intercept('PUT', '**/trackedEntityInstanceFilters/**').as('editTrackedEntityInstanceFiltersByName');
+    cy.intercept('PATCH', '**/trackedEntityInstanceFilters/**').as('editTrackedEntityInstanceFiltersByName');
     cy.contains('Update view').click();
     cy.wait('@editTrackedEntityInstanceFiltersByName', { timeout: 30000 });
 });
 
 When(/^you update the tracker program stage view with the name (.+)$/, (_name) => {
     cy.get('[data-test="list-view-menu-button"]').click();
-    cy.intercept('PUT', '**/programStageWorkingLists/**').as('editProgramStageWorkingListsByName');
+    cy.intercept('PATCH', '**/programStageWorkingLists/**').as('editProgramStageWorkingListsByName');
     cy.contains('Update view').click();
     cy.wait('@editProgramStageWorkingListsByName', { timeout: 30000 });
 });
@@ -509,7 +509,7 @@ When('you update the list with the name Custom Program stage list', () => {
     cy.get('[data-test="list-view-menu-button"]')
         .click();
 
-    cy.intercept('PUT', '**/programStageWorkingLists/**').as('editProgramStageWorkingLists');
+    cy.intercept('PATCH', '**/programStageWorkingLists/**').as('editProgramStageWorkingLists');
     cy.contains('Update view')
         .click();
     cy.wait('@editProgramStageWorkingLists', { timeout: 30000 });

--- a/src/core_modules/capture-core-utils/types/global.ts
+++ b/src/core_modules/capture-core-utils/types/global.ts
@@ -97,7 +97,7 @@ export type ApiUtils = {
         resource: string;
         id?: string;
         data?: any;
-        type?: 'create' | 'replace' | 'update' | 'delete';
+        type?: 'create' | 'replace' | 'update' | 'delete' | 'json-patch';
     }) => Promise<any>;
 };
 

--- a/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/templates.epics.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/EventWorkingLists/epics/templates.epics.ts
@@ -15,6 +15,7 @@ import {
     addTemplateError,
     deleteTemplateSuccess,
     deleteTemplateError,
+    toJsonPatchReplaceOps,
 } from '../../WorkingListsCommon';
 import { getTemplates } from './getTemplates';
 import { SINGLE_EVENT_WORKING_LISTS_TYPE } from '../constants';
@@ -60,36 +61,24 @@ export const updateTemplateEpic = (
             template: {
                 id,
                 name,
-                externalAccess,
-                publicAccess,
-                user,
-                userGroupAccesses,
-                userAccesses,
             },
             criteria: eventQueryCriteria,
-            programId,
             storeId,
         } }: any) => {
             const { occurredAt, ...restCriteria } = eventQueryCriteria;
-            const eventFilterData = {
+            const eventFilterPatch = toJsonPatchReplaceOps({
                 name,
-                program: programId,
                 eventQueryCriteria: {
                     ...restCriteria,
                     ...(occurredAt && { eventDate: occurredAt }),
                 },
-                externalAccess,
-                publicAccess,
-                user,
-                userGroupAccesses,
-                userAccesses,
-            };
+            });
 
             const requestPromise = mutate({
                 resource: 'eventFilters',
                 id,
-                data: eventFilterData,
-                type: 'replace',
+                data: eventFilterPatch,
+                type: 'json-patch',
             }).then(() => {
                 const isActiveTemplate =
                     store.value.workingListsTemplates[storeId].selectedTemplateId === id;
@@ -105,7 +94,7 @@ export const updateTemplateEpic = (
                     log.error(
                         errorCreator('could not update template')({
                             error,
-                            eventFilterData,
+                            eventFilterPatch,
                         }),
                     );
                     const isActiveTemplate =

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/programStageTemplates.epics.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/programStageTemplates.epics.ts
@@ -15,6 +15,7 @@ import {
     updateTemplateSuccess,
     workingListsCommonActionTypes,
     workingListsCommonActionTypesBatchActionTypes,
+    toJsonPatchReplaceOps,
 } from '../../../WorkingListsCommon';
 import { TRACKER_WORKING_LISTS_TYPE } from '../../constants';
 import { getLocationQuery } from '../../../../../utils/routing';
@@ -172,9 +173,7 @@ export const updateProgramStageTemplateEpic = (action$: EpicAction<any>, store: 
         ),
         concatMap((action) => {
             const {
-                template: { id, name, externalAccess, publicAccess, user, userGroupAccesses, userAccesses },
-                program,
-                programStage,
+                template: { id, name },
                 storeId,
                 criteria,
             } = action.payload;
@@ -194,37 +193,28 @@ export const updateProgramStageTemplateEpic = (action$: EpicAction<any>, store: 
                 scheduledAt,
             } = criteria;
 
-            const programStageWorkingLists = {
-                name,
-                program,
-                programStage,
-                externalAccess,
-                publicAccess,
-                user,
-                userGroupAccesses,
-                userAccesses,
-                programStageQueryCriteria: {
-                    displayColumnOrder,
-                    order,
-                    enrolledAt,
-                    eventStatus: status,
-                    ...(assignedUserMode && { assignedUserMode }),
-                    ...(assignedUsers?.length > 0 && { assignedUsers }),
-                    ...(programStatus && { enrollmentStatus: programStatus }),
-                    ...(occurredAt && { enrollmentOccurredAt: occurredAt }),
-                    ...(followUp !== undefined && { followUp: JSON.stringify(followUp) }),
-                    ...(eventOccurredAt && { eventOccurredAt }),
-                    ...(scheduledAt && { eventScheduledAt: scheduledAt }),
-                    attributeValueFilters,
-                    dataFilters,
-                },
+            const programStageQueryCriteria = {
+                displayColumnOrder,
+                order,
+                enrolledAt,
+                eventStatus: status,
+                ...(assignedUserMode && { assignedUserMode }),
+                ...(assignedUsers?.length > 0 && { assignedUsers }),
+                ...(programStatus && { enrollmentStatus: programStatus }),
+                ...(occurredAt && { enrollmentOccurredAt: occurredAt }),
+                ...(followUp !== undefined && { followUp: JSON.stringify(followUp) }),
+                ...(eventOccurredAt && { eventOccurredAt }),
+                ...(scheduledAt && { eventScheduledAt: scheduledAt }),
+                attributeValueFilters,
+                dataFilters,
             };
+            const programStageWorkingListPatch = toJsonPatchReplaceOps({ name, programStageQueryCriteria });
 
             const requestPromise = mutate({
                 resource: 'programStageWorkingLists',
                 id,
-                type: 'replace',
-                data: programStageWorkingLists,
+                type: 'json-patch',
+                data: programStageWorkingListPatch,
             })
                 .then(() => {
                     const isActiveTemplate = store.value.workingListsTemplates[storeId].selectedTemplateId === id;
@@ -237,7 +227,7 @@ export const updateProgramStageTemplateEpic = (action$: EpicAction<any>, store: 
                     log.error(
                         errorCreator('could not update template')({
                             error,
-                            programStageWorkingLists,
+                            programStageWorkingListPatch,
                         }),
                     );
                     const isActiveTemplate = store.value.workingListsTemplates[storeId].selectedTemplateId === id;

--- a/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/teiTemplates.epics.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/TrackerWorkingLists/epics/teiViewEpics/teiTemplates.epics.ts
@@ -15,6 +15,7 @@ import {
     updateTemplateSuccess,
     workingListsCommonActionTypes,
     workingListsCommonActionTypesBatchActionTypes,
+    toJsonPatchReplaceOps,
 } from '../../../WorkingListsCommon';
 import { TRACKER_WORKING_LISTS_TYPE } from '../../constants';
 import { getLocationQuery } from '../../../../../utils/routing';
@@ -153,8 +154,7 @@ export const updateTEITemplateEpic = (action$: EpicAction<any>, store: ReduxStor
         ),
         concatMap((action) => {
             const {
-                template: { id, name, externalAccess, publicAccess, user, userGroupAccesses, userAccesses },
-                program,
+                template: { id, name },
                 storeId,
                 criteria,
             } = action.payload;
@@ -162,32 +162,24 @@ export const updateTEITemplateEpic = (action$: EpicAction<any>, store: ReduxStor
                 programStatus, enrolledAt, occurredAt, attributeValueFilters, order, displayColumnOrder,
                 assignedUserMode, assignedUsers, followUp,
             } = criteria;
-            const trackedEntityInstanceFilters = {
-                name,
-                program,
-                externalAccess,
-                publicAccess,
-                user,
-                userGroupAccesses,
-                userAccesses,
-                entityQueryCriteria: {
-                    displayColumnOrder,
-                    order,
-                    ...(assignedUserMode && { assignedUserMode }),
-                    ...(assignedUsers?.length > 0 && { assignedUsers }),
-                    ...(followUp !== undefined && { followUp: JSON.stringify(followUp) }),
-                    ...(programStatus && { enrollmentStatus: programStatus }),
-                    ...(enrolledAt && { enrollmentCreatedDate: enrolledAt }),
-                    ...(occurredAt && { enrollmentIncidentDate: occurredAt }),
-                    ...(attributeValueFilters?.length > 0 && { attributeValueFilters }),
-                },
+            const entityQueryCriteria = {
+                displayColumnOrder,
+                order,
+                ...(assignedUserMode && { assignedUserMode }),
+                ...(assignedUsers?.length > 0 && { assignedUsers }),
+                ...(followUp !== undefined && { followUp: JSON.stringify(followUp) }),
+                ...(programStatus && { enrollmentStatus: programStatus }),
+                ...(enrolledAt && { enrollmentCreatedDate: enrolledAt }),
+                ...(occurredAt && { enrollmentIncidentDate: occurredAt }),
+                ...(attributeValueFilters?.length > 0 && { attributeValueFilters }),
             };
+            const teiFilterPatch = toJsonPatchReplaceOps({ name, entityQueryCriteria });
 
             const requestPromise = mutate({
                 resource: 'trackedEntityInstanceFilters',
                 id,
-                type: 'replace',
-                data: trackedEntityInstanceFilters,
+                type: 'json-patch',
+                data: teiFilterPatch,
             })
                 .then(() => {
                     const isActiveTemplate = store.value.workingListsTemplates[storeId].selectedTemplateId === id;
@@ -200,7 +192,7 @@ export const updateTEITemplateEpic = (action$: EpicAction<any>, store: ReduxStor
                     log.error(
                         errorCreator('could not update template')({
                             error,
-                            trackedEntityInstanceFilters,
+                            teiFilterPatch,
                         }),
                     );
                     const isActiveTemplate = store.value.workingListsTemplates[storeId].selectedTemplateId === id;

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/index.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/index.ts
@@ -1,1 +1,2 @@
 export { buildFilterQueryArgs } from './buildFilterQueryArgs';
+export { toJsonPatchReplaceOps } from './toJsonPatchReplaceOps';

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/toJsonPatchReplaceOps/__tests__/toJsonPatchReplaceOps.test.js
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/toJsonPatchReplaceOps/__tests__/toJsonPatchReplaceOps.test.js
@@ -1,0 +1,28 @@
+import { toJsonPatchReplaceOps } from '../toJsonPatchReplaceOps';
+
+describe('toJsonPatchReplaceOps', () => {
+    it('builds a replace op per field, preserving order and value', () => {
+        const criteria = { order: 'createdAt:desc', displayColumnOrder: ['occurredAt'] };
+
+        expect(toJsonPatchReplaceOps({ name: 'My view', eventQueryCriteria: criteria })).toEqual([
+            { op: 'replace', path: '/name', value: 'My view' },
+            { op: 'replace', path: '/eventQueryCriteria', value: criteria },
+        ]);
+    });
+
+    it('returns an empty patch for an empty object', () => {
+        expect(toJsonPatchReplaceOps({})).toEqual([]);
+    });
+
+    it('emits ops only for the fields passed in, never sharing or ownership fields', () => {
+        const ops = toJsonPatchReplaceOps({ name: 'x', entityQueryCriteria: {} });
+        const paths = ops.map(op => op.path);
+
+        expect(paths).toEqual(['/name', '/entityQueryCriteria']);
+        expect(paths).not.toContain('/publicAccess');
+        expect(paths).not.toContain('/userGroupAccesses');
+        expect(paths).not.toContain('/userAccesses');
+        expect(paths).not.toContain('/externalAccess');
+        expect(paths).not.toContain('/user');
+    });
+});

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/toJsonPatchReplaceOps/index.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/toJsonPatchReplaceOps/index.ts
@@ -1,0 +1,2 @@
+export { toJsonPatchReplaceOps } from './toJsonPatchReplaceOps';
+export type { JsonPatchReplaceOp } from './toJsonPatchReplaceOps';

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/toJsonPatchReplaceOps/toJsonPatchReplaceOps.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/helpers/toJsonPatchReplaceOps/toJsonPatchReplaceOps.ts
@@ -1,0 +1,10 @@
+export type JsonPatchReplaceOp = Readonly<{
+    op: 'replace';
+    path: string;
+    value: unknown;
+}>;
+
+export const toJsonPatchReplaceOps = (
+    fields: Readonly<Record<string, unknown>>,
+): ReadonlyArray<JsonPatchReplaceOp> =>
+    Object.entries(fields).map(([key, value]) => ({ op: 'replace', path: `/${key}`, value }));

--- a/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/index.ts
+++ b/src/core_modules/capture-core/components/WorkingLists/WorkingListsCommon/index.ts
@@ -7,7 +7,7 @@ export {
 } from './hooks';
 export * from './actions';
 export { includeFiltersWithValueAfterColumnSortingEpic } from './epics';
-export { buildFilterQueryArgs } from './helpers';
+export { buildFilterQueryArgs, toJsonPatchReplaceOps } from './helpers';
 export type {
     LoadView,
     AddTemplate,


### PR DESCRIPTION
[DHIS2-21871](https://dhis2.atlassian.net/browse/DHIS2-21871)

### Summary
Saving a working list view (event filter, TEI filter, or program stage working list) wipes its sharing: user and user group accesses are cleared and public access resets to default.

### Root cause
The update epics send a full `PUT` (`type: 'replace'`) with only the legacy sharing fields (`publicAccess`, `externalAccess`, `userAccesses`, `userGroupAccesses`) and no `sharing` object. From api/41 those legacy fields are ignored, so a full replace resets sharing to defaults. Regression of DHIS2-8420 (whose fix, DHIS2-10493 / DHIS2-10651, added those legacy fields).

### Changes
- Switch the three update epics (`eventFilters`, `trackedEntityInstanceFilters`, `programStageWorkingLists`) from `type: 'replace'` to `type: 'json-patch'`, patching only `name` and the query criteria. Sharing and ownership stay out of the payload, so the server leaves them untouched. (This is DHIS2's documented partial update path; a plain `application/json` PATCH returns 415 here.)
- Add a small pure helper `toJsonPatchReplaceOps`, unit tested.
- Widen the `mutate` type in `capture-core-utils/types/global.ts` to include `'json-patch'`.
- Dropping `user` (owner) also fixes the non-owner 409 on save (DHIS2-13020).
- Update the e2e intercepts from `PUT` to `PATCH`.

### Testing
Verified on play 2.41, 2.43, 2.44: sharing preserved after saving a view. JSON Patch is documented back to 2.40.


[DHIS2-21871]: https://dhis2.atlassian.net/browse/DHIS2-21871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ