### PR TITLE
chore: [DHIS2-18447] Re-enable TEI bulk action Cypress tests

### DIFF
--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.feature
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.feature
@@ -42,8 +42,6 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
     When you select the first 5 rows
     Then the filters should be disabled
 
-#DHIS2-18447
-@skip
   Scenario: The user should see an error message when trying to bulk complete enrollments with errors
     Given you open the main page with Ngelehun and Malaria focus investigation context
     And you select the first 3 rows
@@ -55,8 +53,6 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
     And you close the error dialog
     And the unsuccessful enrollments should still be selected
 
-#DHIS2-18447
-@skip
   Scenario: the user should be able to bulk complete enrollments and events
     Given you open the main page with Ngelehun and Malaria focus investigation context
     And you select the first 4 rows
@@ -66,8 +62,6 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
     When you confirm 3 active enrollments successfully
     Then the bulk complete enrollments modal should close
 
-#DHIS2-18447
-@skip
   Scenario: the user should be able to bulk complete enrollments without completing events
     Given you open the main page with Ngelehun and Malaria Case diagnosis context
     And you select row number 1
@@ -78,8 +72,6 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
     When you confirm 1 active enrollment without completing events successfully
     Then the bulk complete enrollments modal should close
 
-#DHIS2-18447
-@skip
   Scenario: the user should be able to bulk delete enrollments
     Given you open the main page with Ngelehun and Malaria Case diagnosis context
     And you select the first 3 rows
@@ -88,8 +80,6 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
     When you confirm deleting 3 enrollments
     Then the bulk delete enrollments modal should close
 
-#DHIS2-18447
-@skip
   Scenario: the user should be able to bulk delete only active enrollments
     Given you open the main page with Ngelehun and Malaria Case diagnosis context
     And you select the first 3 rows


### PR DESCRIPTION
## What
Re-enables the 5 scenarios in `TrackerBulkActions.feature` that were disabled between Nov 2024 and May 2025 for flakiness against stable instances (https://dhis2.atlassian.net/browse/DHIS2-18447).

## Why now
Ran 3 full e2e CI runs across all 4 supported DHIS2 versions (2.40-2.43) with the `@skip` tags removed, as a reproduction check before deciding on a fix:

- 12/12 executions (3 runs x 4 versions) passed cleanly
- 0 failures, 0 retries needed for any of the 5 scenarios

Whatever caused the original flakiness doesn't reproduce in this sample - likely fixed incidentally by the `cy.intercept` mocking already present in these scenarios' step definitions, added across that same period. Re-enabling and letting normal CI cadence confirm over time, rather than leaving them disabled indefinitely on a ticket that's been idle for 14 months.

(Continuation of https://github.com/dhis2/capture-app/pull/4679, which was the throwaway reproduction PR - closed once signal was gathered.)

AI Assisted