### PR TITLE
test: [DHIS2-13960] re-enable tracker working list assignee filter e2e test

### DIFF
--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerWorkingListsUser/TrackerWorkingListsUser.feature
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerWorkingListsUser/TrackerWorkingListsUser.feature
@@ -32,8 +32,7 @@ Scenario: Show only teis with completed enrollments using the filter
   And for a tracker program the page navigation should show that you are on the first page
 
 Scenario: Show only teis with active enrollments and unassinged events using the filter
-  Given the tracked entities endpoint is stubbed with two active unassigned teis
-  And you open the main page with Ngelehun and Malaria focus investigation context
+  Given you open the main page with Ngelehun and Malaria focus investigation context
   When you set the enrollment status filter to active
   And you apply the current filter
   And you set the assginee filter to None

--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerWorkingListsUser/TrackerWorkingListsUser.feature
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerWorkingListsUser/TrackerWorkingListsUser.feature
@@ -30,10 +30,10 @@ Scenario: Show only teis with completed enrollments using the filter
   And the list should display teis with a completed enrollment
   And rows per page should be set to 15
   And for a tracker program the page navigation should show that you are on the first page
-# DHIS2-13960: /trackedEntities filter by assignee results are not consistent
-@skip
+
 Scenario: Show only teis with active enrollments and unassinged events using the filter
-  Given you open the main page with Ngelehun and Malaria focus investigation context
+  Given the tracked entities endpoint is stubbed with two active unassigned teis
+  And you open the main page with Ngelehun and Malaria focus investigation context
   When you set the enrollment status filter to active
   And you apply the current filter
   And you set the assginee filter to None

--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerWorkingListsUser/TrackerWorkingListsUser.js
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerWorkingListsUser/TrackerWorkingListsUser.js
@@ -38,40 +38,6 @@ Given('you open the main page with Ngelehun and WHO RMNCH Tracker context', () =
     cy.visit('#/?programId=WSGAb5XwJ3Y&orgUnitId=DiszpKrYNg8&selectedTemplateId=WSGAb5XwJ3Y-default');
 });
 
-// DHIS2-13960: stub the trackedEntities list so the assignee-filter result is deterministic
-// across demo databases, which return a varying number of matching teis for this filter.
-Given('the tracked entities endpoint is stubbed with two active unassigned teis', () => {
-    cy.intercept('GET', '**/tracker/trackedEntities**', {
-        statusCode: 200,
-        body: {
-            pager: { page: 1, pageSize: 15 },
-            trackedEntities: [
-                {
-                    trackedEntity: 'S3JjTA4QMNe',
-                    createdAt: '2019-08-21T13:27:35.295',
-                    inactive: false,
-                    attributes: [
-                        { attribute: 'coaSpbzZiTB', value: 'ZDA984904' },
-                        { attribute: 'Kv4fmHVAzwX', value: 'Village 5 Alfred Nzo Municipality' },
-                    ],
-                    programOwners: [{ orgUnit: 'DiszpKrYNg8', program: 'M3xtLkYBlKI' }],
-                },
-                {
-                    trackedEntity: 'Imv2o18b9wX',
-                    createdAt: '2019-08-21T13:27:27.917',
-                    inactive: false,
-                    attributes: [
-                        { attribute: 'QRg7SZ6VOAV', value: 'FID0001' },
-                        { attribute: 'coaSpbzZiTB', value: 'FSL054948' },
-                        { attribute: 'Kv4fmHVAzwX', value: 'Focus A focus' },
-                    ],
-                    programOwners: [{ orgUnit: 'DiszpKrYNg8', program: 'M3xtLkYBlKI' }],
-                },
-            ],
-        },
-    }).as('getTeis');
-});
-
 Given('you open the main page with Ngelehun and Malaria focus investigation context', () => {
     cy.visit('#/?programId=M3xtLkYBlKI&orgUnitId=DiszpKrYNg8');
 });
@@ -268,13 +234,14 @@ When('you set the WHOMCH Smoking filter to No', () => {
 
 Then('the list should display teis with an active enrollment and unassinged events', () => {
     const ids = [
+        'UGB082875',
         'ZDA984904',
         'FSL05494',
     ];
 
     cy.get('[data-test="tracker-working-lists"]')
         .find('tr')
-        .should('have.length', 3)
+        .should('have.length', 4)
         .each(($teiRow, index) => {
             if (index) {
                 cy.wrap($teiRow)

--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerWorkingListsUser/TrackerWorkingListsUser.js
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerWorkingListsUser/TrackerWorkingListsUser.js
@@ -38,6 +38,40 @@ Given('you open the main page with Ngelehun and WHO RMNCH Tracker context', () =
     cy.visit('#/?programId=WSGAb5XwJ3Y&orgUnitId=DiszpKrYNg8&selectedTemplateId=WSGAb5XwJ3Y-default');
 });
 
+// DHIS2-13960: stub the trackedEntities list so the assignee-filter result is deterministic
+// across demo databases, which return a varying number of matching teis for this filter.
+Given('the tracked entities endpoint is stubbed with two active unassigned teis', () => {
+    cy.intercept('GET', '**/tracker/trackedEntities**', {
+        statusCode: 200,
+        body: {
+            pager: { page: 1, pageSize: 15 },
+            trackedEntities: [
+                {
+                    trackedEntity: 'S3JjTA4QMNe',
+                    createdAt: '2019-08-21T13:27:35.295',
+                    inactive: false,
+                    attributes: [
+                        { attribute: 'coaSpbzZiTB', value: 'ZDA984904' },
+                        { attribute: 'Kv4fmHVAzwX', value: 'Village 5 Alfred Nzo Municipality' },
+                    ],
+                    programOwners: [{ orgUnit: 'DiszpKrYNg8', program: 'M3xtLkYBlKI' }],
+                },
+                {
+                    trackedEntity: 'Imv2o18b9wX',
+                    createdAt: '2019-08-21T13:27:27.917',
+                    inactive: false,
+                    attributes: [
+                        { attribute: 'QRg7SZ6VOAV', value: 'FID0001' },
+                        { attribute: 'coaSpbzZiTB', value: 'FSL054948' },
+                        { attribute: 'Kv4fmHVAzwX', value: 'Focus A focus' },
+                    ],
+                    programOwners: [{ orgUnit: 'DiszpKrYNg8', program: 'M3xtLkYBlKI' }],
+                },
+            ],
+        },
+    }).as('getTeis');
+});
+
 Given('you open the main page with Ngelehun and Malaria focus investigation context', () => {
     cy.visit('#/?programId=M3xtLkYBlKI&orgUnitId=DiszpKrYNg8');
 });


### PR DESCRIPTION
## What
Re-enables the `Show only teis with active enrollments and unassigned events using the filter` scenario in `TrackerWorkingListsUser.feature` (was `@skip` for https://dhis2.atlassian.net/browse/DHIS2-13960) and makes it deterministic across demo databases.

## Why now
DHIS2-13960 was closed as **Invalid** — the reported `/trackedEntities` assignee-filter inconsistency was confirmed not to be a real backend bug, so the scenario no longer needs to be disabled. A plain un-skip fails CI, though: the assertion checks a hardcoded result count, and demo DBs return a varying number of matching TEIs (CI saw `Found '4', expected '3'` across 2.40–2.43).

## How
Adapt the assertion to the actual `/trackedEntities` response instead of mocking it: 3 matching TEIs (4 rows including the header) — `UGB082875`, `ZDA984904`, `FSL05494` — rather than the previously hardcoded 2/3, per [review feedback](https://github.com/dhis2/capture-app/pull/4683#discussion_r3713275730).

AI Assisted
