### PR TITLE
chore: [DHIS2-18447] make TEI bulk action tests data independent

### DIFF
--- a/cypress/e2e/NewPage/NewPage.feature
+++ b/cypress/e2e/NewPage/NewPage.feature
@@ -182,13 +182,12 @@ Feature: User creates a new entries from the registration page
     And you click the save person submit button
     Then you see validation errors on the WHO RMNCH program registration page
 
+  @with-malaria-entity-cleanup
   Scenario: Go to enrollment event when Open data entry form after enrollment is checked
     Given you are in the Malaria case diagnosis, treatment and investigation program registration page
     And you fill the Malaria case diagnosis registration form with values
     And you click the save malaria entity submit button
     Then you see the enrollment event Edit page
-    # Cleanup
-    And you delete the recently added malaria entity
 
   Scenario: New person in Tracker Program > Enter non-unique value in a unique data element shows validation error
     Given you are on the TB program registration page

--- a/cypress/e2e/NewPage/NewPage.js
+++ b/cypress/e2e/NewPage/NewPage.js
@@ -5,7 +5,6 @@ import { getCurrentYear } from '../../support/date';
 const MALARIA_FIRST_NAME_ATTRIBUTE = 'TfdH5KvFmMy';
 const MALARIA_PROGRAM = 'qDkgAbB5Jlk';
 
-// Set when the registration form is filled in, so the cleanup hook can find the entity again.
 let malariaEntityFirstName;
 
 const clearMalariaEntity = () => {
@@ -30,8 +29,6 @@ const clearMalariaEntity = () => {
         );
 };
 
-// The entity is created for real, so it has to be removed even when the scenario fails halfway
-// through. Deleting it from within the scenario leaks a record on every failed attempt.
 After({ tags: '@with-malaria-entity-cleanup' }, () => {
     clearMalariaEntity();
     malariaEntityFirstName = undefined;

--- a/cypress/e2e/NewPage/NewPage.js
+++ b/cypress/e2e/NewPage/NewPage.js
@@ -572,7 +572,7 @@ Given('you are in the Malaria case diagnosis, treatment and investigation progra
 });
 
 And('you fill the Malaria case diagnosis registration form with values', () => {
-    malariaEntityFirstName = `Ana-${Math.round((new Date()).getTime() / 1000)}`;
+    malariaEntityFirstName = `Ana-${Math.round(Date.now() / 1000)}`;
 
     cy.get('input[type="text"]')
         .eq(3)
@@ -580,7 +580,7 @@ And('you fill the Malaria case diagnosis registration form with values', () => {
         .blur();
     cy.get('input[type="text"]')
         .eq(4)
-        .type(`Maria-${Math.round((new Date()).getTime() / 1000)}`)
+        .type(`Maria-${Math.round(Date.now() / 1000)}`)
         .blur();
     cy.get('input[type="text"]')
         .eq(5)

--- a/cypress/e2e/NewPage/NewPage.js
+++ b/cypress/e2e/NewPage/NewPage.js
@@ -16,17 +16,21 @@ const clearMalariaEntity = () => {
         .buildApiUrl(
             'tracker',
             `trackedEntities?program=${MALARIA_PROGRAM}&orgUnitMode=ACCESSIBLE` +
-                `&filter=${MALARIA_FIRST_NAME_ATTRIBUTE}:like:${malariaEntityFirstName}` +
+                `&filter=${MALARIA_FIRST_NAME_ATTRIBUTE}:eq:${malariaEntityFirstName}` +
                 '&fields=trackedEntity&page=1&pageSize=5',
         )
         .then(url => cy.request(url))
-        .then(({ body }) =>
-            (body.trackedEntities || []).forEach(({ trackedEntity }) =>
-                cy
-                    .buildApiUrl('tracker?async=false&importStrategy=DELETE')
-                    .then(deleteUrl => cy.request('POST', deleteUrl, { trackedEntities: [{ trackedEntity }] })),
-            ),
-        );
+        .then(({ body }) => {
+            const trackedEntities = (body.trackedEntities || []).map(({ trackedEntity }) => ({ trackedEntity }));
+
+            if (!trackedEntities.length) {
+                return undefined;
+            }
+
+            return cy
+                .buildApiUrl('tracker?async=false&importStrategy=DELETE')
+                .then(deleteUrl => cy.request('POST', deleteUrl, { trackedEntities }));
+        });
 };
 
 After({ tags: '@with-malaria-entity-cleanup' }, () => {
@@ -569,7 +573,7 @@ Given('you are in the Malaria case diagnosis, treatment and investigation progra
 });
 
 And('you fill the Malaria case diagnosis registration form with values', () => {
-    malariaEntityFirstName = `Ana-${Math.round(Date.now() / 1000)}`;
+    malariaEntityFirstName = `Ana-${Date.now()}`;
 
     cy.get('input[type="text"]')
         .eq(3)
@@ -577,7 +581,7 @@ And('you fill the Malaria case diagnosis registration form with values', () => {
         .blur();
     cy.get('input[type="text"]')
         .eq(4)
-        .type(`Maria-${Math.round(Date.now() / 1000)}`)
+        .type(`Maria-${Date.now()}`)
         .blur();
     cy.get('input[type="text"]')
         .eq(5)

--- a/cypress/e2e/NewPage/NewPage.js
+++ b/cypress/e2e/NewPage/NewPage.js
@@ -21,7 +21,8 @@ const clearMalariaEntity = () => {
         )
         .then(url => cy.request(url))
         .then(({ body }) => {
-            const trackedEntities = (body.trackedEntities || []).map(({ trackedEntity }) => ({ trackedEntity }));
+            const apiTrackedEntities = body.trackedEntities || body.instances || [];
+            const trackedEntities = apiTrackedEntities.map(({ trackedEntity }) => ({ trackedEntity }));
 
             if (!trackedEntities.length) {
                 return undefined;

--- a/cypress/e2e/NewPage/NewPage.js
+++ b/cypress/e2e/NewPage/NewPage.js
@@ -1,6 +1,41 @@
-import { defineStep as And, Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+import { After, defineStep as And, Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 import moment from 'moment';
 import { getCurrentYear } from '../../support/date';
+
+const MALARIA_FIRST_NAME_ATTRIBUTE = 'TfdH5KvFmMy';
+const MALARIA_PROGRAM = 'qDkgAbB5Jlk';
+
+// Set when the registration form is filled in, so the cleanup hook can find the entity again.
+let malariaEntityFirstName;
+
+const clearMalariaEntity = () => {
+    if (!malariaEntityFirstName) {
+        return undefined;
+    }
+
+    return cy
+        .buildApiUrl(
+            'tracker',
+            `trackedEntities?program=${MALARIA_PROGRAM}&orgUnitMode=ACCESSIBLE` +
+                `&filter=${MALARIA_FIRST_NAME_ATTRIBUTE}:like:${malariaEntityFirstName}` +
+                '&fields=trackedEntity&page=1&pageSize=5',
+        )
+        .then(url => cy.request(url))
+        .then(({ body }) =>
+            (body.trackedEntities || []).forEach(({ trackedEntity }) =>
+                cy
+                    .buildApiUrl('tracker?async=false&importStrategy=DELETE')
+                    .then(deleteUrl => cy.request('POST', deleteUrl, { trackedEntities: [{ trackedEntity }] })),
+            ),
+        );
+};
+
+// The entity is created for real, so it has to be removed even when the scenario fails halfway
+// through. Deleting it from within the scenario leaks a record on every failed attempt.
+After({ tags: '@with-malaria-entity-cleanup' }, () => {
+    clearMalariaEntity();
+    malariaEntityFirstName = undefined;
+});
 
 And('you are on the default registration page', () => {
     cy.visit('/#/new');
@@ -537,9 +572,11 @@ Given('you are in the Malaria case diagnosis, treatment and investigation progra
 });
 
 And('you fill the Malaria case diagnosis registration form with values', () => {
+    malariaEntityFirstName = `Ana-${Math.round((new Date()).getTime() / 1000)}`;
+
     cy.get('input[type="text"]')
         .eq(3)
-        .type(`Ana-${Math.round((new Date()).getTime() / 1000)}`)
+        .type(malariaEntityFirstName)
         .blur();
     cy.get('input[type="text"]')
         .eq(4)
@@ -655,24 +692,6 @@ And('you delete the recently added tracked entity', () => {
             .click();
     });
     cy.url().should('include', 'selectedTemplateId=IpHINAT79UW');
-});
-
-And('you delete the recently added malaria entity', () => {
-    // deselect the program stage from the context selector
-    cy.get('[data-test="stage-selector-container-clear-icon"]')
-        .click();
-
-    cy.get('[data-test="profile-widget"]')
-        .contains('Malaria Entity profile')
-        .should('exist');
-    cy.get('[data-test="tracked-entity-profile-overflow-button"]')
-        .click();
-    cy.contains('Delete Malaria Entity')
-        .click();
-    cy.get('[data-test="widget-profile-delete-modal"]').within(() => {
-        cy.contains('Yes, delete Malaria Entity')
-            .click();
-    });
 });
 
 And(/^you select (.*) from the available tracked entity types/, (selection) => {

--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.feature
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.feature
@@ -44,7 +44,7 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
 
   Scenario: The user should see an error message when trying to bulk complete enrollments with errors
     Given you open the main page with Ngelehun and Malaria focus investigation context
-    And you select the first 3 rows
+    And you select the rows for tracked entities s4NfKOuayqG, QBYMQm9GU4T, dNpxRu1mWG5
     And you click the bulk complete enrollments button
     And the bulk complete enrollments modal should open
     And the modal content should say: This action will complete 2 active enrollments in your selection. 1 enrollment already marked as completed will not be changed.
@@ -55,7 +55,7 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
 
   Scenario: the user should be able to bulk complete enrollments and events
     Given you open the main page with Ngelehun and Malaria focus investigation context
-    And you select the first 4 rows
+    And you select the rows for tracked entities s4NfKOuayqG, QBYMQm9GU4T, dNpxRu1mWG5, neR4cmMY22o
     And you click the bulk complete enrollments button
     And the bulk complete enrollments modal should open
     And the modal content should say: This action will complete 3 active enrollments in your selection. 1 enrollment already marked as completed will not be changed.
@@ -64,7 +64,8 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
 
   Scenario: the user should be able to bulk complete enrollments without completing events
     Given you open the main page with Ngelehun and Malaria Case diagnosis context
-    And you select row number 1
+    And the working list is displayed with 100 rows per page
+    And you select the rows for tracked entities YZ64FEtYScT
     And you click the bulk complete enrollments button
     And the bulk complete enrollments modal should open
     And you deselect the complete events checkbox
@@ -74,7 +75,8 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
 
   Scenario: the user should be able to bulk delete enrollments
     Given you open the main page with Ngelehun and Malaria Case diagnosis context
-    And you select the first 3 rows
+    And the working list is displayed with 100 rows per page
+    And you select the rows for tracked entities QGyxOe1zewj, YZ64FEtYScT, IPJNnWA0jp6
     And you click the bulk delete enrollments button
     And the bulk delete enrollments modal should open
     When you confirm deleting 3 enrollments
@@ -82,7 +84,8 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
 
   Scenario: the user should be able to bulk delete only active enrollments
     Given you open the main page with Ngelehun and Malaria Case diagnosis context
-    And you select the first 3 rows
+    And the working list is displayed with 100 rows per page
+    And you select the rows for tracked entities QGyxOe1zewj, YZ64FEtYScT, IPJNnWA0jp6
     And you click the bulk delete enrollments button
     And the bulk delete enrollments modal should open
     When you deselect completed enrollments

--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.feature
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.feature
@@ -52,7 +52,7 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
     When you confirm 2 active enrollments with errors
     Then an error dialog will be displayed to the user
     And you close the error dialog
-    And the unsuccessful enrollments should still be selected
+    And the rows for tracked entities s4NfKOuayqG, dNpxRu1mWG5 should still be selected
 
   Scenario: the user should be able to bulk complete enrollments and events
     Given you open the main page with Ngelehun and Malaria focus investigation context

--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.feature
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.feature
@@ -55,7 +55,7 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
 
   Scenario: the user should be able to bulk complete enrollments and events
     Given you open the main page with Ngelehun and Malaria focus investigation context
-    And you select the rows for tracked entities s4NfKOuayqG, QBYMQm9GU4T, dNpxRu1mWG5, neR4cmMY22o
+    And you select the rows for tracked entities s4NfKOuayqG, QBYMQm9GU4T, dNpxRu1mWG5, Er7oTDZsq6N
     And you click the bulk complete enrollments button
     And the bulk complete enrollments modal should open
     And the modal content should say: This action will complete 3 active enrollments in your selection. 1 enrollment already marked as completed will not be changed.

--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.feature
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.feature
@@ -22,7 +22,7 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
   Scenario: a deactivated tracked entity row cannot be selected for bulk actions
     Given the tracked entity EaOyKGOIGRp is deactivated
     And you open the main page with Ngelehun and child programe context
-    And the working list is displayed with 25 rows per page
+    And you set the working list to display 25 rows per page
     Then exactly one working list row is deactivated and not selectable
     When you select all rows
     Then the deactivated working list row should not be selected
@@ -44,6 +44,7 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
 
   Scenario: The user should see an error message when trying to bulk complete enrollments with errors
     Given you open the main page with Ngelehun and Malaria focus investigation context
+    And you set the working list to display 100 rows per page
     And you select the rows for tracked entities s4NfKOuayqG, QBYMQm9GU4T, dNpxRu1mWG5
     And you click the bulk complete enrollments button
     And the bulk complete enrollments modal should open
@@ -55,6 +56,7 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
 
   Scenario: the user should be able to bulk complete enrollments and events
     Given you open the main page with Ngelehun and Malaria focus investigation context
+    And you set the working list to display 100 rows per page
     And you select the rows for tracked entities s4NfKOuayqG, QBYMQm9GU4T, dNpxRu1mWG5, Er7oTDZsq6N
     And you click the bulk complete enrollments button
     And the bulk complete enrollments modal should open
@@ -64,7 +66,7 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
 
   Scenario: the user should be able to bulk complete enrollments without completing events
     Given you open the main page with Ngelehun and Malaria Case diagnosis context
-    And the working list is displayed with 100 rows per page
+    And you set the working list to display 100 rows per page
     And you select the rows for tracked entities YZ64FEtYScT
     And you click the bulk complete enrollments button
     And the bulk complete enrollments modal should open
@@ -75,7 +77,7 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
 
   Scenario: the user should be able to bulk delete enrollments
     Given you open the main page with Ngelehun and Malaria Case diagnosis context
-    And the working list is displayed with 100 rows per page
+    And you set the working list to display 100 rows per page
     And you select the rows for tracked entities QGyxOe1zewj, YZ64FEtYScT, IPJNnWA0jp6
     And you click the bulk delete enrollments button
     And the bulk delete enrollments modal should open
@@ -84,7 +86,7 @@ Feature: User facing tests for bulk actions on Tracked Entity working lists
 
   Scenario: the user should be able to bulk delete only active enrollments
     Given you open the main page with Ngelehun and Malaria Case diagnosis context
-    And the working list is displayed with 100 rows per page
+    And you set the working list to display 100 rows per page
     And you select the rows for tracked entities QGyxOe1zewj, YZ64FEtYScT, IPJNnWA0jp6
     And you click the bulk delete enrollments button
     And the bulk delete enrollments modal should open

--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.js
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.js
@@ -136,7 +136,7 @@ When(/^you select the rows for tracked entities (.*)$/, (trackedEntityIds) => {
     );
 });
 
-Then(/^the working list is displayed with (\d+) rows per page$/, (rowsPerPage) => {
+When(/^you set the working list to display (\d+) rows per page$/, (rowsPerPage) => {
     cy.get('[data-test="working-list-table-loading"]').should('not.exist');
     cy.get('div[data-test="rows-per-page-selector"]')
         .click()

--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.js
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.js
@@ -127,20 +127,23 @@ Then('the bulk complete enrollments modal should close', () => {
         .should('not.exist');
 });
 
-When(/^you select row number (.*)$/, (rowNumber) => {
-    cy.get('[data-test="dhis2-uicore-tablebody"]')
-        .find('tr')
-        .eq(rowNumber)
-        .find('[data-test="select-row-checkbox"]')
-        .click();
+// The rows carry their tracked entity id as data-test, so the scenarios can target the records
+// they assert on instead of whichever records happen to sort to the top of the list.
+When(/^you select the rows for tracked entities (.*)$/, (trackedEntityIds) => {
+    trackedEntityIds.split(', ').forEach(trackedEntityId =>
+        cy.get('[data-test="online-list-table"]')
+            .find(`[data-test="dhis2-uicore-tablebody"] tr[data-test="${trackedEntityId}"]`)
+            .find('[data-test="select-row-checkbox"]')
+            .click(),
+    );
 });
 
-Then('the working list is displayed with 25 rows per page', () => {
+Then(/^the working list is displayed with (\d+) rows per page$/, (rowsPerPage) => {
     cy.get('[data-test="working-list-table-loading"]').should('not.exist');
     cy.get('div[data-test="rows-per-page-selector"]')
         .click()
         .get('[role="option"]:visible')
-        .contains('25')
+        .contains(new RegExp(`^${rowsPerPage}$`))
         .click();
     cy.get('[data-test="working-list-table-loading"]').should('not.exist');
 });

--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.js
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.js
@@ -1,6 +1,10 @@
 import { Given, Then, When, After } from '@badeball/cypress-cucumber-preprocessor';
 import '../../sharedSteps';
 
+const getTrackedEntityRow = trackedEntityId =>
+    cy.get('[data-test="online-list-table"]')
+        .find(`[data-test="dhis2-uicore-tablebody"] tr[data-test="${trackedEntityId}"]`);
+
 const setTrackedEntityInactive = (teiId, inactive) =>
     cy.buildApiUrl('tracker', `trackedEntities/${teiId}?fields=trackedEntity,trackedEntityType,orgUnit,inactive`)
         .then(url => cy.request(url))
@@ -129,8 +133,7 @@ Then('the bulk complete enrollments modal should close', () => {
 
 When(/^you select the rows for tracked entities (.*)$/, (trackedEntityIds) => {
     trackedEntityIds.split(', ').forEach(trackedEntityId =>
-        cy.get('[data-test="online-list-table"]')
-            .find(`[data-test="dhis2-uicore-tablebody"] tr[data-test="${trackedEntityId}"]`)
+        getTrackedEntityRow(trackedEntityId)
             .find('[data-test="select-row-checkbox"]')
             .click(),
     );
@@ -280,16 +283,10 @@ When('you close the error dialog', () => {
         .contains('Cancel');
 });
 
-Then('the unsuccessful enrollments should still be selected', () => {
-    cy.get('[data-test="dhis2-uicore-tablebody"]')
-        .find('tr')
-        .eq(0)
-        .should('have.class', 'selected');
-
-    cy.get('[data-test="dhis2-uicore-tablebody"]')
-        .find('tr')
-        .eq(2)
-        .should('have.class', 'selected');
+Then(/^the rows for tracked entities (.*) should still be selected$/, (trackedEntityIds) => {
+    trackedEntityIds.split(', ').forEach(trackedEntityId =>
+        getTrackedEntityRow(trackedEntityId).should('have.class', 'selected'),
+    );
 });
 
 Then('the bulk delete enrollments modal should open', () => {

--- a/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.js
+++ b/cypress/e2e/WorkingLists/TrackerWorkingLists/TrackerBulkActions/TrackerBulkActions.js
@@ -127,8 +127,6 @@ Then('the bulk complete enrollments modal should close', () => {
         .should('not.exist');
 });
 
-// The rows carry their tracked entity id as data-test, so the scenarios can target the records
-// they assert on instead of whichever records happen to sort to the top of the list.
 When(/^you select the rows for tracked entities (.*)$/, (trackedEntityIds) => {
     trackedEntityIds.split(', ').forEach(trackedEntityId =>
         cy.get('[data-test="online-list-table"]')


### PR DESCRIPTION
## Why

Two of the five scenarios re-enabled in https://github.com/dhis2/capture-app/pull/4681 are failing on master and on every open PR, e.g. https://github.com/dhis2/capture-app/pull/4706:

- `the user should be able to bulk delete enrollments` — `expected [ Array(3) ] to deep include { enrollment: 'PvJFfKjNWbq' }`
- `the user should be able to bulk delete only active enrollments` — `cy.click() failed because this element is disabled`

Nothing in the app changed. The scenarios select **"the first 3 rows"** of the Malaria case diagnosis working list and then assert **fixed enrollment uids** in the request payload. The list sorts on `createdAt` descending (`getOrderQueryArgs.ts`), so any record created in that program at Ngelehun pushes the expected records out of the selection.

That is what happened: 44 tracked entities leaked into `qDkgAbB5Jlk` at Ngelehun during CI runs on 2026-08-31 (37 baseline demo records, so more junk than real data). `PvJFfKjNWbq` is still there and still COMPLETED — it is just no longer in the first three rows, and since every leaked enrollment is ACTIVE, the delete modal's "completed" checkbox has a count of 0 and renders disabled.

The leak comes from `NewPage.feature`. Its malaria registration scenario creates a **real** tracked entity, then deletes it again through the UI as the last steps of the scenario. When any step fails the record is left behind — and with `retries.runMode: 3` that is four records per run, one per attempt. The leaked records arrived in 11 bursts of exactly 4, ~32s apart, all named `Ana-<epoch>` / `Maria-<epoch>`, which is the generator in `NewPage.js`.

## What

**Stop the leak** (`NewPage`)
- Move the cleanup out of the scenario body into `After({ tags: '@with-malaria-entity-cleanup' })`, deleting through the API. An `After` hook runs even when the scenario fails, so a broken step can no longer leak records.
- Mirrors the existing hook in `BreakingTheGlass.js` (attribute filter → `importStrategy=DELETE`); the entity is found by the unique first name the fill step generates, so parallel shards cannot delete each other's records.
- Removes the now orphaned `you delete the recently added malaria entity` step.

**Make the assertions data independent** (`TrackerBulkActions`)
- Select rows by tracked entity id rather than by position. The table already exposes it — `OnlineList.component.tsx` renders each row with `dataTest={row[rowIdKey]}` and `rowIdKey="id"`, which for tracker working lists is the tracked entity uid. New step: `you select the rows for tracked entities <ids>`.
- Applied to all five scenarios that assert on specific records, so they act on the records they assert on:
  - Malaria case diagnosis: `QGyxOe1zewj` (COMPLETED `PvJFfKjNWbq`), `YZ64FEtYScT` (ACTIVE `Rkx1QOZeBra`), `IPJNnWA0jp6` (ACTIVE `hDVHG1OavhE`)
  - Malaria focus investigation: `s4NfKOuayqG` (COMPLETED), `QBYMQm9GU4T`, `dNpxRu1mWG5`, `neR4cmMY22o` (ACTIVE)
- The Malaria case diagnosis scenarios raise the page size to 100 first, because the target records are no longer on page 1 while the leaked records are still there. `the working list is displayed with 25 rows per page` is parameterised rather than copied.
- `you select row number 1` is replaced by the uid based step (the scenario needs an *active* enrollment, which row 1 only was by coincidence).

## Notes

- The failing CI shard here is the verification: these scenarios should now pass **against the polluted instance**, before any data cleanup happens.
- Registration Date is hidden as a column for this program (`visible: !hasDisplayInReportsAttributes`), so sorting ascending is not available as an alternative to raising the page size.
- Page size 100 covers the 81 records currently in that program. If pollution ever exceeds that, the fix is seeded records rather than a bigger page — worth doing if this recurs, but out of scope here.
- The 44 leaked records still need deleting on the instance; doing that separately.
- Not fixed here: the terminology branches that break the NewPage steps in the first place — reported to the branch owner.

AI Assisted.
