### PR TITLE
chore: gate the sharing dialog search box and keep e2e failure artifacts

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -147,6 +147,16 @@ jobs:
                   CYPRESS_dhis2Password_trackerAutoTestRestricted: ${{ secrets.CYPRESS_DHIS2_PASSWORD_TRACKER_AUTO_TEST_RESTRICTED }}
                   NODE_OPTIONS: "--openssl-legacy-provider"
 
+            - uses: actions/upload-artifact@v7
+              if: failure()
+              with:
+                  name: cypress-failure-${{ matrix.versions }}-${{ matrix.spec-group.id }}
+                  path: |
+                      cypress/screenshots
+                      cypress/videos
+                  if-no-files-found: ignore
+                  retention-days: 7
+
     call-e2e-tests-result:
         needs: cypress
         uses: ./.github/workflows/e2e-tests-result.yml

--- a/.github/workflows/verify-app.yml
+++ b/.github/workflows/verify-app.yml
@@ -158,6 +158,16 @@ jobs:
           CYPRESS_dhis2Password_trackerAutoTestRestricted: ${{ secrets.CYPRESS_DHIS2_PASSWORD_TRACKER_AUTO_TEST_RESTRICTED }}
           NODE_OPTIONS: "--openssl-legacy-provider"
 
+      - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: cypress-failure-dev-${{ matrix.spec-group.id }}
+          path: |
+            cypress/screenshots
+            cypress/videos
+          if-no-files-found: ignore
+          retention-days: 7
+
   build:
     runs-on: ubuntu-latest
     needs: [lint, typescript, unit-tests]

--- a/cypress/e2e/WorkingLists/sharedSteps.js
+++ b/cypress/e2e/WorkingLists/sharedSteps.js
@@ -235,7 +235,10 @@ Then(/^you can load the view with the name ?(.*)$/, (name) => {
 When('you change the sharing settings', () => {
     cy.get('[data-test="list-view-menu-button"]').click();
     cy.contains('Share view').click();
-    cy.get('[placeholder="Search"]').type('Boateng');
+    cy.get('[data-test="sharing-dialog"]')
+        .find('[placeholder="Search"]')
+        .should('be.enabled')
+        .type('Boateng');
     cy.contains('Kevin Boateng').click();
     cy.contains('Choose a level').click();
     cy.contains('View and edit').click({ force: true });


### PR DESCRIPTION
## Why

**The sharing dialog search box.** `you change the sharing settings` clicks *Share view* and types into the dialog's search box with nothing in between. That box is disabled while the dialog loads the object's sharing state, and `cy.type()` does not wait for the disabled state to clear — the CI error carries no `Timed out retrying` prefix, so it threw immediately rather than after the command timeout. `cy.get` retried only until the input *existed*, which it does while still disabled.

Not version specific: the same scenario fails the same way on `cypress (2.42, 5)` here and on `cypress (2.43, 5)` on another branch. It is a race.

**Failure artifacts.** Neither cypress job kept its screenshots or videos. Recording to Cypress Cloud is opt-in via `[e2e record]` or the `e2e record` label, and nothing uploaded the local ones — so a failing shard left nothing to look at. One sharing failure on 2.41 is still undiagnosed for exactly this reason.

## What

- Gate the search box with a retrying `should('be.enabled')`, and scope the lookup to `[data-test="sharing-dialog"]` the way the newer `WorkingListsSharing` step already does — the bare `[placeholder="Search"]` would match any search box on the page.
- Upload `cypress/screenshots` and `cypress/videos` on failure only, 7-day retention, in both the version matrix (`e2e-tests.yml`) and the dev shards (`verify-app.yml`).

## Verification

Ran `TrackerWorkingListsUser.feature` against `play.im.dhis2.org/stable-2-43-1` with the gate in place: both sharing scenarios pass, including `The Program stage custom working can be shared`, the one failing in CI. One unrelated scenario fails locally on demo-data counts (`Show only teis with active enrollments and unassinged events` expects 4 rows, play has 3).

Both workflow files were parsed to confirm the new step lands on the right job with `if: failure()`.

AI Assisted.
