### PR TITLE
chore: [DHIS2-18447] Reproduce flaky TEI bulk action Cypress tests (throwaway)

### DIFF
--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.feature
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.feature
@@ -43,7 +43,6 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
     Then the filters should be disabled
 
 #DHIS2-18447
-@skip
   Scenario: The user should see an error message when trying to bulk complete enrollments with errors
     Given you open the main page with Ngelehun and Malaria focus investigation context
     And you select the first 3 rows
@@ -56,7 +55,6 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
     And the unsuccessful enrollments should still be selected
 
 #DHIS2-18447
-@skip
   Scenario: the user should be able to bulk complete enrollments and events
     Given you open the main page with Ngelehun and Malaria focus investigation context
     And you select the first 4 rows
@@ -67,7 +65,6 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
     Then the bulk complete enrollments modal should close
 
 #DHIS2-18447
-@skip
   Scenario: the user should be able to bulk complete enrollments without completing events
     Given you open the main page with Ngelehun and Malaria Case diagnosis context
     And you select row number 1
@@ -79,7 +76,6 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
     Then the bulk complete enrollments modal should close
 
 #DHIS2-18447
-@skip
   Scenario: the user should be able to bulk delete enrollments
     Given you open the main page with Ngelehun and Malaria Case diagnosis context
     And you select the first 3 rows
@@ -89,7 +85,6 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
     Then the bulk delete enrollments modal should close
 
 #DHIS2-18447
-@skip
   Scenario: the user should be able to bulk delete only active enrollments
     Given you open the main page with Ngelehun and Malaria Case diagnosis context
     And you select the first 3 rows


### PR DESCRIPTION
## DO NOT MERGE - throwaway reproduction PR

This PR temporarily removes the `@skip` tag from the 5 scenarios in
`TrackerBulkActions.feature` that were disabled for DHIS2-18447, purely to
trigger CI (`e2e-tests` label) and observe whether/how they still fail
against a stable instance.

Will be closed and the branch deleted once enough signal is gathered.

AI Assisted