### PR TITLE
chore: gate the sharing dialog search box before typing

### DIFF
--- a/cypress/e2e/WorkingLists/sharedSteps.js
+++ b/cypress/e2e/WorkingLists/sharedSteps.js
@@ -235,7 +235,10 @@ Then(/^you can load the view with the name ?(.*)$/, (name) => {
 When('you change the sharing settings', () => {
     cy.get('[data-test="list-view-menu-button"]').click();
     cy.contains('Share view').click();
-    cy.get('[placeholder="Search"]').type('Boateng');
+    cy.get('[data-test="sharing-dialog"]')
+        .find('[placeholder="Search"]')
+        .should('be.enabled')
+        .type('Boateng');
     cy.contains('Kevin Boateng').click();
     cy.contains('Choose a level').click();
     cy.contains('View and edit').click({ force: true });


### PR DESCRIPTION
## Why

`you change the sharing settings` clicks *Share view* and types into the dialog's search box with nothing in between:

```js
cy.contains('Share view').click();
cy.get('[placeholder="Search"]').type('Boateng');
```

That box is disabled while the dialog loads the object's sharing state, and `cy.type()` does not wait for the disabled state to clear. The CI error shows it — note the missing `Timed out retrying` prefix, so it threw immediately rather than after the command timeout:

```
CypressError: `cy.type()` failed because it targeted a disabled element.
```

`cy.get` retried only until the input *existed*, which it does while still disabled.

Not version specific: the same scenario fails the same way on `cypress (2.42, 5)` and, on another branch, on `cypress (2.43, 5)`. It is a race.

## What

Gate the input with a retrying `should('be.enabled')`, and scope the lookup to `[data-test="sharing-dialog"]` the way the newer `WorkingListsSharing` step already does — the bare `[placeholder="Search"]` would match any search box on the page.

## Verification

Ran `TrackerWorkingListsUser.feature` against `play.im.dhis2.org/stable-2-43-1` with the gate in place: both sharing scenarios pass, including `The Program stage custom working can be shared`, the one failing in CI. One unrelated scenario fails locally on demo-data counts (`Show only teis with active enrollments and unassinged events` expects 4 rows, play has 3).

The version matrix only runs when the PR is labelled (`e2e-tests` / `testing`), so a label is needed to exercise this in CI.

AI Assisted.
